### PR TITLE
feat: store thread_ts in log.jsonl for Slack messages

### DIFF
--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -281,10 +281,11 @@ export class SlackBot implements Bot {
   /**
    * Log a bot response to log.jsonl
    */
-  logBotResponse(channel: string, text: string, ts: string): void {
+  logBotResponse(channel: string, text: string, ts: string, threadTs?: string): void {
     this.logToFile(channel, {
       date: new Date().toISOString(),
       ts,
+      threadTs,
       user: "bot",
       text,
       attachments: [],
@@ -655,6 +656,7 @@ export class SlackBot implements Bot {
     this.logToFile(event.channel, {
       date: new Date(parseFloat(event.ts) * 1000).toISOString(),
       ts: event.ts,
+      threadTs: event.thread_ts,
       user: event.user,
       userName: user?.userName,
       displayName: user?.displayName,

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -75,7 +75,7 @@ export function createSlackAdapters(
           }
 
           if (messageTs) {
-            slack.logBotResponse(event.channel, text, messageTs);
+            slack.logBotResponse(event.channel, text, messageTs, rootTs);
           }
         } catch (err) {
           log.logWarning("Slack respond error", err instanceof Error ? err.message : String(err));

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,6 +17,7 @@ export interface LoggedMessage {
   text: string;
   attachments: Attachment[];
   isBot: boolean;
+  threadTs?: string; // slack thread timestamp (root message ts)
 }
 
 export interface ChannelStoreConfig {


### PR DESCRIPTION
## Summary
- Add `threadTs` field to `LoggedMessage` interface in `store.ts`
- Log `thread_ts` in `logUserMessage` (user messages)
- Add `threadTs` parameter to `logBotResponse` (bot responses)
- Pass `rootTs` when calling `logBotResponse` in `context.ts`

This enables future thread-aware context management for Issue #3.

## Test plan
- [ ] Run mama with Slack
- [ ] Check `log.jsonl` contains `threadTs` field
- [ ] Verify thread messages have correct `threadTs` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)