### PR TITLE
Add multi-platform event routing for EventsWatcher

### DIFF
--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -519,8 +519,14 @@ export class SlackBot implements Bot {
       });
     } else {
       for (const ev of periodicEvents) {
-        const channel = this.channels.get(ev.channelId);
-        const channelName = channel ? `#${channel.name}` : ev.channelId;
+        const channelLabel =
+          ev.platform === "slack"
+            ? (() => {
+                const channel = this.channels.get(ev.channelId);
+                const channelName = channel ? `#${channel.name}` : ev.channelId;
+                return `${ev.platform}:${channelName}`;
+              })()
+            : `${ev.platform}:${ev.channelId}`;
         const nextStr = ev.nextRun
           ? new Date(ev.nextRun).toLocaleString("en-US", {
               month: "short",
@@ -533,7 +539,7 @@ export class SlackBot implements Bot {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `*${ev.text}*\n└ \`${ev.schedule}\` · ${channelName} · Next: ${nextStr}`,
+            text: `*${ev.text}*\n└ \`${ev.schedule}\` · ${channelLabel} · Next: ${nextStr}`,
           },
         });
       }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -225,17 +225,17 @@ You can schedule events that wake you up at specific times or when external thin
 
 **Immediate** - Triggers as soon as harness sees the file. Use in scripts/webhooks to signal external events.
 \`\`\`json
-{"type": "immediate", "channelId": "${channelId}", "text": "New GitHub issue opened"}
+{"type": "immediate", "platform": "${platform.name}", "channelId": "${channelId}", "text": "New GitHub issue opened"}
 \`\`\`
 
 **One-shot** - Triggers once at a specific time. Use for reminders.
 \`\`\`json
-{"type": "one-shot", "channelId": "${channelId}", "text": "Remind Mario about dentist", "at": "2025-12-15T09:00:00+01:00"}
+{"type": "one-shot", "platform": "${platform.name}", "channelId": "${channelId}", "text": "Remind Mario about dentist", "at": "2025-12-15T09:00:00+01:00"}
 \`\`\`
 
 **Periodic** - Triggers on a cron schedule. Use for recurring tasks.
 \`\`\`json
-{"type": "periodic", "channelId": "${channelId}", "text": "Check inbox and summarize", "schedule": "0 9 * * 1-5", "timezone": "${Intl.DateTimeFormat().resolvedOptions().timeZone}"}
+{"type": "periodic", "platform": "${platform.name}", "channelId": "${channelId}", "text": "Check inbox and summarize", "schedule": "0 9 * * 1-5", "timezone": "${Intl.DateTimeFormat().resolvedOptions().timeZone}"}
 \`\`\`
 
 ### Cron Format
@@ -248,11 +248,14 @@ You can schedule events that wake you up at specific times or when external thin
 ### Timezones
 All \`at\` timestamps must include offset (e.g., \`+01:00\`). Periodic events use IANA timezone names. The harness runs in ${Intl.DateTimeFormat().resolvedOptions().timeZone}. When users mention times without timezone, assume ${Intl.DateTimeFormat().resolvedOptions().timeZone}.
 
+### Platform Routing
+Set \`platform\` to the target bot platform (\`${platform.name}\` for this conversation). When only one platform is running, omitting \`platform\` is allowed for backward compatibility, but include it by default to avoid ambiguity.
+
 ### Creating Events
 Use unique filenames to avoid overwriting existing events. Include a timestamp or random suffix:
 \`\`\`bash
 cat > ${workspacePath}/events/dentist-reminder-$(date +%s).json << 'EOF'
-{"type": "one-shot", "channelId": "${channelId}", "text": "Dentist tomorrow", "at": "2025-12-14T09:00:00+01:00"}
+{"type": "one-shot", "platform": "${platform.name}", "channelId": "${channelId}", "text": "Dentist tomorrow", "at": "2025-12-14T09:00:00+01:00"}
 EOF
 \`\`\`
 Or check if file exists first before creating.

--- a/src/events.ts
+++ b/src/events.ts
@@ -20,12 +20,14 @@ import * as log from "./log.js";
 
 export interface ImmediateEvent {
   type: "immediate";
+  platform: string;
   channelId: string;
   text: string;
 }
 
 export interface OneShotEvent {
   type: "one-shot";
+  platform: string;
   channelId: string;
   text: string;
   at: string; // ISO 8601 with timezone offset
@@ -33,6 +35,7 @@ export interface OneShotEvent {
 
 export interface PeriodicEvent {
   type: "periodic";
+  platform: string;
   channelId: string;
   text: string;
   schedule: string; // cron syntax
@@ -43,6 +46,7 @@ export type MamaEvent = ImmediateEvent | OneShotEvent | PeriodicEvent;
 
 export interface PeriodicEventInfo {
   filename: string;
+  platform: string;
   channelId: string;
   text: string;
   schedule: string;
@@ -68,13 +72,13 @@ export class EventsWatcher {
 
   constructor(
     private eventsDir: string,
-    private bot: Bot,
+    private botsByPlatform: Record<string, Bot>,
   ) {
     this.startTime = Date.now();
   }
 
   /**
-   * Start watching for events. Call this after SlackBot is ready.
+   * Start watching for events. Call this after platform bots are initialized.
    */
   start(): void {
     // Ensure events directory exists
@@ -137,10 +141,14 @@ export class EventsWatcher {
       const filePath = join(this.eventsDir, filename);
       try {
         const content = readFileSync(filePath, "utf-8");
-        const data = JSON.parse(content) as PeriodicEvent;
+        const data = this.parseEvent(content, filename);
+        if (!data || data.type !== "periodic") {
+          continue;
+        }
         const next = cron.nextRun();
         results.push({
           filename,
+          platform: data.platform,
           channelId: data.channelId,
           text: data.text,
           schedule: data.schedule,
@@ -272,15 +280,23 @@ export class EventsWatcher {
       throw new Error(`Missing required fields (type, channelId, text) in ${filename}`);
     }
 
+    const platform = this.resolvePlatform(data.platform, filename);
+
     switch (data.type) {
       case "immediate":
-        return { type: "immediate", channelId: data.channelId, text: data.text };
+        return { type: "immediate", platform, channelId: data.channelId, text: data.text };
 
       case "one-shot":
         if (!data.at) {
           throw new Error(`Missing 'at' field for one-shot event in ${filename}`);
         }
-        return { type: "one-shot", channelId: data.channelId, text: data.text, at: data.at };
+        return {
+          type: "one-shot",
+          platform,
+          channelId: data.channelId,
+          text: data.text,
+          at: data.at,
+        };
 
       case "periodic":
         if (!data.schedule) {
@@ -291,6 +307,7 @@ export class EventsWatcher {
         }
         return {
           type: "periodic",
+          platform,
           channelId: data.channelId,
           text: data.text,
           schedule: data.schedule,
@@ -300,6 +317,28 @@ export class EventsWatcher {
       default:
         throw new Error(`Unknown event type '${data.type}' in ${filename}`);
     }
+  }
+
+  private resolvePlatform(platformValue: unknown, filename: string): string {
+    const availablePlatforms = Object.keys(this.botsByPlatform);
+
+    if (typeof platformValue === "string" && platformValue.trim().length > 0) {
+      const platform = platformValue.trim().toLowerCase();
+      if (!this.botsByPlatform[platform]) {
+        throw new Error(
+          `Unknown platform '${platformValue}' in ${filename}. Expected one of: ${availablePlatforms.join(", ")}`,
+        );
+      }
+      return platform;
+    }
+
+    if (availablePlatforms.length === 1) {
+      return availablePlatforms[0];
+    }
+
+    throw new Error(
+      `Missing required field 'platform' in ${filename}. Available platforms: ${availablePlatforms.join(", ")}`,
+    );
   }
 
   private handleImmediate(filename: string, event: ImmediateEvent): void {
@@ -380,6 +419,15 @@ export class EventsWatcher {
     }
 
     const message = `[EVENT:${filename}:${event.type}:${scheduleInfo}] ${event.text}`;
+    const bot = this.botsByPlatform[event.platform];
+
+    if (!bot) {
+      log.logWarning(`No bot configured for event platform '${event.platform}'`, filename);
+      if (deleteAfter) {
+        this.deleteFile(filename);
+      }
+      return;
+    }
 
     // Create synthetic BotEvent - use channelId as ts for stable session key
     const syntheticEvent: BotEvent = {
@@ -391,7 +439,7 @@ export class EventsWatcher {
     };
 
     // Enqueue for processing
-    const enqueued = this.bot.enqueueEvent(syntheticEvent);
+    const enqueued = bot.enqueueEvent(syntheticEvent);
 
     if (enqueued && deleteAfter) {
       // Delete file after successful enqueue (immediate and one-shot)
@@ -424,9 +472,12 @@ export class EventsWatcher {
 }
 
 /**
- * Create and start an events watcher.
+ * Create an events watcher for all configured platforms.
  */
-export function createEventsWatcher(workspaceDir: string, bot: Bot): EventsWatcher {
+export function createEventsWatcher(
+  workspaceDir: string,
+  botsByPlatform: Record<string, Bot>,
+): EventsWatcher {
   const eventsDir = join(workspaceDir, "events");
-  return new EventsWatcher(eventsDir, bot);
+  return new EventsWatcher(eventsDir, botsByPlatform);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -358,41 +358,42 @@ log.logStartup(workingDir, sandboxDesc);
 
 // Create platform bots
 const bots: Bot[] = [];
+const botsByPlatform: Record<string, Bot> = {};
 
 if (hasSlack) {
   const sharedStore = new ChannelStore({ workingDir, botToken: MOM_SLACK_BOT_TOKEN! });
-  bots.push(
-    new SlackBotClass(handler, {
-      appToken: MOM_SLACK_APP_TOKEN!,
-      botToken: MOM_SLACK_BOT_TOKEN!,
-      workingDir,
-      store: sharedStore,
-    }),
-  );
+  const slackBot = new SlackBotClass(handler, {
+    appToken: MOM_SLACK_APP_TOKEN!,
+    botToken: MOM_SLACK_BOT_TOKEN!,
+    workingDir,
+    store: sharedStore,
+  });
+  bots.push(slackBot);
+  botsByPlatform.slack = slackBot;
   log.logInfo("Platform: Slack");
 }
 if (hasTelegram) {
-  bots.push(
-    new TelegramBot(handler, {
-      token: MOM_TELEGRAM_BOT_TOKEN!,
-      workingDir,
-    }),
-  );
+  const telegramBot = new TelegramBot(handler, {
+    token: MOM_TELEGRAM_BOT_TOKEN!,
+    workingDir,
+  });
+  bots.push(telegramBot);
+  botsByPlatform.telegram = telegramBot;
   log.logInfo("Platform: Telegram");
 }
 if (hasDiscord) {
-  bots.push(
-    new DiscordBot(handler, {
-      token: MOM_DISCORD_BOT_TOKEN!,
-      workingDir,
-    }),
-  );
+  const discordBot = new DiscordBot(handler, {
+    token: MOM_DISCORD_BOT_TOKEN!,
+    workingDir,
+  });
+  bots.push(discordBot);
+  botsByPlatform.discord = discordBot;
   log.logInfo("Platform: Discord");
 }
 
-// Start events watcher (use first bot for event delivery)
-const eventsWatcher = createEventsWatcher(workingDir, bots[0]);
-const slackBot = bots.find((b) => b instanceof SlackBotClass) as SlackBotClass | undefined;
+// Start events watcher with explicit platform routing
+const eventsWatcher = createEventsWatcher(workingDir, botsByPlatform);
+const slackBot = botsByPlatform.slack as SlackBotClass | undefined;
 if (slackBot) {
   slackBot.setEventsWatcher(eventsWatcher);
 }

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,107 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
+import type { Bot, BotEvent } from "../src/adapter.js";
+import { EventsWatcher } from "../src/events.js";
+
+function makeBot(platform: string) {
+  const enqueueEvent = vi.fn<(event: BotEvent) => boolean>().mockReturnValue(true);
+
+  const bot: Bot = {
+    start: async () => {},
+    postMessage: async () => "1",
+    updateMessage: async () => {},
+    enqueueEvent,
+    getPlatformInfo: () => ({
+      name: platform,
+      formattingGuide: "",
+      channels: [],
+      users: [],
+    }),
+  };
+
+  return { bot, enqueueEvent };
+}
+
+describe("EventsWatcher platform routing", () => {
+  let tmpDir: string;
+  let eventsDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mama-events-test-${Date.now()}`);
+    eventsDir = join(tmpDir, "events");
+    mkdirSync(eventsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("defaults platform when exactly one bot is configured", () => {
+    const { bot } = makeBot("telegram");
+    const watcher = new EventsWatcher(eventsDir, { telegram: bot }) as any;
+
+    const parsed = watcher.parseEvent(
+      JSON.stringify({
+        type: "immediate",
+        channelId: "123",
+        text: "Check inbox",
+      }),
+      "single-platform.json",
+    );
+
+    expect(parsed).toEqual({
+      type: "immediate",
+      platform: "telegram",
+      channelId: "123",
+      text: "Check inbox",
+    });
+  });
+
+  test("rejects ambiguous events when multiple platforms are configured", () => {
+    const { bot: slackBot } = makeBot("slack");
+    const { bot: telegramBot } = makeBot("telegram");
+    const watcher = new EventsWatcher(eventsDir, {
+      slack: slackBot,
+      telegram: telegramBot,
+    }) as any;
+
+    expect(() =>
+      watcher.parseEvent(
+        JSON.stringify({
+          type: "immediate",
+          channelId: "123",
+          text: "Check inbox",
+        }),
+        "ambiguous.json",
+      ),
+    ).toThrow(/Missing required field 'platform'/);
+  });
+
+  test("routes synthetic events to the explicitly requested platform", () => {
+    const { bot: slackBot, enqueueEvent: enqueueSlack } = makeBot("slack");
+    const { bot: discordBot, enqueueEvent: enqueueDiscord } = makeBot("discord");
+    const watcher = new EventsWatcher(eventsDir, {
+      slack: slackBot,
+      discord: discordBot,
+    }) as any;
+
+    watcher.execute("deploy-reminder.json", {
+      type: "immediate",
+      platform: "discord",
+      channelId: "CH-42",
+      text: "Deploy in 10 minutes",
+    });
+
+    expect(enqueueSlack).not.toHaveBeenCalled();
+    expect(enqueueDiscord).toHaveBeenCalledTimes(1);
+    expect(enqueueDiscord).toHaveBeenCalledWith({
+      type: "mention",
+      channel: "CH-42",
+      user: "EVENT",
+      text: "[EVENT:deploy-reminder.json:immediate:immediate] Deploy in 10 minutes",
+      ts: "CH-42",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Refactor `EventsWatcher` to accept `botsByPlatform: Record<string, Bot>` instead of a single bot, enabling events to target specific platforms (Slack, Telegram, Discord)
- Add `platform` field to all event types (`ImmediateEvent`, `OneShotEvent`, `PeriodicEvent`) for explicit routing
- Auto-resolve platform when only one bot is configured; reject ambiguous events when multiple platforms are active
- Update agent system prompt to include `platform` in event JSON examples
- Show platform labels in Slack's periodic event listing (e.g. `slack:#general`, `telegram:123`)

## Test plan
- [x] `test/events.test.ts` — platform default resolution, ambiguous event rejection, and cross-platform routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)