### PR TITLE
feat: add Google OAuth 2.0 per-user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We actively track the upstream `pi-mom` and plan to:
 ## Features
 
 - **Multi-platform** — Slack, Telegram, and Discord adapters out of the box
+- **Per-user Google OAuth** — each Slack user authorises their own Google account once; the agent uses their identity for GCP / GDC operations
 - **Thread sessions** — each thread / reply chain gets its own isolated conversation context
 - **Concurrent threads** — multiple threads in the same channel run independently
 - **Sandbox execution** — run agent commands on host or inside a Docker container
@@ -196,6 +197,164 @@ GOOGLE_CLOUD_PROJECT=<your-project-id> mama <working-directory>
 ```
 
 Logs appear in Cloud Logging under **Log name: `mama`**. Console output (stdout) is unaffected and continues to work alongside Cloud Logging.
+
+---
+
+## Google OAuth — per-user GCP authentication
+
+This feature lets each Slack user authorise their own Google account **once**. After that, the agent can run `gdcloud` / GCP API calls **as that user** rather than as the bot's service account.
+
+### Architecture
+
+```
+[ First-time setup — once per user ]
+
+User sends "auth" in Slack
+  → Bot generates a Google consent URL and replies
+  → User clicks the link, completes the consent screen
+  → Google redirects to /oauth/callback on the mama server
+  → Server exchanges the code for a refresh_token
+  → refresh_token is stored in GCP Secret Manager
+     key: gdc-sandbox-token-{slack_user_id}
+
+[ Every subsequent command ]
+
+User sends a command in Slack
+  → Agent fetches the user's access_token via
+    GET http://localhost:PORT/api/token/{slack_user_id}
+    (auto-refreshes from Secret Manager when expired)
+  → Agent runs: CLOUDSDK_AUTH_ACCESS_TOKEN=<token> gdcloud ...
+```
+
+### Prerequisites
+
+| Requirement | Details |
+|---|---|
+| GCP project | Set `GOOGLE_CLOUD_PROJECT` |
+| Secret Manager API | Enable `secretmanager.googleapis.com` in your project |
+| Service account | Needs `roles/secretmanager.admin` (or a custom role with `secretmanager.secrets.*` permissions) |
+| OAuth 2.0 client | Create in [Google Cloud Console](https://console.cloud.google.com/apis/credentials) — **Web application** type |
+| Public HTTPS URL | The redirect URI must be reachable from users' browsers (use Cloud Run, a load balancer, or ngrok for testing) |
+
+### Step-by-step setup
+
+#### 1 — Enable APIs
+
+```bash
+gcloud services enable secretmanager.googleapis.com --project=YOUR_PROJECT
+gcloud services enable oauth2.googleapis.com --project=YOUR_PROJECT
+```
+
+#### 2 — Create an OAuth 2.0 client
+
+1. Open **APIs & Services → Credentials** in Google Cloud Console.
+2. Click **Create Credentials → OAuth client ID**.
+3. Choose **Web application**.
+4. Add your redirect URI, e.g. `https://mama.example.com/oauth/callback`.
+5. Download or copy the **Client ID** and **Client Secret**.
+
+#### 3 — Grant Secret Manager permissions to the mama service account
+
+```bash
+gcloud projects add-iam-policy-binding YOUR_PROJECT \
+  --member="serviceAccount:mama-sa@YOUR_PROJECT.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.admin"
+```
+
+#### 4 — Set environment variables
+
+```bash
+export GOOGLE_CLOUD_PROJECT=YOUR_PROJECT
+export GOOGLE_OAUTH_CLIENT_ID=YOUR_CLIENT_ID.apps.googleusercontent.com
+export GOOGLE_OAUTH_CLIENT_SECRET=YOUR_CLIENT_SECRET
+export GOOGLE_OAUTH_REDIRECT_URI=https://mama.example.com/oauth/callback
+export GOOGLE_OAUTH_PORT=8080          # optional, default: 8080
+```
+
+#### 5 — Expose the callback port
+
+The mama process listens on `GOOGLE_OAUTH_PORT` (default **8080**). Make sure this port is reachable from the public internet (or your internal network) at the domain you registered as the redirect URI.
+
+**Cloud Run example** — add the port to the container and use the service URL as the redirect URI:
+
+```yaml
+# service.yaml (excerpt)
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/YOUR_PROJECT/mama
+          ports:
+            - containerPort: 8080   # Slack Socket Mode (no inbound port needed)
+            - containerPort: 8080   # OAuth callback
+          env:
+            - name: GOOGLE_OAUTH_PORT
+              value: "8080"
+```
+
+**Local testing** — use ngrok:
+
+```bash
+ngrok http 8080
+# Use the ngrok HTTPS URL as GOOGLE_OAUTH_REDIRECT_URI
+```
+
+### User workflow
+
+Once deployed, users interact with the bot via Slack:
+
+```
+# Authorise (one-time):
+@mama auth
+  → Bot replies with a Google consent URL (valid for 10 minutes)
+  → Click the link → authorise → see "✓ Authorised as you@company.com"
+
+# Remove authorisation:
+@mama revoke
+```
+
+### Using the token in agent commands
+
+The OAuth server exposes a **localhost-only** token endpoint:
+
+```
+GET http://localhost:PORT/api/token/{slack_user_id}
+```
+
+- Returns the current access token as plain text (auto-refreshed when < 5 min remaining).
+- Returns `404 no_token` if the user has never authorised.
+- Only accepts connections from `127.0.0.1` / `::1` — safe to call from bash.
+
+Inside a skill or the agent's bash tool:
+
+```bash
+SLACK_USER_ID="U0123456789"
+TOKEN=$(curl -sf http://localhost:8080/api/token/$SLACK_USER_ID)
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "no_token" ]; then
+  echo "User has not authorised. Ask them to send 'auth' in Slack first."
+  exit 1
+fi
+
+CLOUDSDK_AUTH_ACCESS_TOKEN=$TOKEN gdcloud compute instances list \
+  --project=sandbox-project
+```
+
+### Secret storage layout in Secret Manager
+
+| Secret name | Content |
+|---|---|
+| `gdc-sandbox-token-{slack_user_id}` | JSON: `{ refresh_token, access_token, expires_at, email }` |
+
+Each new authorisation adds a new **version** to the existing secret (previous versions are retained by GCP for audit purposes).
+
+### Security notes
+
+- The token endpoint (`/api/token/…`) rejects all non-localhost connections.
+- Refresh tokens are never logged or included in Slack messages.
+- Users can revoke access at any time with `@mama revoke` (deletes the secret).
+- You can also revoke from Google at <https://myaccount.google.com/permissions>.
+
+---
 
 ## Working Directory Layout
 

--- a/README.md
+++ b/README.md
@@ -328,8 +328,9 @@ GET http://localhost:PORT/api/token/{slack_user_id}
 Inside a skill or the agent's bash tool:
 
 ```bash
-SLACK_USER_ID="U0123456789"
-TOKEN=$(curl -sf http://localhost:8080/api/token/$SLACK_USER_ID)
+SLACK_USER_ID="${MAMA_SLACK_USER_ID:?missing slack user id}"
+TOKEN_URL="${MAMA_GOOGLE_ACCESS_TOKEN_URL:-http://127.0.0.1:8080/api/token/$SLACK_USER_ID}"
+TOKEN=$(curl -sf "$TOKEN_URL")
 if [ -z "$TOKEN" ] || [ "$TOKEN" = "no_token" ]; then
   echo "User has not authorised. Ask them to send 'auth' in Slack first."
   exit 1
@@ -338,6 +339,17 @@ fi
 CLOUDSDK_AUTH_ACCESS_TOKEN=$TOKEN gdcloud compute instances list \
   --project=sandbox-project
 ```
+
+For Slack-triggered runs, mama now injects the caller context into bash/skills:
+
+- `MAMA_PLATFORM`
+- `MAMA_USER_ID`
+- `MAMA_CHANNEL_ID`
+- `MAMA_THREAD_TS` (when in thread)
+- `MAMA_SLACK_USER_ID` (Slack only)
+- `MAMA_GOOGLE_TOKEN_BASE_URL` / `MAMA_GOOGLE_ACCESS_TOKEN_URL` when Google OAuth is enabled
+
+In Docker sandbox mode, `MAMA_GOOGLE_ACCESS_TOKEN_URL` automatically uses `host.docker.internal` instead of `localhost`, so the container can still fetch the caller's token from the mama process running on the host.
 
 ### Secret storage layout in Secret Manager
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.42",
         "@google-cloud/logging": "^11.2.1",
+        "@google-cloud/secret-manager": "^5.6.0",
         "@mariozechner/pi-agent-core": "^0.58.3",
         "@mariozechner/pi-ai": "^0.58.3",
         "@mariozechner/pi-coding-agent": "^0.58.3",
@@ -1215,6 +1216,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-5.6.0.tgz",
+      "integrity": "sha512-0daW/OXQEVc6VQKPyJTQNyD+563I/TYQ7GCQJx4dq3lB666R9FUPvqHx9b/o/qQtZ5pfuoCbGZl3krpxgTSW8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@google/genai": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "^0.0.42",
     "@google-cloud/logging": "^11.2.1",
+    "@google-cloud/secret-manager": "^5.6.0",
     "@mariozechner/pi-agent-core": "^0.58.3",
     "@mariozechner/pi-ai": "^0.58.3",
     "@mariozechner/pi-coding-agent": "^0.58.3",

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -6,6 +6,7 @@ import { basename, join } from "path";
 import type { Bot, BotEvent, BotHandler, PlatformInfo } from "../../adapter.js";
 import type { EventsWatcher } from "../../events.js";
 import * as log from "../../log.js";
+import type { OAuthManager } from "../../oauth/index.js";
 import type { Attachment, ChannelStore } from "../../store.js";
 import { createSlackAdapters } from "./context.js";
 
@@ -175,14 +176,22 @@ export class SlackBot implements Bot {
   private channels = new Map<string, SlackChannel>();
   private queues = new Map<string, ChannelQueue>();
   private eventsWatcher: EventsWatcher | null = null;
+  private oauthManager: OAuthManager | null = null;
 
   constructor(
     handler: BotHandler,
-    config: { appToken: string; botToken: string; workingDir: string; store: ChannelStore },
+    config: {
+      appToken: string;
+      botToken: string;
+      workingDir: string;
+      store: ChannelStore;
+      oauthManager?: OAuthManager;
+    },
   ) {
     this.handler = handler;
     this.workingDir = config.workingDir;
     this.store = config.store;
+    this.oauthManager = config.oauthManager ?? null;
     this.socketClient = new SocketModeClient({ appToken: config.appToken });
     this.webClient = new WebClient(config.botToken);
   }
@@ -538,6 +547,41 @@ export class SlackBot implements Bot {
     return { type: "home", blocks };
   }
 
+  // ==========================================================================
+  // Private - OAuth command handling
+  // ==========================================================================
+
+  /**
+   * Handle `auth` / `revoke` commands for Google OAuth.
+   * Returns true if the command was handled so callers can skip normal processing.
+   */
+  private async handleOAuthCommand(
+    userId: string,
+    channelId: string,
+    text: string,
+  ): Promise<boolean> {
+    if (!this.oauthManager) return false;
+
+    const normalized = text.toLowerCase().trim();
+
+    if (normalized === "auth") {
+      const url = this.oauthManager.generateAuthUrl(userId, channelId);
+      await this.postMessage(
+        channelId,
+        `Click the link below to authorize your Google account:\n${url}\n\n_This link expires in 10 minutes._`,
+      );
+      return true;
+    }
+
+    if (normalized === "revoke") {
+      await this.oauthManager.revokeToken(userId);
+      await this.postMessage(channelId, "_Your Google authorization has been revoked._");
+      return true;
+    }
+
+    return false;
+  }
+
   private setupEventHandlers(): void {
     // Channel @mentions
     this.socketClient.on("app_mention", ({ event, ack }) => {
@@ -594,23 +638,29 @@ export class SlackBot implements Bot {
         return;
       }
 
-      // SYNC: Check if busy (per-thread)
-      if (this.handler.isRunning(sessionKey)) {
-        this.postMessage(
-          e.channel,
-          "_Already working in this thread. Say `@mama stop` to cancel._",
-        );
-      } else {
-        this.getQueue(sessionKey).enqueue(() => {
-          const adapters = createSlackAdapters(slackEvent, this, false);
-          return this.handler.handleEvent(
-            slackEvent as unknown as import("../../adapter.js").BotEvent,
-            this,
-            adapters,
-            false,
-          );
+      // Handle OAuth commands (auth / revoke)
+      this.handleOAuthCommand(e.user, e.channel, slackEvent.text)
+        .then((handled) => {
+          if (!handled && !this.handler.isRunning(sessionKey)) {
+            this.getQueue(sessionKey).enqueue(() => {
+              const adapters = createSlackAdapters(slackEvent, this, false);
+              return this.handler.handleEvent(
+                slackEvent as unknown as import("../../adapter.js").BotEvent,
+                this,
+                adapters,
+                false,
+              );
+            });
+          } else if (!handled && this.handler.isRunning(sessionKey)) {
+            this.postMessage(
+              e.channel,
+              "_Already working in this thread. Say `@mama stop` to cancel._",
+            );
+          }
+        })
+        .catch((err) => {
+          log.logWarning("OAuth command error", err instanceof Error ? err.message : String(err));
         });
-      }
 
       ack();
     });
@@ -704,19 +754,28 @@ export class SlackBot implements Bot {
           return;
         }
 
-        if (this.handler.isRunning(dmSessionKey)) {
-          this.postMessage(e.channel, "_Already working. Say `stop` to cancel._");
-        } else {
-          this.getQueue(dmSessionKey).enqueue(() => {
-            const adapters = createSlackAdapters(slackEvent, this, false);
-            return this.handler.handleEvent(
-              slackEvent as unknown as import("../../adapter.js").BotEvent,
-              this,
-              adapters,
-              false,
-            );
+        // Handle OAuth commands (auth / revoke)
+        this.handleOAuthCommand(e.user!, e.channel, slackEvent.text)
+          .then((handled) => {
+            if (!handled) {
+              if (this.handler.isRunning(dmSessionKey)) {
+                this.postMessage(e.channel, "_Already working. Say `stop` to cancel._");
+              } else {
+                this.getQueue(dmSessionKey).enqueue(() => {
+                  const adapters = createSlackAdapters(slackEvent, this, false);
+                  return this.handler.handleEvent(
+                    slackEvent as unknown as import("../../adapter.js").BotEvent,
+                    this,
+                    adapters,
+                    false,
+                  );
+                });
+              }
+            }
+          })
+          .catch((err) => {
+            log.logWarning("OAuth command error", err instanceof Error ? err.message : String(err));
           });
-        }
       }
 
       ack();

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,7 +17,7 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import type { ChatMessage, ChatResponseContext, PlatformInfo } from "./adapter.js";
-import { loadAgentConfig } from "./config.js";
+import { loadAgentConfig, loadEnvConfig } from "./config.js";
 import { createMamaSettingsManager, syncLogToSessionManager } from "./context.js";
 import * as log from "./log.js";
 import { createExecutor, type SandboxConfig } from "./sandbox.js";
@@ -132,6 +132,7 @@ function buildSystemPrompt(
   sandboxConfig: SandboxConfig,
   platform: PlatformInfo,
   skills: Skill[],
+  requestContext?: string,
 ): string {
   const channelPath = `${workspacePath}/${channelId}`;
   const isDocker = sandboxConfig.type === "docker";
@@ -173,6 +174,8 @@ Channels: ${channelMappings}
 Users: ${userMappings}
 
 When mentioning users, use <@username> format (e.g., <@mario>).
+
+${requestContext ? `${requestContext}\n` : ""}
 
 ## Environment
 ${envDescription}
@@ -317,6 +320,83 @@ Each tool requires a "label" parameter (shown to user).
 `;
 }
 
+export function buildRunEnvironment(
+  platform: PlatformInfo,
+  message: ChatMessage,
+  sandboxConfig: SandboxConfig,
+  googleOAuthPort?: number,
+): Record<string, string> {
+  const channelId = message.sessionKey.split(":")[0];
+  const env: Record<string, string> = {
+    MAMA_PLATFORM: platform.name,
+    MAMA_USER_ID: message.userId,
+    MAMA_CHANNEL_ID: channelId,
+  };
+
+  if (message.threadTs) {
+    env.MAMA_THREAD_TS = message.threadTs;
+  }
+
+  if (platform.name === "slack") {
+    env.MAMA_SLACK_USER_ID = message.userId;
+
+    if (googleOAuthPort) {
+      const tokenHost = sandboxConfig.type === "docker" ? "host.docker.internal" : "127.0.0.1";
+      const tokenBaseUrl = `http://${tokenHost}:${googleOAuthPort}/api/token`;
+      env.MAMA_GOOGLE_TOKEN_BASE_URL = tokenBaseUrl;
+      env.MAMA_GOOGLE_ACCESS_TOKEN_URL = `${tokenBaseUrl}/${message.userId}`;
+    }
+  }
+
+  return env;
+}
+
+export function buildCurrentRequestContext(
+  platform: PlatformInfo,
+  message: ChatMessage,
+  executionEnv: Record<string, string>,
+): string {
+  const lines = [
+    "## Current Request",
+    `- Platform: ${platform.name}`,
+    `- User ID: ${message.userId}`,
+    `- Channel ID: ${message.sessionKey.split(":")[0]}`,
+  ];
+
+  if (message.userName) {
+    lines.push(`- User name: ${message.userName}`);
+  }
+
+  if (message.threadTs) {
+    lines.push(`- Thread root: ${message.threadTs}`);
+  }
+
+  if (platform.name === "slack") {
+    lines.push(
+      "- Use only the requesting Slack user's permissions. Never substitute another Slack user ID to fetch or use credentials.",
+    );
+    lines.push("- Bash and skills receive these env vars for the current caller:");
+    lines.push(`  - MAMA_SLACK_USER_ID=${executionEnv.MAMA_SLACK_USER_ID ?? message.userId}`);
+
+    if (executionEnv.MAMA_GOOGLE_TOKEN_BASE_URL) {
+      lines.push(
+        `  - MAMA_GOOGLE_TOKEN_BASE_URL=${executionEnv.MAMA_GOOGLE_TOKEN_BASE_URL}`,
+      );
+    }
+
+    if (executionEnv.MAMA_GOOGLE_ACCESS_TOKEN_URL) {
+      lines.push(
+        `  - MAMA_GOOGLE_ACCESS_TOKEN_URL=${executionEnv.MAMA_GOOGLE_ACCESS_TOKEN_URL}`,
+      );
+      lines.push(
+        "- Prefer MAMA_GOOGLE_ACCESS_TOKEN_URL over hardcoding localhost URLs, especially in Docker sandbox mode.",
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
 function truncate(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
   return `${text.substring(0, maxLen - 3)}...`;
@@ -396,6 +476,7 @@ export async function createRunner(
   workspaceDir: string,
 ): Promise<AgentRunner> {
   const agentConfig = loadAgentConfig(workspaceDir);
+  const envConfig = loadEnvConfig();
 
   // Initialize logger with settings from config
   log.initLogger({
@@ -405,9 +486,10 @@ export async function createRunner(
 
   const executor = createExecutor(sandboxConfig);
   const workspacePath = executor.getWorkspacePath(channelDir.replace(`/${channelId}`, ""));
+  let executionEnv: Record<string, string> = {};
 
   // Create tools (per-runner, with per-runner upload function setter)
-  const { tools, setUploadFunction } = createMamaTools(executor);
+  const { tools, setUploadFunction } = createMamaTools(executor, () => executionEnv);
 
   // Resolve model from config
   // Use 'as any' cast because agentConfig.provider/model are plain strings,
@@ -431,6 +513,7 @@ export async function createRunner(
     sandboxConfig,
     emptyPlatform,
     skills,
+    undefined,
   );
 
   // Create session manager and settings manager
@@ -727,6 +810,13 @@ export async function createRunner(
       // Update system prompt with fresh memory, channel/user info, and skills
       const memory = await getMemory(channelDir);
       const skills = loadMamaSkills(channelDir, workspacePath);
+      executionEnv = buildRunEnvironment(
+        platform,
+        message,
+        sandboxConfig,
+        envConfig.googleOAuthPort,
+      );
+      const requestContext = buildCurrentRequestContext(platform, message, executionEnv);
       const systemPrompt = buildSystemPrompt(
         workspacePath,
         channelId,
@@ -734,6 +824,7 @@ export async function createRunner(
         sandboxConfig,
         platform,
         skills,
+        requestContext,
       );
       session.agent.setSystemPrompt(systemPrompt);
 
@@ -946,6 +1037,7 @@ export async function createRunner(
       runState.responseCtx = null;
       runState.logCtx = null;
       runState.queue = null;
+      executionEnv = {};
 
       return { stopReason: runState.stopReason, errorMessage: runState.errorMessage };
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,46 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 
+// ============================================================================
+// Environment Config
+// ============================================================================
+
+export interface EnvConfig {
+  // Bot tokens
+  slackAppToken?: string;
+  slackBotToken?: string;
+  telegramBotToken?: string;
+  discordBotToken?: string;
+  // Google OAuth
+  googleOAuthClientId?: string;
+  googleOAuthClientSecret?: string;
+  googleOAuthRedirectUri?: string;
+  googleCloudProject?: string;
+  googleOAuthPort?: number;
+}
+
+export function loadEnvConfig(): EnvConfig {
+  return {
+    // Bot tokens
+    slackAppToken: process.env.MOM_SLACK_APP_TOKEN,
+    slackBotToken: process.env.MOM_SLACK_BOT_TOKEN,
+    telegramBotToken: process.env.MOM_TELEGRAM_BOT_TOKEN,
+    discordBotToken: process.env.MOM_DISCORD_BOT_TOKEN,
+    // Google OAuth
+    googleOAuthClientId: process.env.GOOGLE_OAUTH_CLIENT_ID,
+    googleOAuthClientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET,
+    googleOAuthRedirectUri: process.env.GOOGLE_OAUTH_REDIRECT_URI,
+    googleCloudProject: process.env.GOOGLE_CLOUD_PROJECT,
+    googleOAuthPort: process.env.GOOGLE_OAUTH_PORT
+      ? parseInt(process.env.GOOGLE_OAUTH_PORT, 10)
+      : undefined,
+  };
+}
+
+// ============================================================================
+// Agent Config
+// ============================================================================
+
 export interface AgentConfig {
   provider: string;
   model: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+// Utils barrel export
+export * from "./utils/sanitize.js";
+// Middleware barrel export
+export * from "./middleware/rateLimit.js";

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { type AgentRunner, createRunner } from "./agent.js";
 import { downloadChannel } from "./download.js";
 import { createEventsWatcher } from "./events.js";
 import * as log from "./log.js";
+import { OAuthManager, startOAuthServer } from "./oauth/index.js";
 import { parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
 import { ChannelStore } from "./store.js";
 
@@ -43,6 +44,13 @@ const MOM_SLACK_APP_TOKEN = process.env.MOM_SLACK_APP_TOKEN;
 const MOM_SLACK_BOT_TOKEN = process.env.MOM_SLACK_BOT_TOKEN;
 const MOM_TELEGRAM_BOT_TOKEN = process.env.MOM_TELEGRAM_BOT_TOKEN;
 const MOM_DISCORD_BOT_TOKEN = process.env.MOM_DISCORD_BOT_TOKEN;
+
+// Google OAuth (optional — set all four to enable per-user auth)
+const GOOGLE_OAUTH_CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID;
+const GOOGLE_OAUTH_CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+const GOOGLE_OAUTH_REDIRECT_URI = process.env.GOOGLE_OAUTH_REDIRECT_URI;
+const GOOGLE_CLOUD_PROJECT = process.env.GOOGLE_CLOUD_PROJECT;
+const GOOGLE_OAUTH_PORT = parseInt(process.env.GOOGLE_OAUTH_PORT ?? "8080", 10);
 
 interface ParsedArgs {
   workingDir?: string;
@@ -348,8 +356,55 @@ const handler: BotHandler = {
 
 log.logStartup(workingDir, sandbox.type === "host" ? "host" : `docker:${sandbox.container}`);
 
-// Create the appropriate platform bot
+// ============================================================================
+// Google OAuth (optional)
+// ============================================================================
+
+// Forward-declare bot so the OAuth callback (which runs after startup) can reference it
 let bot: Bot;
+let oauthManager: OAuthManager | undefined;
+let stopOAuthServer: (() => void) | undefined;
+
+if (
+  GOOGLE_OAUTH_CLIENT_ID &&
+  GOOGLE_OAUTH_CLIENT_SECRET &&
+  GOOGLE_OAUTH_REDIRECT_URI &&
+  GOOGLE_CLOUD_PROJECT
+) {
+  oauthManager = new OAuthManager({
+    clientId: GOOGLE_OAUTH_CLIENT_ID,
+    clientSecret: GOOGLE_OAUTH_CLIENT_SECRET,
+    redirectUri: GOOGLE_OAUTH_REDIRECT_URI,
+    projectId: GOOGLE_CLOUD_PROJECT,
+  });
+
+  stopOAuthServer = startOAuthServer(
+    GOOGLE_OAUTH_PORT,
+    async (code, state) => {
+      const result = await oauthManager!.handleCallback(code, state);
+      if (result && hasSlack) {
+        // DM the user to let them know authorization succeeded
+        const slackBot = bot as SlackBotClass;
+        slackBot
+          .postMessage(
+            result.channelId,
+            `_✓ Google authorization successful! Authorized as *${result.email}*._`,
+          )
+          .catch(() => {});
+      }
+      return { success: !!result, email: result?.email };
+    },
+    (slackUserId) => oauthManager!.getAccessToken(slackUserId),
+  );
+
+  log.logInfo(
+    `Google OAuth enabled (callback: ${GOOGLE_OAUTH_REDIRECT_URI}, port: ${GOOGLE_OAUTH_PORT})`,
+  );
+}
+
+// ============================================================================
+// Create the appropriate platform bot
+// ============================================================================
 
 if (hasSlack) {
   const sharedStore = new ChannelStore({ workingDir, botToken: MOM_SLACK_BOT_TOKEN! });
@@ -358,6 +413,7 @@ if (hasSlack) {
     botToken: MOM_SLACK_BOT_TOKEN!,
     workingDir,
     store: sharedStore,
+    oauthManager,
   });
   log.logInfo("Platform: Slack");
 } else if (hasTelegram) {
@@ -396,6 +452,7 @@ process.on("SIGINT", async () => {
     log.logWarning(`Forcing exit with ${inFlightRuns.size} runs still in progress`);
   }
 
+  stopOAuthServer?.();
   eventsWatcher.stop();
   process.exit(0);
 });
@@ -414,6 +471,7 @@ process.on("SIGTERM", async () => {
     log.logWarning(`Forcing exit with ${inFlightRuns.size} runs still in progress`);
   }
 
+  stopOAuthServer?.();
   eventsWatcher.stop();
   process.exit(0);
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import * as log from "./log.js";
 import { OAuthManager, startOAuthServer } from "./oauth/index.js";
 import { parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
 import { ChannelStore } from "./store.js";
+import { loadEnvConfig } from "./config.js";
 
 // ============================================================================
 // Config
@@ -40,17 +41,8 @@ function getVersion(): string {
   return "unknown";
 }
 
-const MOM_SLACK_APP_TOKEN = process.env.MOM_SLACK_APP_TOKEN;
-const MOM_SLACK_BOT_TOKEN = process.env.MOM_SLACK_BOT_TOKEN;
-const MOM_TELEGRAM_BOT_TOKEN = process.env.MOM_TELEGRAM_BOT_TOKEN;
-const MOM_DISCORD_BOT_TOKEN = process.env.MOM_DISCORD_BOT_TOKEN;
-
-// Google OAuth (optional — set all four to enable per-user auth)
-const GOOGLE_OAUTH_CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID;
-const GOOGLE_OAUTH_CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
-const GOOGLE_OAUTH_REDIRECT_URI = process.env.GOOGLE_OAUTH_REDIRECT_URI;
-const GOOGLE_CLOUD_PROJECT = process.env.GOOGLE_CLOUD_PROJECT;
-const GOOGLE_OAUTH_PORT = parseInt(process.env.GOOGLE_OAUTH_PORT ?? "8080", 10);
+// Load environment config
+const envConfig = loadEnvConfig();
 
 interface ParsedArgs {
   workingDir?: string;
@@ -101,11 +93,11 @@ if (parsedArgs.showVersion) {
 
 // Handle --download mode (Slack only)
 if (parsedArgs.downloadChannel) {
-  if (!MOM_SLACK_BOT_TOKEN) {
+  if (!envConfig.slackBotToken) {
     console.error("Missing env: MOM_SLACK_BOT_TOKEN");
     process.exit(1);
   }
-  await downloadChannel(parsedArgs.downloadChannel, MOM_SLACK_BOT_TOKEN);
+  await downloadChannel(parsedArgs.downloadChannel, envConfig.slackBotToken);
   process.exit(0);
 }
 
@@ -119,9 +111,9 @@ if (!parsedArgs.workingDir) {
 const { workingDir, sandbox } = { workingDir: parsedArgs.workingDir, sandbox: parsedArgs.sandbox };
 
 // Validate platform tokens
-const hasSlack = !!(MOM_SLACK_APP_TOKEN && MOM_SLACK_BOT_TOKEN);
-const hasTelegram = !!MOM_TELEGRAM_BOT_TOKEN;
-const hasDiscord = !!MOM_DISCORD_BOT_TOKEN;
+const hasSlack = !!(envConfig.slackAppToken && envConfig.slackBotToken);
+const hasTelegram = !!envConfig.telegramBotToken;
+const hasDiscord = !!envConfig.discordBotToken;
 
 if (!hasSlack && !hasTelegram && !hasDiscord) {
   console.error(
@@ -366,20 +358,20 @@ let oauthManager: OAuthManager | undefined;
 let stopOAuthServer: (() => void) | undefined;
 
 if (
-  GOOGLE_OAUTH_CLIENT_ID &&
-  GOOGLE_OAUTH_CLIENT_SECRET &&
-  GOOGLE_OAUTH_REDIRECT_URI &&
-  GOOGLE_CLOUD_PROJECT
+  envConfig.googleOAuthClientId &&
+  envConfig.googleOAuthClientSecret &&
+  envConfig.googleOAuthRedirectUri &&
+  envConfig.googleCloudProject
 ) {
   oauthManager = new OAuthManager({
-    clientId: GOOGLE_OAUTH_CLIENT_ID,
-    clientSecret: GOOGLE_OAUTH_CLIENT_SECRET,
-    redirectUri: GOOGLE_OAUTH_REDIRECT_URI,
-    projectId: GOOGLE_CLOUD_PROJECT,
+    clientId: envConfig.googleOAuthClientId,
+    clientSecret: envConfig.googleOAuthClientSecret,
+    redirectUri: envConfig.googleOAuthRedirectUri,
+    projectId: envConfig.googleCloudProject,
   });
 
   stopOAuthServer = startOAuthServer(
-    GOOGLE_OAUTH_PORT,
+    envConfig.googleOAuthPort ?? 8080,
     async (code, state) => {
       const result = await oauthManager!.handleCallback(code, state);
       if (result && hasSlack) {
@@ -398,7 +390,7 @@ if (
   );
 
   log.logInfo(
-    `Google OAuth enabled (callback: ${GOOGLE_OAUTH_REDIRECT_URI}, port: ${GOOGLE_OAUTH_PORT})`,
+    `Google OAuth enabled (callback: ${envConfig.googleOAuthRedirectUri}, port: ${envConfig.googleOAuthPort ?? 8080})`,
   );
 }
 
@@ -407,10 +399,10 @@ if (
 // ============================================================================
 
 if (hasSlack) {
-  const sharedStore = new ChannelStore({ workingDir, botToken: MOM_SLACK_BOT_TOKEN! });
+  const sharedStore = new ChannelStore({ workingDir, botToken: envConfig.slackBotToken! });
   bot = new SlackBotClass(handler, {
-    appToken: MOM_SLACK_APP_TOKEN!,
-    botToken: MOM_SLACK_BOT_TOKEN!,
+    appToken: envConfig.slackAppToken!,
+    botToken: envConfig.slackBotToken!,
     workingDir,
     store: sharedStore,
     oauthManager,
@@ -418,13 +410,13 @@ if (hasSlack) {
   log.logInfo("Platform: Slack");
 } else if (hasTelegram) {
   bot = new TelegramBot(handler, {
-    token: MOM_TELEGRAM_BOT_TOKEN!,
+    token: envConfig.telegramBotToken!,
     workingDir,
   });
   log.logInfo("Platform: Telegram");
 } else {
   bot = new DiscordBot(handler, {
-    token: MOM_DISCORD_BOT_TOKEN!,
+    token: envConfig.discordBotToken!,
     workingDir,
   });
   log.logInfo("Platform: Discord");

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,216 @@
+/**
+ * Rate limiting middleware for mama bot
+ * Prevents API abuse and ensures fair usage
+ */
+
+interface RateLimitRecord {
+  count: number;
+  resetAt: number;
+  blocked: boolean;
+}
+
+interface RateLimitConfig {
+  /** Maximum requests per window */
+  maxRequests: number;
+  /** Window size in milliseconds */
+  windowMs: number;
+  /** Whether to block immediately or just flag */
+  strictMode: boolean;
+}
+
+/** Default configuration */
+const DEFAULT_CONFIG: RateLimitConfig = {
+  maxRequests: 100,
+  windowMs: 60000, // 1 minute
+  strictMode: false,
+};
+
+/** Store for rate limit records by user ID */
+const rateLimitStore = new Map<string, RateLimitRecord>();
+
+/** Store for rate limit records by IP (for OAuth server) */
+const ipRateLimitStore = new Map<string, RateLimitRecord>();
+
+/**
+ * Check if a user has exceeded their rate limit
+ */
+export function checkRateLimit(
+  identifier: string,
+  config: Partial<RateLimitConfig> = {}
+): { allowed: boolean; remaining: number; resetAt: number } {
+  const { maxRequests, windowMs, strictMode } = { ...DEFAULT_CONFIG, ...config };
+  const now = Date.now();
+
+  // Clean up old records periodically
+  if (Math.random() < 0.01) {
+    cleanupExpiredRecords();
+  }
+
+  let record = rateLimitStore.get(identifier);
+
+  // Initialize or reset if window expired
+  if (!record || now > record.resetAt) {
+    record = {
+      count: 0,
+      resetAt: now + windowMs,
+      blocked: false,
+    };
+    rateLimitStore.set(identifier, record);
+  }
+
+  // Check if blocked in strict mode
+  if (strictMode && record.blocked) {
+    return {
+      allowed: false,
+      remaining: 0,
+      resetAt: record.resetAt,
+    };
+  }
+
+  // Increment counter
+  record.count++;
+
+  // Check if limit exceeded
+  if (record.count > maxRequests) {
+    if (strictMode) {
+      record.blocked = true;
+    }
+    return {
+      allowed: false,
+      remaining: 0,
+      resetAt: record.resetAt,
+    };
+  }
+
+  return {
+    allowed: true,
+    remaining: Math.max(0, maxRequests - record.count),
+    resetAt: record.resetAt,
+  };
+}
+
+/**
+ * Check rate limit for IP addresses (OAuth server)
+ */
+export function checkIpRateLimit(
+  ip: string,
+  config: Partial<RateLimitConfig> = {}
+): { allowed: boolean; remaining: number; resetAt: number } {
+  const { maxRequests, windowMs } = { ...DEFAULT_CONFIG, ...config };
+  const now = Date.now();
+
+  let record = ipRateLimitStore.get(ip);
+
+  if (!record || now > record.resetAt) {
+    record = {
+      count: 0,
+      resetAt: now + windowMs,
+      blocked: false,
+    };
+    ipRateLimitStore.set(ip, record);
+  }
+
+  record.count++;
+
+  if (record.count > maxRequests) {
+    return {
+      allowed: false,
+      remaining: 0,
+      resetAt: record.resetAt,
+    };
+  }
+
+  return {
+    allowed: true,
+    remaining: Math.max(0, maxRequests - record.count),
+    resetAt: record.resetAt,
+  };
+}
+
+/**
+ * Get current rate limit status for an identifier
+ */
+export function getRateLimitStatus(identifier: string): RateLimitRecord | undefined {
+  return rateLimitStore.get(identifier);
+}
+
+/**
+ * Reset rate limit for a specific identifier
+ */
+export function resetRateLimit(identifier: string): void {
+  rateLimitStore.delete(identifier);
+}
+
+/**
+ * Clean up expired records to prevent memory leaks
+ */
+function cleanupExpiredRecords(): void {
+  const now = Date.now();
+
+  for (const [key, record] of rateLimitStore.entries()) {
+    if (now > record.resetAt) {
+      rateLimitStore.delete(key);
+    }
+  }
+
+  for (const [key, record] of ipRateLimitStore.entries()) {
+    if (now > record.resetAt) {
+      ipRateLimitStore.delete(key);
+    }
+  }
+}
+
+/**
+ * Express middleware style helper for OAuth server
+ */
+interface MockResponse {
+  status: (code: number) => MockResponse;
+  json: (body: object) => MockResponse;
+  setHeader: (name: string, value: string | number) => MockResponse;
+}
+
+export function createRateLimitMiddleware(
+  config: Partial<RateLimitConfig> = {}
+) {
+  return (req: { ip?: string }, res: MockResponse, next: () => void) => {
+    const ip = req.ip || "unknown";
+    const result = checkIpRateLimit(ip, config);
+
+    // Add rate limit headers
+    res.setHeader("X-RateLimit-Limit", config.maxRequests || DEFAULT_CONFIG.maxRequests);
+    res.setHeader("X-RateLimit-Remaining", result.remaining);
+    res.setHeader("X-RateLimit-Reset", Math.ceil(result.resetAt / 1000));
+
+    if (!result.allowed) {
+      res.status(429).json({
+        error: "Too Many Requests",
+        retryAfter: Math.ceil((result.resetAt - Date.now()) / 1000),
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Get statistics for monitoring
+ */
+export function getRateLimitStats(): {
+  activeUsers: number;
+  activeIPs: number;
+} {
+  const now = Date.now();
+  
+  let activeUsers = 0;
+  for (const record of rateLimitStore.values()) {
+    if (now <= record.resetAt) activeUsers++;
+  }
+
+  let activeIPs = 0;
+  for (const record of ipRateLimitStore.values()) {
+    if (now <= record.resetAt) activeIPs++;
+  }
+
+  return { activeUsers, activeIPs };
+}

--- a/src/oauth/google.ts
+++ b/src/oauth/google.ts
@@ -1,0 +1,127 @@
+import { request } from "https";
+
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+const SCOPES = [
+  "https://www.googleapis.com/auth/cloud-platform",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "openid",
+];
+
+export function generateAuthUrl(clientId: string, redirectUri: string, state: string): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: SCOPES.join(" "),
+    state,
+    access_type: "offline",
+    prompt: "consent",
+  });
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCode(
+  clientId: string,
+  clientSecret: string,
+  redirectUri: string,
+  code: string,
+): Promise<{ access_token: string; refresh_token: string; expires_in: number }> {
+  const body = new URLSearchParams({
+    code,
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uri: redirectUri,
+    grant_type: "authorization_code",
+  });
+  return postJson(GOOGLE_TOKEN_URL, body.toString()) as Promise<{
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+  }>;
+}
+
+export async function refreshAccessToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<{ access_token: string; expires_in: number }> {
+  const body = new URLSearchParams({
+    refresh_token: refreshToken,
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "refresh_token",
+  });
+  return postJson(GOOGLE_TOKEN_URL, body.toString()) as Promise<{
+    access_token: string;
+    expires_in: number;
+  }>;
+}
+
+export async function getUserEmail(accessToken: string): Promise<string> {
+  const info = await getJson(GOOGLE_USERINFO_URL, accessToken);
+  return (info as { email: string }).email;
+}
+
+function postJson(url: string, body: string): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const req = request(
+      {
+        hostname: urlObj.hostname,
+        path: urlObj.pathname + urlObj.search,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          try {
+            const json = JSON.parse(data) as Record<string, unknown>;
+            if (json["error"])
+              reject(new Error(`OAuth error: ${json["error"]}: ${json["error_description"]}`));
+            else resolve(json);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function getJson(url: string, accessToken: string): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const req = request(
+      {
+        hostname: urlObj.hostname,
+        path: urlObj.pathname + urlObj.search,
+        method: "GET",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data) as Record<string, unknown>);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1,0 +1,3 @@
+export { OAuthManager } from "./manager.js";
+export { startOAuthServer } from "./server.js";
+export type { TokenData } from "./types.js";

--- a/src/oauth/manager.ts
+++ b/src/oauth/manager.ts
@@ -1,0 +1,145 @@
+import * as log from "../log.js";
+import { exchangeCode, generateAuthUrl, getUserEmail, refreshAccessToken } from "./google.js";
+import { SecretManagerStore } from "./secretManager.js";
+import type { PendingAuthState, TokenData } from "./types.js";
+
+const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+export class OAuthManager {
+  private clientId: string;
+  private clientSecret: string;
+  private redirectUri: string;
+  private store: SecretManagerStore;
+  private pendingStates = new Map<string, PendingAuthState>();
+
+  constructor(config: {
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+    projectId: string;
+  }) {
+    this.clientId = config.clientId;
+    this.clientSecret = config.clientSecret;
+    this.redirectUri = config.redirectUri;
+    this.store = new SecretManagerStore(config.projectId);
+  }
+
+  /**
+   * Generate an OAuth URL for the given Slack user.
+   * The URL sends them through Google's consent screen.
+   */
+  generateAuthUrl(slackUserId: string, channelId: string): string {
+    this.cleanupExpiredStates();
+    const stateKey = `${slackUserId}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    this.pendingStates.set(stateKey, { slackUserId, channelId, createdAt: Date.now() });
+    return generateAuthUrl(this.clientId, this.redirectUri, stateKey);
+  }
+
+  /**
+   * Handle the OAuth redirect callback.
+   * Exchanges the code for tokens and persists them to Secret Manager.
+   * Returns the Slack user info so the caller can notify them.
+   */
+  async handleCallback(
+    code: string,
+    state: string,
+  ): Promise<{ slackUserId: string; channelId: string; email: string } | null> {
+    const pending = this.pendingStates.get(state);
+    if (!pending) {
+      log.logWarning("OAuth callback: unknown or already-used state");
+      return null;
+    }
+    if (Date.now() - pending.createdAt > STATE_TTL_MS) {
+      this.pendingStates.delete(state);
+      log.logWarning("OAuth callback: state expired");
+      return null;
+    }
+    this.pendingStates.delete(state);
+
+    try {
+      const tokens = await exchangeCode(
+        this.clientId,
+        this.clientSecret,
+        this.redirectUri,
+        code,
+      );
+
+      let email = "(unknown)";
+      try {
+        email = await getUserEmail(tokens.access_token);
+      } catch {
+        // Non-fatal; continue without email
+      }
+
+      const tokenData: TokenData = {
+        refresh_token: tokens.refresh_token,
+        access_token: tokens.access_token,
+        expires_at: Date.now() + tokens.expires_in * 1000,
+        email,
+      };
+
+      await this.store.storeTokens(pending.slackUserId, tokenData);
+      log.logInfo(`OAuth: stored tokens for Slack user ${pending.slackUserId} (${email})`);
+
+      return { slackUserId: pending.slackUserId, channelId: pending.channelId, email };
+    } catch (err) {
+      log.logWarning("OAuth handleCallback error", err instanceof Error ? err.message : String(err));
+      return null;
+    }
+  }
+
+  /**
+   * Return a valid access token for the given Slack user, refreshing if necessary.
+   * Returns null if the user has never authorized.
+   */
+  async getAccessToken(slackUserId: string): Promise<string | null> {
+    const tokens = await this.store.getTokens(slackUserId);
+    if (!tokens?.refresh_token) return null;
+
+    // Still valid (with a 5-minute buffer)?
+    if (tokens.access_token && tokens.expires_at && tokens.expires_at > Date.now() + 300_000) {
+      return tokens.access_token;
+    }
+
+    // Refresh
+    try {
+      const refreshed = await refreshAccessToken(
+        this.clientId,
+        this.clientSecret,
+        tokens.refresh_token,
+      );
+      const updated: TokenData = {
+        ...tokens,
+        access_token: refreshed.access_token,
+        expires_at: Date.now() + refreshed.expires_in * 1000,
+      };
+      await this.store.storeTokens(slackUserId, updated);
+      return refreshed.access_token;
+    } catch (err) {
+      log.logWarning(
+        `OAuth refresh failed for ${slackUserId}`,
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    }
+  }
+
+  /** Returns true if the user has a stored refresh token. */
+  async hasToken(slackUserId: string): Promise<boolean> {
+    const tokens = await this.store.getTokens(slackUserId);
+    return !!tokens?.refresh_token;
+  }
+
+  /** Remove stored tokens for the user. */
+  async revokeToken(slackUserId: string): Promise<void> {
+    await this.store.deleteTokens(slackUserId);
+    log.logInfo(`OAuth: revoked tokens for Slack user ${slackUserId}`);
+  }
+
+  private cleanupExpiredStates(): void {
+    const now = Date.now();
+    for (const [key, state] of this.pendingStates) {
+      if (now - state.createdAt > STATE_TTL_MS) this.pendingStates.delete(key);
+    }
+  }
+}

--- a/src/oauth/providers/provider.ts
+++ b/src/oauth/providers/provider.ts
@@ -1,0 +1,62 @@
+/**
+ * Generic OAuth Provider Interface
+ * 各平台 OAuth 實現需遵守此接口
+ */
+
+export interface OAuthTokens {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number; // seconds
+  token_type?: string;
+}
+
+export interface OAuthUserInfo {
+  id: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+  [key: string]: unknown;
+}
+
+export interface OAuthProviderConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+export interface OAuthProvider {
+  /** 平台名稱 */
+  readonly name: string;
+  
+  /** OAuth 授權 URL */
+  getAuthorizationUrl(state: string): string;
+  
+  /** 交換授權碼為 Token */
+  exchangeCode(code: string): Promise<OAuthTokens>;
+  
+  /** 刷新 Access Token */
+  refreshToken(refreshToken: string): Promise<OAuthTokens>;
+  
+  /** 取得用戶資訊 */
+  getUserInfo(accessToken: string): Promise<OAuthUserInfo>;
+  
+  /** 取得預設Scopes */
+  getDefaultScopes(): string[];
+}
+
+export interface StoredTokenData {
+  provider: string;
+  access_token: string;
+  refresh_token?: string;
+  expires_at?: number;
+  email?: string;
+  userId?: string;
+  userInfo?: OAuthUserInfo;
+}
+
+export interface PendingAuthState {
+  slackUserId: string;
+  channelId: string;
+  provider: string;
+  createdAt: number;
+}

--- a/src/oauth/secretManager.ts
+++ b/src/oauth/secretManager.ts
@@ -1,0 +1,67 @@
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import type { TokenData } from "./types.js";
+
+const SECRET_PREFIX = "gdc-sandbox-token";
+
+export class SecretManagerStore {
+  private client: SecretManagerServiceClient;
+  private projectId: string;
+
+  constructor(projectId: string) {
+    this.client = new SecretManagerServiceClient();
+    this.projectId = projectId;
+  }
+
+  private secretId(slackUserId: string): string {
+    return `${SECRET_PREFIX}-${slackUserId}`;
+  }
+
+  private secretName(slackUserId: string): string {
+    return `projects/${this.projectId}/secrets/${this.secretId(slackUserId)}`;
+  }
+
+  async storeTokens(slackUserId: string, tokens: TokenData): Promise<void> {
+    const payload = JSON.stringify(tokens);
+    const payloadBuffer = Buffer.from(payload);
+
+    try {
+      // Try to add a new version (secret already exists)
+      await this.client.addSecretVersion({
+        parent: this.secretName(slackUserId),
+        payload: { data: payloadBuffer },
+      });
+    } catch {
+      // Secret doesn't exist yet — create it, then add a version
+      await this.client.createSecret({
+        parent: `projects/${this.projectId}`,
+        secretId: this.secretId(slackUserId),
+        secret: { replication: { automatic: {} } },
+      });
+      await this.client.addSecretVersion({
+        parent: this.secretName(slackUserId),
+        payload: { data: payloadBuffer },
+      });
+    }
+  }
+
+  async getTokens(slackUserId: string): Promise<TokenData | null> {
+    try {
+      const [version] = await this.client.accessSecretVersion({
+        name: `${this.secretName(slackUserId)}/versions/latest`,
+      });
+      const data = version.payload?.data;
+      if (!data) return null;
+      return JSON.parse(data.toString()) as TokenData;
+    } catch {
+      return null;
+    }
+  }
+
+  async deleteTokens(slackUserId: string): Promise<void> {
+    try {
+      await this.client.deleteSecret({ name: this.secretName(slackUserId) });
+    } catch {
+      // Ignore if secret doesn't exist
+    }
+  }
+}

--- a/src/oauth/server.ts
+++ b/src/oauth/server.ts
@@ -1,0 +1,117 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "http";
+import * as log from "../log.js";
+
+export type OAuthCallbackHandler = (
+  code: string,
+  state: string,
+) => Promise<{ success: boolean; email?: string }>;
+
+export type TokenRequestHandler = (slackUserId: string) => Promise<string | null>;
+
+/**
+ * Combined HTTP server that handles:
+ * - GET /oauth/callback  — Google OAuth redirect URI
+ * - GET /api/token/:userId — Internal token endpoint (localhost only)
+ */
+export function startOAuthServer(
+  port: number,
+  onCallback: OAuthCallbackHandler,
+  onTokenRequest: TokenRequestHandler,
+): () => void {
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end("Bad Request");
+      return;
+    }
+
+    const url = new URL(req.url, `http://localhost:${port}`);
+
+    // ── OAuth callback ──────────────────────────────────────────────────────
+    if (url.pathname === "/oauth/callback") {
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+      const error = url.searchParams.get("error");
+
+      if (error) {
+        res.writeHead(400, { "Content-Type": "text/html" });
+        res.end(htmlPage("Authorization Failed", `<p style="color:#c62828">${error}</p>`));
+        return;
+      }
+
+      if (!code || !state) {
+        res.writeHead(400, { "Content-Type": "text/html" });
+        res.end(htmlPage("Bad Request", "<p>Missing code or state parameter.</p>"));
+        return;
+      }
+
+      try {
+        const result = await onCallback(code, state);
+        if (result.success) {
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(
+            htmlPage(
+              "Authorization Successful",
+              `<p style="color:#2e7d32;font-size:1.2em">✓ Authorized as <strong>${result.email ?? "unknown"}</strong></p>
+               <p>You can close this tab and return to Slack.</p>`,
+            ),
+          );
+        } else {
+          res.writeHead(500, { "Content-Type": "text/html" });
+          res.end(htmlPage("Authorization Failed", "<p>An internal error occurred.</p>"));
+        }
+      } catch (err) {
+        log.logWarning("OAuth callback error", String(err));
+        res.writeHead(500, { "Content-Type": "text/html" });
+        res.end(htmlPage("Internal Server Error", "<p>Please try again.</p>"));
+      }
+      return;
+    }
+
+    // ── Token API (localhost only) ───────────────────────────────────────────
+    const tokenMatch = url.pathname.match(/^\/api\/token\/([^/]+)$/);
+    if (tokenMatch) {
+      const remoteAddr = req.socket.remoteAddress;
+      if (remoteAddr !== "127.0.0.1" && remoteAddr !== "::1" && remoteAddr !== "::ffff:127.0.0.1") {
+        res.writeHead(403);
+        res.end("Forbidden");
+        return;
+      }
+
+      const slackUserId = tokenMatch[1];
+      const token = await onTokenRequest(slackUserId);
+      if (token) {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end(token);
+      } else {
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("no_token");
+      }
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("Not Found");
+  });
+
+  server.listen(port, "0.0.0.0", () => {
+    log.logInfo(`OAuth server listening on port ${port}`);
+  });
+
+  return () => server.close();
+}
+
+function htmlPage(title: string, body: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>${title}</title>
+  <style>body{font-family:sans-serif;max-width:600px;margin:60px auto;text-align:center}</style>
+</head>
+<body>
+  <h1>${title}</h1>
+  ${body}
+</body>
+</html>`;
+}

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -1,0 +1,12 @@
+export interface TokenData {
+  refresh_token: string;
+  access_token?: string;
+  expires_at?: number;
+  email?: string;
+}
+
+export interface PendingAuthState {
+  slackUserId: string;
+  channelId: string;
+  createdAt: number;
+}

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -98,6 +98,7 @@ export interface Executor {
 export interface ExecOptions {
   timeout?: number;
   signal?: AbortSignal;
+  env?: Record<string, string>;
 }
 
 export interface ExecResult {
@@ -111,8 +112,9 @@ class HostExecutor implements Executor {
     return new Promise((resolve, reject) => {
       const shell = process.platform === "win32" ? "cmd" : "sh";
       const shellArgs = process.platform === "win32" ? ["/c"] : ["-c"];
+      const commandWithEnv = applyCommandEnv(command, options?.env);
 
-      const child = spawn(shell, [...shellArgs, command], {
+      const child = spawn(shell, [...shellArgs, commandWithEnv], {
         detached: true,
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -190,7 +192,8 @@ class DockerExecutor implements Executor {
 
   async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
     // Wrap command for docker exec
-    const dockerCmd = `docker exec ${this.container} sh -c ${shellEscape(command)}`;
+    const commandWithEnv = applyCommandEnv(command, options?.env);
+    const dockerCmd = `docker exec ${this.container} sh -c ${shellEscape(commandWithEnv)}`;
     const hostExecutor = new HostExecutor();
     return hostExecutor.exec(dockerCmd, options);
   }
@@ -227,4 +230,17 @@ function killProcessTree(pid: number): void {
 function shellEscape(s: string): string {
   // Escape for passing to sh -c
   return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+function applyCommandEnv(command: string, env?: Record<string, string>): string {
+  if (!env || Object.keys(env).length === 0) {
+    return command;
+  }
+
+  const assignments = Object.entries(env)
+    .filter(([key]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
+    .map(([key, value]) => `${key}=${shellEscape(value)}`)
+    .join(" ");
+
+  return assignments ? `${assignments} ${command}` : command;
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -36,7 +36,10 @@ interface BashToolDetails {
   fullOutputPath?: string;
 }
 
-export function createBashTool(executor: Executor): AgentTool<typeof bashSchema> {
+export function createBashTool(
+  executor: Executor,
+  getExecutionEnv?: () => Record<string, string>,
+): AgentTool<typeof bashSchema> {
   return {
     name: "bash",
     label: "bash",
@@ -51,7 +54,11 @@ export function createBashTool(executor: Executor): AgentTool<typeof bashSchema>
       let tempFilePath: string | undefined;
       let tempFileStream: ReturnType<typeof createWriteStream> | undefined;
 
-      const result = await executor.exec(command, { timeout, signal });
+      const result = await executor.exec(command, {
+        timeout,
+        signal,
+        env: getExecutionEnv?.() ?? {},
+      });
       let output = "";
       if (result.stdout) output += result.stdout;
       if (result.stderr) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,7 +6,10 @@ import { createEditTool } from "./edit.js";
 import { createReadTool } from "./read.js";
 import { createWriteTool } from "./write.js";
 
-export function createMamaTools(executor: Executor): {
+export function createMamaTools(
+  executor: Executor,
+  getExecutionEnv?: () => Record<string, string>,
+): {
   tools: AgentTool<any>[];
   setUploadFunction: (fn: (filePath: string, title?: string) => Promise<void>) => void;
 } {
@@ -14,7 +17,7 @@ export function createMamaTools(executor: Executor): {
   return {
     tools: [
       createReadTool(executor),
-      createBashTool(executor),
+      createBashTool(executor, getExecutionEnv),
       createEditTool(executor),
       createWriteTool(executor),
       attachTool,

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,78 @@
+/**
+ * Input sanitization utilities for mama bot
+ * Prevents XSS and ensures safe message handling
+ */
+
+const MAX_MESSAGE_LENGTH = 10000;
+const DANGEROUS_PATTERNS = [/<script/i, /javascript:/i, /on\w+=/i];
+
+/**
+ * Sanitize user input text to prevent XSS and injection attacks
+ */
+export function sanitizeInput(text: string | null | undefined): string {
+  if (!text) return "";
+
+  return text
+    // Remove null bytes
+    .replace(/\0/g, "")
+    // Trim whitespace
+    .trim()
+    // Limit length
+    .slice(0, MAX_MESSAGE_LENGTH);
+}
+
+/**
+ * Check if text contains potentially dangerous patterns
+ */
+export function containsDangerousPatterns(text: string): boolean {
+  return DANGEROUS_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Sanitize file names to prevent path traversal
+ */
+export function sanitizeFileName(fileName: string): string {
+  return fileName
+    .replace(/\.\./g, "_") // Prevent directory traversal
+    .replace(/[/\\:*?"<>|]/g, "_") // Remove invalid characters
+    .slice(0, 255) // Limit length
+    .trim();
+}
+
+/**
+ * Validate session key format
+ * Format: platform:channelId[:threadTs]
+ */
+export function isValidSessionKey(key: string): boolean {
+  if (!key || typeof key !== "string") return false;
+  
+  // Basic format check: must contain platform:channelId
+  const parts = key.split(":");
+  if (parts.length < 2) return false;
+  
+  const [platform, channelId, ...rest] = parts;
+  const validPlatforms = ["slack", "discord", "telegram"];
+  
+  if (!validPlatforms.includes(platform.toLowerCase())) return false;
+  if (!channelId || channelId.length < 1) return false;
+  
+  // If thread timestamp exists, validate format
+  if (rest.length > 0) {
+    const threadTs = rest.join(":");
+    // Slack/Discord timestamps are numeric
+    if (!/^\d+(\.\d+)?$/.test(threadTs)) return false;
+  }
+  
+  return true;
+}
+
+/**
+ * Escape special characters for logging
+ */
+export function escapeForLogging(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}

--- a/test/agent-auth-context.test.ts
+++ b/test/agent-auth-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import type { ChatMessage, PlatformInfo } from "../src/adapter.js";
+import { buildCurrentRequestContext, buildRunEnvironment } from "../src/agent.js";
+import type { SandboxConfig } from "../src/sandbox.js";
+
+function makePlatform(name: PlatformInfo["name"]): PlatformInfo {
+  return {
+    name,
+    formattingGuide: "",
+    channels: [],
+    users: [],
+  };
+}
+
+function makeMessage(): ChatMessage {
+  return {
+    id: "1000.0002",
+    sessionKey: "C001:1000.0001",
+    userId: "U001",
+    userName: "alice",
+    text: "list my instances",
+    threadTs: "1000.0001",
+  };
+}
+
+describe("buildRunEnvironment", () => {
+  test("builds Slack token env for host sandbox", () => {
+    const env = buildRunEnvironment(
+      makePlatform("slack"),
+      makeMessage(),
+      { type: "host" } satisfies SandboxConfig,
+      8080,
+    );
+
+    expect(env).toMatchObject({
+      MAMA_PLATFORM: "slack",
+      MAMA_USER_ID: "U001",
+      MAMA_CHANNEL_ID: "C001",
+      MAMA_THREAD_TS: "1000.0001",
+      MAMA_SLACK_USER_ID: "U001",
+      MAMA_GOOGLE_TOKEN_BASE_URL: "http://127.0.0.1:8080/api/token",
+      MAMA_GOOGLE_ACCESS_TOKEN_URL: "http://127.0.0.1:8080/api/token/U001",
+    });
+  });
+
+  test("uses host.docker.internal for Docker sandbox token endpoint", () => {
+    const env = buildRunEnvironment(
+      makePlatform("slack"),
+      makeMessage(),
+      { type: "docker", container: "mama-sandbox" } satisfies SandboxConfig,
+      8080,
+    );
+
+    expect(env.MAMA_GOOGLE_TOKEN_BASE_URL).toBe("http://host.docker.internal:8080/api/token");
+    expect(env.MAMA_GOOGLE_ACCESS_TOKEN_URL).toBe(
+      "http://host.docker.internal:8080/api/token/U001",
+    );
+  });
+
+  test("does not expose Slack-only token vars on non-Slack platforms", () => {
+    const env = buildRunEnvironment(
+      makePlatform("telegram"),
+      makeMessage(),
+      { type: "host" } satisfies SandboxConfig,
+      8080,
+    );
+
+    expect(env.MAMA_PLATFORM).toBe("telegram");
+    expect(env.MAMA_USER_ID).toBe("U001");
+    expect(env.MAMA_SLACK_USER_ID).toBeUndefined();
+    expect(env.MAMA_GOOGLE_ACCESS_TOKEN_URL).toBeUndefined();
+  });
+});
+
+describe("buildCurrentRequestContext", () => {
+  test("documents Slack auth isolation and execution env", () => {
+    const env = buildRunEnvironment(
+      makePlatform("slack"),
+      makeMessage(),
+      { type: "host" } satisfies SandboxConfig,
+      8080,
+    );
+
+    const context = buildCurrentRequestContext(makePlatform("slack"), makeMessage(), env);
+
+    expect(context).toContain("Use only the requesting Slack user's permissions");
+    expect(context).toContain("MAMA_SLACK_USER_ID=U001");
+    expect(context).toContain("MAMA_GOOGLE_ACCESS_TOKEN_URL=http://127.0.0.1:8080/api/token/U001");
+  });
+});

--- a/test/bash-tool.test.ts
+++ b/test/bash-tool.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from "vitest";
+import type { Executor } from "../src/sandbox.js";
+import { createBashTool } from "../src/tools/bash.js";
+
+describe("createBashTool", () => {
+  test("passes per-run execution env to executor", async () => {
+    const executor: Executor = {
+      exec: vi.fn().mockResolvedValue({ stdout: "ok", stderr: "", code: 0 }),
+      getWorkspacePath: vi.fn().mockReturnValue("/workspace"),
+    };
+
+    const tool = createBashTool(executor, () => ({
+      MAMA_SLACK_USER_ID: "U001",
+      MAMA_GOOGLE_ACCESS_TOKEN_URL: "http://127.0.0.1:8080/api/token/U001",
+    }));
+
+    const result = await tool.execute("tool-1", {
+      label: "Check env injection",
+      command: "echo ok",
+    });
+
+    expect(executor.exec).toHaveBeenCalledWith(
+      "echo ok",
+      expect.objectContaining({
+        env: {
+          MAMA_SLACK_USER_ID: "U001",
+          MAMA_GOOGLE_ACCESS_TOKEN_URL: "http://127.0.0.1:8080/api/token/U001",
+        },
+      }),
+    );
+    expect(result).toEqual({
+      content: [{ type: "text", text: "ok" }],
+      details: undefined,
+    });
+  });
+});

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -1,0 +1,459 @@
+import http from "node:http";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+// ============================================================================
+// Hoisted mocks — defined before vi.mock() calls (vitest hoists vi.mock to top)
+// ============================================================================
+
+const googleMocks = vi.hoisted(() => ({
+  generateAuthUrl: vi.fn(),
+  exchangeCode: vi.fn(),
+  refreshAccessToken: vi.fn(),
+  getUserEmail: vi.fn(),
+}));
+
+// Individual spy functions shared by all SecretManagerServiceClient instances
+const smFns = vi.hoisted(() => ({
+  addSecretVersion: vi.fn(),
+  createSecret: vi.fn(),
+  accessSecretVersion: vi.fn(),
+  deleteSecret: vi.fn(),
+}));
+
+// ── Module stubs ─────────────────────────────────────────────────────────────
+
+vi.mock("../src/oauth/google.js", () => googleMocks);
+
+vi.mock("@google-cloud/secret-manager", () => ({
+  // Must use a regular function (not arrow) so it can be called with `new`
+  SecretManagerServiceClient: vi.fn(function () {
+    return {
+      addSecretVersion: smFns.addSecretVersion,
+      createSecret: smFns.createSecret,
+      accessSecretVersion: smFns.accessSecretVersion,
+      deleteSecret: smFns.deleteSecret,
+    };
+  }),
+}));
+
+// ── Static imports (resolved after mocks are registered) ─────────────────────
+
+import { OAuthManager } from "../src/oauth/manager.js";
+import { SecretManagerStore } from "../src/oauth/secretManager.js";
+import { startOAuthServer } from "../src/oauth/server.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeManager() {
+  return new OAuthManager({
+    clientId: "CLIENT_ID",
+    clientSecret: "CLIENT_SECRET",
+    redirectUri: "https://example.com/oauth/callback",
+    projectId: "test-project",
+  });
+}
+
+function httpGet(port: number, path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get({ hostname: "127.0.0.1", port, path }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.on("error", reject);
+  });
+}
+
+// ============================================================================
+// SecretManagerStore
+// ============================================================================
+
+describe("SecretManagerStore", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("storeTokens: creates secret then adds version when secret does not exist", async () => {
+    // First addSecretVersion throws NOT_FOUND; after createSecret it succeeds
+    smFns.addSecretVersion
+      .mockRejectedValueOnce(Object.assign(new Error("NOT_FOUND"), { code: 5 }))
+      .mockResolvedValueOnce([{}]);
+    smFns.createSecret.mockResolvedValue([{}]);
+
+    const store = new SecretManagerStore("test-project");
+    await store.storeTokens("U001", { refresh_token: "rt1" });
+
+    expect(smFns.createSecret).toHaveBeenCalledOnce();
+    expect(smFns.addSecretVersion).toHaveBeenCalledTimes(2);
+  });
+
+  test("storeTokens: adds version directly when secret already exists", async () => {
+    smFns.addSecretVersion.mockResolvedValue([{}]);
+
+    const store = new SecretManagerStore("test-project");
+    await store.storeTokens("U002", { refresh_token: "rt2" });
+
+    expect(smFns.addSecretVersion).toHaveBeenCalledOnce();
+    expect(smFns.createSecret).not.toHaveBeenCalled();
+  });
+
+  test("storeTokens: passes serialised JSON payload to Secret Manager", async () => {
+    smFns.addSecretVersion.mockResolvedValue([{}]);
+
+    const tokens = { refresh_token: "rt", access_token: "at", email: "a@b.com" };
+    const store = new SecretManagerStore("test-project");
+    await store.storeTokens("U003", tokens);
+
+    const [call] = smFns.addSecretVersion.mock.calls;
+    const payloadStr = (call[0] as { payload: { data: Buffer } }).payload.data.toString();
+    expect(JSON.parse(payloadStr)).toEqual(tokens);
+  });
+
+  test("getTokens: returns parsed TokenData", async () => {
+    const tokens = { refresh_token: "rt3", email: "user@example.com" };
+    smFns.accessSecretVersion.mockResolvedValue([
+      { payload: { data: Buffer.from(JSON.stringify(tokens)) } },
+    ]);
+
+    const store = new SecretManagerStore("test-project");
+    expect(await store.getTokens("U004")).toEqual(tokens);
+  });
+
+  test("getTokens: returns null when secret does not exist", async () => {
+    smFns.accessSecretVersion.mockRejectedValue(
+      Object.assign(new Error("NOT_FOUND"), { code: 5 }),
+    );
+
+    const store = new SecretManagerStore("test-project");
+    expect(await store.getTokens("U_MISSING")).toBeNull();
+  });
+
+  test("deleteTokens: calls deleteSecret with the correct resource name", async () => {
+    smFns.deleteSecret.mockResolvedValue([{}]);
+
+    const store = new SecretManagerStore("test-project");
+    await store.deleteTokens("U005");
+
+    expect(smFns.deleteSecret).toHaveBeenCalledWith({
+      name: "projects/test-project/secrets/gdc-sandbox-token-U005",
+    });
+  });
+
+  test("deleteTokens: silently ignores errors", async () => {
+    smFns.deleteSecret.mockRejectedValue(new Error("already gone"));
+
+    const store = new SecretManagerStore("test-project");
+    await expect(store.deleteTokens("U006")).resolves.toBeUndefined();
+  });
+});
+
+// ============================================================================
+// OAuthManager
+// ============================================================================
+
+describe("OAuthManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default URL generation delegates to google mock
+    googleMocks.generateAuthUrl.mockImplementation(
+      (_cid: string, _uri: string, state: string) =>
+        `https://accounts.google.com/o/oauth2/v2/auth?state=${state}`,
+    );
+  });
+
+  // ── URL generation ──────────────────────────────────────────────────────────
+
+  test("generateAuthUrl: returns a Google auth URL containing the state", () => {
+    const mgr = makeManager();
+    const url = mgr.generateAuthUrl("U001", "C001");
+
+    expect(url).toMatch(/accounts\.google\.com/);
+    expect(url).toMatch(/state=/);
+    expect(googleMocks.generateAuthUrl).toHaveBeenCalledOnce();
+  });
+
+  test("generateAuthUrl: encodes userId into the state so users can be matched later", () => {
+    const mgr = makeManager();
+    const url = mgr.generateAuthUrl("U001", "C001");
+    // Our manager passes a state that starts with the userId
+    const state = new URL(url).searchParams.get("state") ?? "";
+    expect(state.startsWith("U001_")).toBe(true);
+  });
+
+  test("generateAuthUrl: generates unique states for concurrent requests", () => {
+    const mgr = makeManager();
+    const url1 = mgr.generateAuthUrl("U001", "C001");
+    const url2 = mgr.generateAuthUrl("U001", "C001");
+    const s1 = new URL(url1).searchParams.get("state");
+    const s2 = new URL(url2).searchParams.get("state");
+    expect(s1).not.toBe(s2);
+  });
+
+  // ── Callback handling ───────────────────────────────────────────────────────
+
+  test("handleCallback: returns null for an unknown state", async () => {
+    const mgr = makeManager();
+    expect(await mgr.handleCallback("code", "UNKNOWN_STATE")).toBeNull();
+  });
+
+  test("handleCallback: returns null for an expired state (> 10 minutes)", async () => {
+    vi.useFakeTimers();
+    const mgr = makeManager();
+    const url = mgr.generateAuthUrl("U001", "C001");
+    const state = new URL(url).searchParams.get("state") ?? "";
+
+    vi.advanceTimersByTime(11 * 60 * 1000);
+
+    expect(await mgr.handleCallback("code", state)).toBeNull();
+    vi.useRealTimers();
+  });
+
+  test("handleCallback: exchanges code, persists tokens, returns user info", async () => {
+    googleMocks.exchangeCode.mockResolvedValue({
+      access_token: "access_tok",
+      refresh_token: "refresh_tok",
+      expires_in: 3600,
+    });
+    googleMocks.getUserEmail.mockResolvedValue("alice@example.com");
+    smFns.addSecretVersion.mockResolvedValue([{}]);
+
+    const mgr = makeManager();
+    const url = mgr.generateAuthUrl("U001", "C001");
+    const state = new URL(url).searchParams.get("state") ?? "";
+
+    const result = await mgr.handleCallback("auth_code", state);
+
+    expect(result).toEqual({ slackUserId: "U001", channelId: "C001", email: "alice@example.com" });
+    expect(googleMocks.exchangeCode).toHaveBeenCalledWith(
+      "CLIENT_ID",
+      "CLIENT_SECRET",
+      "https://example.com/oauth/callback",
+      "auth_code",
+    );
+    expect(smFns.addSecretVersion).toHaveBeenCalledOnce();
+  });
+
+  test("handleCallback: falls back to '(unknown)' email when getUserEmail fails", async () => {
+    googleMocks.exchangeCode.mockResolvedValue({
+      access_token: "at",
+      refresh_token: "rt",
+      expires_in: 3600,
+    });
+    googleMocks.getUserEmail.mockRejectedValue(new Error("network error"));
+    smFns.addSecretVersion.mockResolvedValue([{}]);
+
+    const mgr = makeManager();
+    const url = mgr.generateAuthUrl("U001", "C001");
+    const state = new URL(url).searchParams.get("state") ?? "";
+
+    const result = await mgr.handleCallback("code", state);
+    expect(result?.email).toBe("(unknown)");
+  });
+
+  test("handleCallback: returns null when exchangeCode throws", async () => {
+    googleMocks.exchangeCode.mockRejectedValue(new Error("invalid_grant"));
+
+    const mgr = makeManager();
+    const url = mgr.generateAuthUrl("U001", "C001");
+    const state = new URL(url).searchParams.get("state") ?? "";
+
+    expect(await mgr.handleCallback("bad_code", state)).toBeNull();
+  });
+
+  test("handleCallback: state is one-time-use and cannot be replayed", async () => {
+    googleMocks.exchangeCode.mockResolvedValue({
+      access_token: "at",
+      refresh_token: "rt",
+      expires_in: 3600,
+    });
+    googleMocks.getUserEmail.mockResolvedValue("u@e.com");
+    smFns.addSecretVersion.mockResolvedValue([{}]);
+
+    const mgr = makeManager();
+    const url = mgr.generateAuthUrl("U001", "C001");
+    const state = new URL(url).searchParams.get("state") ?? "";
+
+    await mgr.handleCallback("code", state);
+    expect(await mgr.handleCallback("code", state)).toBeNull();
+  });
+
+  // ── Token retrieval ─────────────────────────────────────────────────────────
+
+  test("getAccessToken: returns null when user has no stored token", async () => {
+    smFns.accessSecretVersion.mockRejectedValue(
+      Object.assign(new Error("NOT_FOUND"), { code: 5 }),
+    );
+
+    expect(await makeManager().getAccessToken("U_NONE")).toBeNull();
+  });
+
+  test("getAccessToken: returns cached token when it has not yet expired", async () => {
+    const stored = {
+      refresh_token: "rt",
+      access_token: "still_valid",
+      expires_at: Date.now() + 60 * 60 * 1000,
+    };
+    smFns.accessSecretVersion.mockResolvedValue([
+      { payload: { data: Buffer.from(JSON.stringify(stored)) } },
+    ]);
+
+    expect(await makeManager().getAccessToken("U001")).toBe("still_valid");
+    expect(googleMocks.refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  test("getAccessToken: auto-refreshes an expired token and persists the new one", async () => {
+    const stored = {
+      refresh_token: "rt_old",
+      access_token: "expired",
+      expires_at: Date.now() - 1000,
+    };
+    smFns.accessSecretVersion.mockResolvedValue([
+      { payload: { data: Buffer.from(JSON.stringify(stored)) } },
+    ]);
+    googleMocks.refreshAccessToken.mockResolvedValue({
+      access_token: "new_token",
+      expires_in: 3600,
+    });
+    smFns.addSecretVersion.mockResolvedValue([{}]);
+
+    const token = await makeManager().getAccessToken("U001");
+
+    expect(token).toBe("new_token");
+    expect(googleMocks.refreshAccessToken).toHaveBeenCalledWith(
+      "CLIENT_ID",
+      "CLIENT_SECRET",
+      "rt_old",
+    );
+    // Updated token should be persisted
+    expect(smFns.addSecretVersion).toHaveBeenCalledOnce();
+  });
+
+  test("getAccessToken: returns null when the refresh request fails", async () => {
+    const stored = { refresh_token: "rt", access_token: "expired", expires_at: Date.now() - 1 };
+    smFns.accessSecretVersion.mockResolvedValue([
+      { payload: { data: Buffer.from(JSON.stringify(stored)) } },
+    ]);
+    googleMocks.refreshAccessToken.mockRejectedValue(new Error("token_revoked"));
+
+    expect(await makeManager().getAccessToken("U001")).toBeNull();
+  });
+
+  // ── hasToken ────────────────────────────────────────────────────────────────
+
+  test("hasToken: returns false when no token is stored", async () => {
+    smFns.accessSecretVersion.mockRejectedValue(new Error("NOT_FOUND"));
+    expect(await makeManager().hasToken("U_NONE")).toBe(false);
+  });
+
+  test("hasToken: returns true when a refresh_token is stored", async () => {
+    smFns.accessSecretVersion.mockResolvedValue([
+      { payload: { data: Buffer.from(JSON.stringify({ refresh_token: "rt" })) } },
+    ]);
+    expect(await makeManager().hasToken("U001")).toBe(true);
+  });
+
+  // ── revokeToken ─────────────────────────────────────────────────────────────
+
+  test("revokeToken: deletes the secret for the given user", async () => {
+    smFns.deleteSecret.mockResolvedValue([{}]);
+
+    await makeManager().revokeToken("U001");
+
+    expect(smFns.deleteSecret).toHaveBeenCalledWith({
+      name: "projects/test-project/secrets/gdc-sandbox-token-U001",
+    });
+  });
+});
+
+// ============================================================================
+// OAuth HTTP server
+// ============================================================================
+
+describe("OAuth server", () => {
+  const PORT = 19877;
+  let stopServer: () => void;
+
+  const onCallback = vi.fn<[string, string], Promise<{ success: boolean; email?: string }>>();
+  const onTokenRequest = vi.fn<[string], Promise<string | null>>();
+
+  beforeAll(() => {
+    stopServer = startOAuthServer(PORT, onCallback, onTokenRequest);
+  });
+
+  afterAll(() => stopServer());
+
+  beforeEach(() => {
+    onCallback.mockReset();
+    onTokenRequest.mockReset();
+  });
+
+  // ── /oauth/callback ─────────────────────────────────────────────────────────
+
+  test("returns 200 success HTML on a valid callback", async () => {
+    onCallback.mockResolvedValue({ success: true, email: "alice@example.com" });
+
+    const { status, body } = await httpGet(PORT, "/oauth/callback?code=CODE&state=STATE");
+
+    expect(status).toBe(200);
+    expect(body).toContain("Authorization Successful");
+    expect(body).toContain("alice@example.com");
+    expect(onCallback).toHaveBeenCalledWith("CODE", "STATE");
+  });
+
+  test("returns 500 when the callback handler signals failure", async () => {
+    onCallback.mockResolvedValue({ success: false });
+
+    const { status, body } = await httpGet(PORT, "/oauth/callback?code=CODE&state=STATE");
+
+    expect(status).toBe(500);
+    expect(body).toContain("Authorization Failed");
+  });
+
+  test("returns 400 when Google sends an error param (e.g. access_denied)", async () => {
+    const { status, body } = await httpGet(PORT, "/oauth/callback?error=access_denied");
+
+    expect(status).toBe(400);
+    expect(body).toContain("access_denied");
+    expect(onCallback).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when code or state is missing from the query", async () => {
+    const { status } = await httpGet(PORT, "/oauth/callback?code=ONLY_CODE");
+    expect(status).toBe(400);
+  });
+
+  test("returns 500 when the callback handler throws", async () => {
+    onCallback.mockRejectedValue(new Error("storage error"));
+
+    const { status } = await httpGet(PORT, "/oauth/callback?code=C&state=S");
+    expect(status).toBe(500);
+  });
+
+  // ── /api/token/:userId ──────────────────────────────────────────────────────
+
+  test("returns 200 with the access token for a valid user", async () => {
+    onTokenRequest.mockResolvedValue("ya29.ACCESS_TOKEN");
+
+    const { status, body } = await httpGet(PORT, "/api/token/U001");
+
+    expect(status).toBe(200);
+    expect(body).toBe("ya29.ACCESS_TOKEN");
+    expect(onTokenRequest).toHaveBeenCalledWith("U001");
+  });
+
+  test("returns 404 'no_token' when the user has no stored token", async () => {
+    onTokenRequest.mockResolvedValue(null);
+
+    const { status, body } = await httpGet(PORT, "/api/token/U_NONE");
+
+    expect(status).toBe(404);
+    expect(body).toBe("no_token");
+  });
+
+  // ── Other paths ─────────────────────────────────────────────────────────────
+
+  test("returns 404 for unrecognised paths", async () => {
+    const { status } = await httpGet(PORT, "/healthz");
+    expect(status).toBe(404);
+  });
+});

--- a/test/rateLimit.test.ts
+++ b/test/rateLimit.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  checkRateLimit,
+  checkIpRateLimit,
+  getRateLimitStatus,
+  resetRateLimit,
+  getRateLimitStats,
+  createRateLimitMiddleware,
+} from "../src/middleware/rateLimit.js";
+
+// Use unique identifiers for each test to avoid interference
+let testCounter = 0;
+
+function getUniqueUserId() {
+  return `test-user-${Date.now()}-${++testCounter}`;
+}
+
+function getUniqueIP() {
+  return `192.168.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 256)}`;
+}
+
+describe("checkRateLimit", () => {
+  const userId = getUniqueUserId();
+
+  beforeEach(() => {
+    resetRateLimit(userId);
+  });
+
+  it("should allow requests under limit", () => {
+    const result = checkRateLimit(userId, { maxRequests: 10, windowMs: 60000 });
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(9);
+  });
+
+  it("should track remaining requests", () => {
+    const config = { maxRequests: 5, windowMs: 60000 };
+
+    const r1 = checkRateLimit(userId, config);
+    const r2 = checkRateLimit(userId, config);
+    const r3 = checkRateLimit(userId, config);
+
+    expect(r1.remaining).toBe(4);
+    expect(r2.remaining).toBe(3);
+    expect(r3.remaining).toBe(2);
+  });
+
+  it("should block requests over limit", () => {
+    const config = { maxRequests: 3, windowMs: 60000 };
+
+    checkRateLimit(userId, config);
+    checkRateLimit(userId, config);
+    checkRateLimit(userId, config);
+    const result = checkRateLimit(userId, config);
+
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+
+  it("should reset after window expires", async () => {
+    const config = { maxRequests: 2, windowMs: 100 };
+
+    checkRateLimit(userId, config);
+    checkRateLimit(userId, config);
+    expect(checkRateLimit(userId, config).allowed).toBe(false);
+
+    // Wait for window to expire
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const result = checkRateLimit(userId, config);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(1);
+  });
+
+  it("should block immediately in strict mode", () => {
+    const config = { maxRequests: 2, windowMs: 60000, strictMode: true };
+
+    checkRateLimit(userId, config);
+    checkRateLimit(userId, config);
+    checkRateLimit(userId, config);
+
+    // Should remain blocked even after waiting
+    expect(checkRateLimit(userId, config).allowed).toBe(false);
+  });
+
+  it("should include resetAt timestamp", () => {
+    const before = Date.now();
+    const result = checkRateLimit(userId, { maxRequests: 10, windowMs: 60000 });
+    const after = Date.now();
+
+    expect(result.resetAt).toBeGreaterThanOrEqual(before + 60000);
+    expect(result.resetAt).toBeLessThanOrEqual(after + 60000);
+  });
+});
+
+describe("checkIpRateLimit", () => {
+  const ip = getUniqueIP();
+
+  beforeEach(() => {
+    // Reset is done by identifier in rateLimitStore
+    // We need to use a new IP for each test
+  });
+
+  it("should limit requests by IP", () => {
+    const config = { maxRequests: 5, windowMs: 60000 };
+
+    const ip1 = getUniqueIP();
+    const ip2 = getUniqueIP();
+
+    // ip1 makes 5 requests
+    for (let i = 0; i < 5; i++) {
+      expect(checkIpRateLimit(ip1, config).allowed).toBe(true);
+    }
+
+    // ip2 should still be allowed
+    expect(checkIpRateLimit(ip2, config).allowed).toBe(true);
+
+    // ip1 should be blocked
+    expect(checkIpRateLimit(ip1, config).allowed).toBe(false);
+  });
+
+  it("should track IPs independently", () => {
+    const config = { maxRequests: 3, windowMs: 60000 };
+
+    const ipA = getUniqueIP();
+    const ipB = getUniqueIP();
+
+    for (let i = 0; i < 3; i++) {
+      checkIpRateLimit(ipA, config);
+    }
+
+    const result = checkIpRateLimit(ipB, config);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(2);
+  });
+});
+
+describe("getRateLimitStatus", () => {
+  it("should return undefined for unknown identifier", () => {
+    expect(getRateLimitStatus("non-existent-id")).toBeUndefined();
+  });
+
+  it("should return current status after requests", () => {
+    const userId = getUniqueUserId();
+    const config = { maxRequests: 10, windowMs: 60000 };
+
+    checkRateLimit(userId, config);
+    checkRateLimit(userId, config);
+
+    const status = getRateLimitStatus(userId);
+    expect(status).toBeDefined();
+    expect(status!.count).toBe(2);
+    expect(status!.blocked).toBe(false);
+  });
+});
+
+describe("resetRateLimit", () => {
+  it("should clear rate limit for identifier", () => {
+    const userId = getUniqueUserId();
+    const config = { maxRequests: 2, windowMs: 60000 };
+
+    checkRateLimit(userId, config);
+    checkRateLimit(userId, config);
+
+    resetRateLimit(userId);
+
+    const result = checkRateLimit(userId, config);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(1);
+  });
+});
+
+describe("getRateLimitStats", () => {
+  it("should return zero for empty store", () => {
+    const stats = getRateLimitStats();
+    expect(stats.activeUsers).toBeGreaterThanOrEqual(0);
+    expect(stats.activeIPs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should track active users", () => {
+    const user1 = getUniqueUserId();
+    const user2 = getUniqueUserId();
+
+    checkRateLimit(user1, { maxRequests: 10, windowMs: 60000 });
+    checkRateLimit(user2, { maxRequests: 10, windowMs: 60000 });
+
+    const stats = getRateLimitStats();
+    expect(stats.activeUsers).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("createRateLimitMiddleware", () => {
+  it("should create middleware function", () => {
+    const middleware = createRateLimitMiddleware({ maxRequests: 10, windowMs: 60000 });
+    expect(typeof middleware).toBe("function");
+  });
+
+  it("should call next() when allowed", () => {
+    const middleware = createRateLimitMiddleware({ maxRequests: 10, windowMs: 60000 });
+    let called = false;
+
+    const req = { ip: getUniqueIP() };
+    const res = {
+      status: (code: number) => {
+        expect(code).toBe(429);
+        return { json: () => {} };
+      },
+      setHeader: () => {},
+    };
+
+    middleware(req as any, res as any, () => {
+      called = true;
+    });
+
+    expect(called).toBe(true);
+  });
+
+  it("should set rate limit headers", () => {
+    const middleware = createRateLimitMiddleware({ maxRequests: 100, windowMs: 60000 });
+    const headers: Record<string, string> = {};
+
+    const req = { ip: getUniqueIP() };
+    const res = {
+      status: () => ({ json: () => {} }),
+      setHeader: (name: string, value: string) => {
+        headers[name] = value;
+      },
+    };
+
+    middleware(req as any, res as any, () => {});
+
+    expect(headers["X-RateLimit-Limit"]).toBe(100);
+    expect(headers["X-RateLimit-Remaining"]).toBeDefined();
+    expect(headers["X-RateLimit-Reset"]).toBeDefined();
+  });
+
+  it("should return 429 when rate limited", () => {
+    const ip = getUniqueIP();
+    const config = { maxRequests: 2, windowMs: 60000 };
+
+    // Exhaust the limit
+    checkIpRateLimit(ip, config);
+    checkIpRateLimit(ip, config);
+
+    const middleware = createRateLimitMiddleware(config);
+    let statusCode = 0;
+
+    const req = { ip };
+    const res = {
+      status: (code: number) => {
+        statusCode = code;
+        return { json: () => {} };
+      },
+      setHeader: () => {},
+    };
+
+    middleware(req as any, res as any, () => {
+      throw new Error("next() should not be called");
+    });
+
+    expect(statusCode).toBe(429);
+  });
+});

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeInput,
+  containsDangerousPatterns,
+  sanitizeFileName,
+  isValidSessionKey,
+  escapeForLogging,
+} from "../src/utils/sanitize.js";
+
+describe("sanitizeInput", () => {
+  it("should return empty string for null input", () => {
+    expect(sanitizeInput(null)).toBe("");
+    expect(sanitizeInput(undefined)).toBe("");
+  });
+
+  it("should trim whitespace", () => {
+    expect(sanitizeInput("  hello  ")).toBe("hello");
+    expect(sanitizeInput("\n\ttest\n")).toBe("test");
+  });
+
+  it("should remove null bytes", () => {
+    expect(sanitizeInput("hel\x00lo")).toBe("hello");
+  });
+
+  it("should limit message length to 10000 characters", () => {
+    const longText = "a".repeat(15000);
+    expect(sanitizeInput(longText).length).toBe(10000);
+  });
+
+  it("should preserve normal text", () => {
+    expect(sanitizeInput("Hello, World!")).toBe("Hello, World!");
+    expect(sanitizeInput("中文測試")).toBe("中文測試");
+  });
+});
+
+describe("containsDangerousPatterns", () => {
+  it("should detect script tags", () => {
+    expect(containsDangerousPatterns("<script>alert(1)</script>")).toBe(true);
+    expect(containsDangerousPatterns("<SCRIPT>alert(1)</SCRIPT>")).toBe(true);
+  });
+
+  it("should detect javascript: protocol", () => {
+    expect(containsDangerousPatterns("javascript:void(0)")).toBe(true);
+    expect(containsDangerousPatterns("JAVASCRIPT:alert(1)")).toBe(true);
+  });
+
+  it("should detect inline event handlers", () => {
+    expect(containsDangerousPatterns('<img onerror="alert(1)">')).toBe(true);
+    expect(containsDangerousPatterns("onclick=alert(1)")).toBe(true);
+    expect(containsDangerousPatterns("onmouseover=alert(1)")).toBe(true);
+  });
+
+  it("should return false for safe text", () => {
+    expect(containsDangerousPatterns("Hello, World!")).toBe(false);
+    expect(containsDangerousPatterns("This is a normal message")).toBe(false);
+    expect(containsDangerousPatterns("中文內容")).toBe(false);
+  });
+});
+
+describe("sanitizeFileName", () => {
+  it("should prevent directory traversal", () => {
+    // Each dot in ".." is replaced, so "../" becomes "__"
+    expect(sanitizeFileName("../etc/passwd")).toBe("__etc_passwd");
+    expect(sanitizeFileName("..\\windows\\system32")).toBe("__windows_system32");
+  });
+
+  it("should replace invalid characters", () => {
+    expect(sanitizeFileName("file:name.txt")).toBe("file_name.txt");
+    // Multiple special characters each get replaced
+    expect(sanitizeFileName('file*name?"|.txt')).toBe("file_name___.txt");
+  });
+
+  it("should limit filename length", () => {
+    const longName = "a".repeat(300) + ".txt";
+    expect(sanitizeFileName(longName).length).toBe(255);
+  });
+
+  it("should preserve valid filenames", () => {
+    expect(sanitizeFileName("document.pdf")).toBe("document.pdf");
+    expect(sanitizeFileName("my-image_2024.png")).toBe("my-image_2024.png");
+  });
+});
+
+describe("isValidSessionKey", () => {
+  it("should validate Slack session keys", () => {
+    expect(isValidSessionKey("slack:C0123456789")).toBe(true);
+    expect(isValidSessionKey("slack:C0123456789:1234567890.123456")).toBe(true);
+  });
+
+  it("should validate Discord session keys", () => {
+    expect(isValidSessionKey("discord:123456789012345678")).toBe(true);
+    expect(isValidSessionKey("discord:123456789012345678:9876543210.123")).toBe(true);
+  });
+
+  it("should validate Telegram session keys", () => {
+    expect(isValidSessionKey("telegram:-1001234567890")).toBe(true);
+  });
+
+  it("should reject invalid platform", () => {
+    expect(isValidSessionKey("invalid:channel")).toBe(false);
+    expect(isValidSessionKey("unknown:123")).toBe(false);
+  });
+
+  it("should reject malformed keys", () => {
+    expect(isValidSessionKey("slack")).toBe(false);
+    expect(isValidSessionKey("slack:")).toBe(false);
+    expect(isValidSessionKey("")).toBe(false);
+    expect(isValidSessionKey(null as any)).toBe(false);
+  });
+
+  it("should reject invalid thread timestamp format", () => {
+    expect(isValidSessionKey("slack:C0123456789:invalid")).toBe(false);
+    expect(isValidSessionKey("slack:C0123456789:abc.def")).toBe(false);
+  });
+});
+
+describe("escapeForLogging", () => {
+  it("should escape backslashes", () => {
+    expect(escapeForLogging("path\\to\\file")).toBe("path\\\\to\\\\file");
+  });
+
+  it("should escape newlines", () => {
+    expect(escapeForLogging("line1\nline2")).toBe("line1\\nline2");
+  });
+
+  it("should escape carriage returns", () => {
+    expect(escapeForLogging("line1\rline2")).toBe("line1\\rline2");
+  });
+
+  it("should escape tabs", () => {
+    expect(escapeForLogging("col1\tcol2")).toBe("col1\\tcol2");
+  });
+
+  it("should handle empty string", () => {
+    expect(escapeForLogging("")).toBe("");
+  });
+});


### PR DESCRIPTION
Enables each Slack user to authorize their own Google account once,
after which the agent can use their identity for GDC Sandbox operations.

Changes:
- src/oauth/types.ts       — TokenData + PendingAuthState interfaces
- src/oauth/google.ts      — generateAuthUrl, exchangeCode, refreshAccessToken, getUserEmail
- src/oauth/secretManager.ts — GCP Secret Manager CRUD (gdc-sandbox-token-{userId})
- src/oauth/server.ts      — HTTP server: GET /oauth/callback + GET /api/token/:userId
- src/oauth/manager.ts     — OAuthManager: URL generation, callback handling, auto-refresh
- src/oauth/index.ts       — barrel exports
- src/adapters/slack/bot.ts — accept oauthManager, handle `auth` / `revoke` commands
- src/main.ts              — initialise OAuthManager + OAuth server when env vars present
- package.json             — add @google-cloud/secret-manager dependency

Required env vars (all optional; set all four to enable):
  GOOGLE_OAUTH_CLIENT_ID
  GOOGLE_OAUTH_CLIENT_SECRET
  GOOGLE_OAUTH_REDIRECT_URI   (public URL pointing to /oauth/callback)
  GOOGLE_CLOUD_PROJECT
  GOOGLE_OAUTH_PORT           (default: 8080)

User workflow:
  1. User sends `auth` (DM or @mention) → bot replies with consent URL
  2. User clicks → authorizes → callback stores refresh token in Secret Manager
  3. Agent can call GET http://localhost:PORT/api/token/{slackUserId} to get a
     fresh access token and inject it as CLOUDSDK_AUTH_ACCESS_TOKEN for gdcloud

https://claude.ai/code/session_013kxJDkDbDZckUdDWAyvSdE