### PR TITLE
feat(security): isolate secrets from agent context and redact from logs

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -47,6 +47,27 @@ export interface LogConfig {
 
 let logger: pino.Logger | null = null;
 
+// Secret redaction
+const registeredSecrets = new Set<string>();
+
+export function registerSecret(value: string): void {
+  if (value && value.length >= 8) registeredSecrets.add(value);
+}
+
+/** Only for use in tests. */
+export function __resetSecretsForTest(): void {
+  registeredSecrets.clear();
+}
+
+function redact(text: string): string {
+  if (registeredSecrets.size === 0) return text;
+  let result = text;
+  for (const secret of registeredSecrets) {
+    result = result.split(secret).join("[REDACTED]");
+  }
+  return result;
+}
+
 export function initLogger(config?: LogConfig): void {
   if (logger) return;
 
@@ -139,8 +160,9 @@ function formatToolArgs(args: Record<string, unknown>): string {
 
 // User messages
 export function logUserMessage(ctx: LogContext, text: string): void {
-  if (logger) logger.info({ event: "user_message", ...ctxFields(ctx), text }, text);
-  console.log(chalk.green(`${timestamp()} ${formatContext(ctx)} ${text}`));
+  const safe = redact(text);
+  if (logger) logger.info({ event: "user_message", ...ctxFields(ctx), text: safe }, safe);
+  console.log(chalk.green(`${timestamp()} ${formatContext(ctx)} ${safe}`));
 }
 
 // Tool execution
@@ -150,13 +172,14 @@ export function logToolStart(
   label: string,
   args: Record<string, unknown>,
 ): void {
+  const safeLabel = redact(label);
   if (logger)
     logger.debug(
-      { event: "tool_start", ...ctxFields(ctx), tool: toolName, label, args },
-      `${toolName}: ${label}`,
+      { event: "tool_start", ...ctxFields(ctx), tool: toolName, label: safeLabel, args },
+      `${toolName}: ${safeLabel}`,
     );
-  const formattedArgs = formatToolArgs(args);
-  console.log(chalk.yellow(`${timestamp()} ${formatContext(ctx)} ↳ ${toolName}: ${label}`));
+  const formattedArgs = redact(formatToolArgs(args));
+  console.log(chalk.yellow(`${timestamp()} ${formatContext(ctx)} ↳ ${toolName}: ${safeLabel}`));
   if (formattedArgs) {
     // Indent the args
     const indented = formattedArgs
@@ -173,15 +196,16 @@ export function logToolSuccess(
   durationMs: number,
   result: string,
 ): void {
+  const safeResult = redact(result);
   if (logger)
     logger.debug(
-      { event: "tool_success", ...ctxFields(ctx), tool: toolName, durationMs, result },
+      { event: "tool_success", ...ctxFields(ctx), tool: toolName, durationMs, result: safeResult },
       `${toolName} completed`,
     );
   const duration = (durationMs / 1000).toFixed(1);
   console.log(chalk.yellow(`${timestamp()} ${formatContext(ctx)} ✓ ${toolName} (${duration}s)`));
 
-  const truncated = truncate(result, 1000);
+  const truncated = truncate(safeResult, 1000);
   if (truncated) {
     const indented = truncated
       .split("\n")
@@ -197,15 +221,16 @@ export function logToolError(
   durationMs: number,
   error: string,
 ): void {
+  const safeError = redact(error);
   if (logger)
     logger.warn(
-      { event: "tool_error", ...ctxFields(ctx), tool: toolName, durationMs, error },
+      { event: "tool_error", ...ctxFields(ctx), tool: toolName, durationMs, error: safeError },
       `${toolName} failed`,
     );
   const duration = (durationMs / 1000).toFixed(1);
   console.log(chalk.yellow(`${timestamp()} ${formatContext(ctx)} ✗ ${toolName} (${duration}s)`));
 
-  const truncated = truncate(error, 1000);
+  const truncated = truncate(safeError, 1000);
   const indented = truncated
     .split("\n")
     .map((line) => `           ${line}`)
@@ -220,9 +245,11 @@ export function logResponseStart(ctx: LogContext): void {
 }
 
 export function logThinking(ctx: LogContext, thinking: string): void {
-  if (logger) logger.debug({ event: "thinking", ...ctxFields(ctx), text: thinking }, "Thinking");
+  const safeThinking = redact(thinking);
+  if (logger)
+    logger.debug({ event: "thinking", ...ctxFields(ctx), text: safeThinking }, "Thinking");
   console.log(chalk.yellow(`${timestamp()} ${formatContext(ctx)} 💭 Thinking`));
-  const truncated = truncate(thinking, 1000);
+  const truncated = truncate(safeThinking, 1000);
   const indented = truncated
     .split("\n")
     .map((line) => `           ${line}`)
@@ -231,9 +258,10 @@ export function logThinking(ctx: LogContext, thinking: string): void {
 }
 
 export function logResponse(ctx: LogContext, text: string): void {
-  if (logger) logger.info({ event: "response", ...ctxFields(ctx), text }, "Response");
+  const safeText = redact(text);
+  if (logger) logger.info({ event: "response", ...ctxFields(ctx), text: safeText }, "Response");
   console.log(chalk.yellow(`${timestamp()} ${formatContext(ctx)} 💬 Response`));
-  const truncated = truncate(text, 1000);
+  const truncated = truncate(safeText, 1000);
   const indented = truncated
     .split("\n")
     .map((line) => `           ${line}`)
@@ -301,13 +329,14 @@ export function logWarning(message: string, details?: string): void {
 }
 
 export function logAgentError(ctx: LogContext | "system", error: string): void {
+  const safeError = redact(error);
   if (logger) {
-    const extra = ctx === "system" ? { error } : { ...ctxFields(ctx), error };
+    const extra = ctx === "system" ? { error: safeError } : { ...ctxFields(ctx), error: safeError };
     logger.error({ event: "agent_error", ...extra }, "Agent error");
   }
   const context = ctx === "system" ? "[system]" : formatContext(ctx);
   console.log(chalk.yellow(`${timestamp()} ${context} ✗ Agent error`));
-  const indented = error
+  const indented = safeError
     .split("\n")
     .map((line) => `           ${line}`)
     .join("\n");

--- a/src/log.ts
+++ b/src/log.ts
@@ -2,6 +2,9 @@ import { Logging } from "@google-cloud/logging";
 import { Writable } from "node:stream";
 import chalk from "chalk";
 import pino from "pino";
+import { redact } from "./redact.js";
+
+export { registerSecret, __resetSecretsForTest } from "./redact.js";
 
 const PINO_TO_GCP: Record<number, string> = {
   10: "DEBUG",
@@ -46,27 +49,6 @@ export interface LogConfig {
 }
 
 let logger: pino.Logger | null = null;
-
-// Secret redaction
-const registeredSecrets = new Set<string>();
-
-export function registerSecret(value: string): void {
-  if (value && value.length >= 8) registeredSecrets.add(value);
-}
-
-/** Only for use in tests. */
-export function __resetSecretsForTest(): void {
-  registeredSecrets.clear();
-}
-
-function redact(text: string): string {
-  if (registeredSecrets.size === 0) return text;
-  let result = text;
-  for (const secret of registeredSecrets) {
-    result = result.split(secret).join("[REDACTED]");
-  }
-  return result;
-}
 
 export function initLogger(config?: LogConfig): void {
   if (logger) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import { type AgentRunner, createRunner } from "./agent.js";
 import { downloadChannel } from "./download.js";
 import { createEventsWatcher } from "./events.js";
 import * as log from "./log.js";
-import { parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
+import { parseSandboxArg, registerSecretEnvVar, type SandboxConfig, validateSandbox } from "./sandbox.js";
 import { ChannelStore } from "./store.js";
 
 // ============================================================================
@@ -43,6 +43,20 @@ const MOM_SLACK_APP_TOKEN = process.env.MOM_SLACK_APP_TOKEN;
 const MOM_SLACK_BOT_TOKEN = process.env.MOM_SLACK_BOT_TOKEN;
 const MOM_TELEGRAM_BOT_TOKEN = process.env.MOM_TELEGRAM_BOT_TOKEN;
 const MOM_DISCORD_BOT_TOKEN = process.env.MOM_DISCORD_BOT_TOKEN;
+
+// Register platform tokens so they are redacted from logs and stripped from
+// the environment exposed to agent-executed bash commands.
+for (const [name, value] of [
+  ["MOM_SLACK_APP_TOKEN", MOM_SLACK_APP_TOKEN],
+  ["MOM_SLACK_BOT_TOKEN", MOM_SLACK_BOT_TOKEN],
+  ["MOM_TELEGRAM_BOT_TOKEN", MOM_TELEGRAM_BOT_TOKEN],
+  ["MOM_DISCORD_BOT_TOKEN", MOM_DISCORD_BOT_TOKEN],
+] as [string, string | undefined][]) {
+  if (value) {
+    log.registerSecret(value);
+    registerSecretEnvVar(name);
+  }
+}
 
 interface ParsedArgs {
   workingDir?: string;

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,19 @@
+const registeredSecrets = new Set<string>();
+
+export function registerSecret(value: string): void {
+  if (value && value.length >= 8) registeredSecrets.add(value);
+}
+
+/** Only for use in tests. */
+export function __resetSecretsForTest(): void {
+  registeredSecrets.clear();
+}
+
+export function redact(text: string): string {
+  if (registeredSecrets.size === 0) return text;
+  let result = text;
+  for (const secret of registeredSecrets) {
+    result = result.split(secret).join("[REDACTED]");
+  }
+  return result;
+}

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -2,6 +2,20 @@ import { spawn } from "child_process";
 
 export type SandboxConfig = { type: "host" } | { type: "docker"; container: string };
 
+// Names of env vars that hold secrets and must not be exposed to agent-executed commands
+const secretEnvVarNames = new Set<string>();
+
+export function registerSecretEnvVar(name: string): void {
+  secretEnvVarNames.add(name);
+}
+
+function buildSafeEnv(): NodeJS.ProcessEnv {
+  if (secretEnvVarNames.size === 0) return process.env;
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !secretEnvVarNames.has(key)),
+  ) as NodeJS.ProcessEnv;
+}
+
 export function parseSandboxArg(value: string): SandboxConfig {
   if (value === "host") {
     return { type: "host" };
@@ -115,6 +129,7 @@ class HostExecutor implements Executor {
       const child = spawn(shell, [...shellArgs, command], {
         detached: true,
         stdio: ["ignore", "pipe", "pipe"],
+        env: buildSafeEnv(),
       });
 
       let stdout = "";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,10 +1,38 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { createAttachTool } from "../adapters/slack/tools/attach.js";
+import { redact } from "../redact.js";
 import type { Executor } from "../sandbox.js";
 import { createBashTool } from "./bash.js";
 import { createEditTool } from "./edit.js";
 import { createReadTool } from "./read.js";
 import { createWriteTool } from "./write.js";
+
+/**
+ * Wrap a tool so that text content blocks and error messages are redacted
+ * before reaching the LLM context window.
+ */
+function withRedaction<S>(tool: AgentTool<S>): AgentTool<S> {
+  const originalExecute = tool.execute;
+  return {
+    ...tool,
+    execute: async (...args: Parameters<typeof originalExecute>) => {
+      try {
+        const result = await originalExecute(...args);
+        return {
+          ...result,
+          content: result.content.map((block) =>
+            block.type === "text" ? { ...block, text: redact(block.text) } : block,
+          ),
+        };
+      } catch (err) {
+        if (err instanceof Error) {
+          throw new Error(redact(err.message));
+        }
+        throw err;
+      }
+    },
+  };
+}
 
 export function createMamaTools(executor: Executor): {
   tools: AgentTool<any>[];
@@ -13,11 +41,11 @@ export function createMamaTools(executor: Executor): {
   const { tool: attachTool, setUploadFunction } = createAttachTool();
   return {
     tools: [
-      createReadTool(executor),
-      createBashTool(executor),
-      createEditTool(executor),
-      createWriteTool(executor),
-      attachTool,
+      withRedaction(createReadTool(executor)),
+      withRedaction(createBashTool(executor)),
+      withRedaction(createEditTool(executor)),
+      withRedaction(createWriteTool(executor)),
+      withRedaction(attachTool),
     ],
     setUploadFunction,
   };


### PR DESCRIPTION
- Add SecretRedactor to log.ts: registers secret values and redacts them
  from all log output (tool results, agent responses, user messages, errors)
- Add registerSecretEnvVar() to sandbox.ts: strips registered secret env
  vars from the environment passed to agent-executed bash commands, so the
  LLM cannot exfiltrate tokens via `echo $MOM_SLACK_BOT_TOKEN`
- Register all platform tokens (Slack/Telegram/Discord) at startup in
  main.ts for both log redaction and env var stripping

https://claude.ai/code/session_018zMoUT3oHWybsQRUBJfMaF