### PR TITLE
Fix: Telegram attachment handling for agent image inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 dist/
 data/
+bin/
+
 *.env
 .env*
+

--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -54,6 +54,7 @@ class ChannelQueue {
 export class TelegramBot implements Bot {
   private client: GrammyBot;
   private handler: BotHandler;
+  private botToken: string;
   private workingDir: string;
   private botUserId: string | null = null;
   private botUsername: string | null = null;
@@ -62,6 +63,7 @@ export class TelegramBot implements Bot {
 
   constructor(handler: BotHandler, config: { token: string; workingDir: string }) {
     this.handler = handler;
+    this.botToken = config.token;
     this.workingDir = config.workingDir;
     this.client = new GrammyBot(config.token);
     this.client.catch((err) => {
@@ -184,11 +186,14 @@ export class TelegramBot implements Bot {
 
   /**
    * Process attachments from a Telegram message
-   * Downloads files in background and returns metadata
+   * Downloads files before returning metadata so the agent can read them immediately
    * Returns format compatible with ChatMessage: { name: string, localPath: string }[]
    */
-  processAttachments(chatId: string, message: any): { name: string; localPath: string }[] {
-    const result: { name: string; localPath: string }[] = [];
+  async processAttachments(
+    chatId: string,
+    message: any,
+  ): Promise<{ name: string; localPath: string }[]> {
+    const downloads: Array<Promise<{ name: string; localPath: string } | null>> = [];
 
     // Handle photos (take the largest size for best quality)
     if (message.photo && message.photo.length > 0) {
@@ -196,13 +201,7 @@ export class TelegramBot implements Bot {
       const photo = photos[photos.length - 1]; // Largest photo
       const fileId = photo.file_id;
 
-      this.processTelegramFile(chatId, fileId, `photo_${message.message_id}.jpg`)
-        .then((attachment) => {
-          if (attachment) result.push(attachment);
-        })
-        .catch((err) => {
-          log.logWarning(`Failed to download Telegram photo`, `${err}`);
-        });
+      downloads.push(this.processTelegramFile(chatId, fileId, `photo_${message.message_id}.jpg`));
     }
 
     // Handle documents
@@ -211,16 +210,13 @@ export class TelegramBot implements Bot {
       const fileId = doc.file_id;
       const fileName = doc.file_name ?? `document_${message.message_id}`;
 
-      this.processTelegramFile(chatId, fileId, fileName)
-        .then((attachment) => {
-          if (attachment) result.push(attachment);
-        })
-        .catch((err) => {
-          log.logWarning(`Failed to download Telegram document`, `${err}`);
-        });
+      downloads.push(this.processTelegramFile(chatId, fileId, fileName));
     }
 
-    return result;
+    const attachments = await Promise.all(downloads);
+    return attachments.filter(
+      (attachment): attachment is { name: string; localPath: string } => attachment !== null,
+    );
   }
 
   /**
@@ -249,7 +245,7 @@ export class TelegramBot implements Bot {
       if (!existsSync(fullDir)) mkdirSync(fullDir, { recursive: true });
 
       // Construct download URL
-      const downloadUrl = `https://api.telegram.org/file/bot${this.botUserId}/${file.file_path}`;
+      const downloadUrl = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
 
       // Download the file
       const response = await fetch(downloadUrl);
@@ -295,7 +291,7 @@ export class TelegramBot implements Bot {
   }
 
   private setupEventHandlers(): void {
-    this.client.on("message", (ctx) => {
+    this.client.on("message", async (ctx) => {
       const msg = ctx.message;
 
       // Skip messages from before startup (Telegram replays recent messages on poll start)
@@ -323,7 +319,7 @@ export class TelegramBot implements Bot {
       const sessionKey = `${chatId}:${threadTs ?? msgId}`;
 
       // Process attachments (starts download in background)
-      const processedAttachments = this.processAttachments(chatId, msg);
+      const processedAttachments = await this.processAttachments(chatId, msg);
 
       const event: TelegramEvent = {
         type: "message",

--- a/test/issue-verification.test.ts
+++ b/test/issue-verification.test.ts
@@ -3,89 +3,7 @@ import { appendFileSync, mkdirSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 
 // ============================================================================
-// Test 1: Verify Discord/Telegram attachments are NOT captured
-// ============================================================================
-
-describe("ISSUE VERIFICATION: Discord attachments not captured", () => {
-  test("Discord bot logs messages with empty attachments array", () => {
-    // This test verifies the bug: Discord messages with attachments
-    // are logged with attachments: [] (empty array)
-
-    // Looking at the source code (src/adapters/discord/bot.ts:315):
-    // this.logToFile(channelId, {
-    //   ...
-    //   attachments: [],  // <-- HARDCODED EMPTY!
-    //   isBot: false,
-    // });
-
-    // The msg object from Discord has:
-    // - msg.attachments (AttachmentManager)
-    // - msg.embeds (Collection<Embed>)
-    // But they are NEVER captured!
-
-    // This is the PROOF that attachments are not processed:
-    const discordLogEntry = {
-      date: new Date().toISOString(),
-      ts: "1234567890.123456",
-      user: "U123",
-      userName: "testuser",
-      text: "Check out this image",
-      attachments: [], // <-- ALWAYS EMPTY in current implementation!
-      isBot: false,
-    };
-
-    expect(discordLogEntry.attachments).toEqual([]);
-    // The bug: attachments should contain actual attachment data from msg.attachments
-  });
-});
-
-describe("ISSUE VERIFICATION: Telegram attachments not captured", () => {
-  test("Telegram bot logs messages with empty attachments array", () => {
-    // Looking at the source code (src/adapters/telegram/bot.ts:254):
-    // this.logToFile(chatId, {
-    //   ...
-    //   attachments: [],  // <-- HARDCODED EMPTY!
-    //   isBot: false,
-    // });
-
-    // The msg object from Telegram has:
-    // - msg.photo (Photo[] | undefined)
-    // - msg.document (Document | undefined)
-    // - msg.sticker (Sticker | undefined)
-    // But they are NEVER captured!
-
-    const telegramLogEntry = {
-      date: new Date().toISOString(),
-      ts: "123",
-      user: "123456789",
-      userName: "testuser",
-      text: "Check out this photo",
-      attachments: [], // <-- ALWAYS EMPTY in current implementation!
-      isBot: false,
-    };
-
-    expect(telegramLogEntry.attachments).toEqual([]);
-  });
-
-  test("Telegram detects documents/photos but doesn't process them", () => {
-    // Looking at telegram/bot.ts:219:
-    // if (!text && !msg.document && !msg.photo) return;
-
-    // The code checks for document/photo EXISTENCE but never stores them!
-    // This is the bug - detection without processing.
-
-    const hasDocument = true; // msg.document exists
-    const hasPhoto = true; // msg.photo exists
-    const attachments = []; // But it's never captured
-
-    // The message would trigger processing but attachments would be lost
-    expect(hasDocument || hasPhoto).toBe(true);
-    expect(attachments).toEqual([]);
-  });
-});
-
-// ============================================================================
-// Test 2: Verify grep CAN search log.jsonl for historical records
+// Verify grep CAN search log.jsonl for historical records
 // ============================================================================
 
 describe("ISSUE VERIFICATION: Grep can search historical records", () => {
@@ -213,17 +131,17 @@ describe("ISSUE VERIFICATION: Grep can search historical records", () => {
     }
   });
 
-  test("syncLogToSessionManager uses 2-day window (default)", async () => {
+  test("syncLogToSessionManager uses 10-day window (default)", async () => {
     // This verifies the default behavior
-    // 2 days ago from now would filter out January messages
+    // 10 days ago from now would filter out January messages
 
     const now = Date.now();
-    const twoDaysAgo = now - 2 * 24 * 60 * 60 * 1000;
+    const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
 
-    // Messages from January 2025 would be older than 2 days
+    // Messages from January 2025 would be older than 10 days
     const januaryDate = new Date("2025-01-01").getTime();
 
-    expect(januaryDate).toBeLessThan(twoDaysAgo);
+    expect(januaryDate).toBeLessThan(tenDaysAgo);
     // So they would be EXCLUDED from sync by default!
   });
 
@@ -231,14 +149,14 @@ describe("ISSUE VERIFICATION: Grep can search historical records", () => {
     const { execSync } = await import("child_process");
 
     // This proves that older messages ARE in the log
-    // but would NOT be included in the 2-day sync window
+    // but would NOT be included in the 10-day sync window
 
     // All 5 messages exist
     const allResult = execSync(`wc -l ${join(testDir, "log.jsonl")}`, { encoding: "utf-8" });
     expect(allResult).toContain("5");
 
     // But January messages would be filtered out by syncLogToSessionManager
-    // because they are more than 2 days old
+    // because they are more than 10 days old
     const januaryCount = execSync(`grep '"date":"2025-01' ${join(testDir, "log.jsonl")} | wc -l`, {
       encoding: "utf-8",
     });
@@ -246,47 +164,8 @@ describe("ISSUE VERIFICATION: Grep can search historical records", () => {
 
     // This demonstrates the DESIGNED behavior:
     // - grep CAN find all historical messages
-    // - But auto-sync only gets last 2 days
+    // - But auto-sync only gets the recent default window
   });
 });
 
-// ============================================================================
-// Summary: Issue Verification Results
-// ============================================================================
-
-/*
-ISSUE 1: Discord/Telegram attachments NOT captured
-----------------------------------------------------
-VERIFIED (Before fix): Both Discord and Telegram adapters hardcoded `attachments: []`
-when logging messages. The code detected attachments but never stored them.
-
-Code locations (BEFORE):
-- src/adapters/discord/bot.ts:315 (old line)
-- src/adapters/telegram/bot.ts:254 (old line)
-
-IMPACT: Users sharing images/files on Discord/Telegram were NOT seen by the AI.
-
-FIXED: Both adapters now:
-1. Extract attachments from incoming messages
-2. Download files asynchronously in background
-3. Store attachment metadata (name, localPath) in log.jsonl
-4. Pass attachments to the AI context
-
-Code locations (AFTER):
-- src/adapters/discord/bot.ts: processAttachments() method
-- src/adapters/telegram/bot.ts: processAttachments() method
-
-ISSUE 2: Grep CAN search historical records
---------------------------------------------
-VERIFIED: The log.jsonl file contains ALL messages, and grep can search them.
-However, syncLogToSessionManager only syncs the last 2 days by default.
-
-Code location: src/context.ts:38 (DEFAULT_SYNC_DAYS = 2)
-
-Impact:
-- Grep CAN find older messages (manual search works)
-- But AI won't see them automatically in context
-- AI must be explicitly told to use grep (via system prompt examples)
-
-This is a DESIGN CHOICE, not a bug. The 2-day window prevents token bloat.
-*/
+// Historical attachment verification moved into dedicated adapter tests.

--- a/test/telegram-bot.test.ts
+++ b/test/telegram-bot.test.ts
@@ -1,0 +1,83 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { BotHandler } from "../src/adapter.js";
+import { TelegramBot } from "../src/adapters/telegram/bot.js";
+
+function makeHandler(): BotHandler {
+  return {
+    isRunning: vi.fn().mockReturnValue(false),
+    getRunningSessions: vi.fn().mockReturnValue([]),
+    handleEvent: vi.fn(),
+    handleStop: vi.fn(),
+    forceStop: vi.fn(),
+    resolveSessionKey: vi.fn((key: string) => key),
+    registerThreadAlias: vi.fn(),
+  };
+}
+
+describe("TelegramBot attachments", () => {
+  let workingDir: string;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    workingDir = join(tmpdir(), `mama-telegram-bot-${Date.now()}`);
+    mkdirSync(workingDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  test("processAttachments waits for downloads and returns completed metadata", async () => {
+    const bot = new TelegramBot(makeHandler(), { token: "TEST_TOKEN", workingDir });
+    const processTelegramFile = vi
+      .fn()
+      .mockResolvedValueOnce({ name: "photo_42.jpg", localPath: "123/attachments/1_photo.jpg" })
+      .mockResolvedValueOnce({ name: "report.pdf", localPath: "123/attachments/2_report.pdf" });
+
+    (bot as any).processTelegramFile = processTelegramFile;
+
+    const attachments = await bot.processAttachments("123", {
+      message_id: 42,
+      photo: [{ file_id: "small-photo" }, { file_id: "large-photo" }],
+      document: { file_id: "doc-1", file_name: "report.pdf" },
+    });
+
+    expect(processTelegramFile).toHaveBeenNthCalledWith(1, "123", "large-photo", "photo_42.jpg");
+    expect(processTelegramFile).toHaveBeenNthCalledWith(2, "123", "doc-1", "report.pdf");
+    expect(attachments).toEqual([
+      { name: "photo_42.jpg", localPath: "123/attachments/1_photo.jpg" },
+      { name: "report.pdf", localPath: "123/attachments/2_report.pdf" },
+    ]);
+  });
+
+  test("processTelegramFile downloads via bot token and writes the attachment", async () => {
+    const bot = new TelegramBot(makeHandler(), { token: "TEST_TOKEN", workingDir });
+    const getFile = vi.fn().mockResolvedValue({ file_path: "photos/file_123.jpg" });
+    (bot as any).client = { api: { getFile } };
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const attachment = await (bot as any).processTelegramFile("456", "file-id", "photo.jpg");
+
+    expect(getFile).toHaveBeenCalledWith("file-id");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/file/botTEST_TOKEN/photos/file_123.jpg",
+    );
+    expect(attachment).toMatchObject({
+      name: "photo.jpg",
+      localPath: expect.stringMatching(/^456\/attachments\/\d+_photo\.jpg$/),
+    });
+
+    const savedFile = join(workingDir, attachment.localPath);
+    expect(existsSync(savedFile)).toBe(true);
+    expect(readFileSync(savedFile)).toEqual(Buffer.from([1, 2, 3, 4]));
+  });
+});


### PR DESCRIPTION
Closes #7

## Summary
- wait for Telegram photo and document downloads before building the event payload so attachments are available when the agent runs
- use the bot token, not the bot user ID, when downloading Telegram files
- add attachment-focused Telegram bot tests and remove stale issue-verification coverage that no longer matches the implementation

## Testing
- `npm test`
- `npm run lint`