### PR TITLE
feat(events): add broadcast support via channelId "*"

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -276,15 +276,27 @@ export class EventsWatcher {
   private parseEvent(content: string, filename: string): MamaEvent | null {
     const data = JSON.parse(content);
 
-    if (!data.type || !data.channelId || !data.text) {
-      throw new Error(`Missing required fields (type, channelId, text) in ${filename}`);
+    if (!data.type || !data.text) {
+      throw new Error(`Missing required fields (type, text) in ${filename}`);
     }
 
-    const platform = this.resolvePlatform(data.platform, filename);
+    // "*" channelId or explicit broadcast:true triggers broadcast mode
+    const isBroadcast = data.channelId === "*" || data.broadcast === true;
+
+    if (!isBroadcast && !data.channelId) {
+      throw new Error(
+        `Missing required field 'channelId' in ${filename}. Use "*" to broadcast to all channels.`,
+      );
+    }
+
+    const channelId = isBroadcast ? "*" : data.channelId;
+    const platform = isBroadcast
+      ? this.resolvePlatform(data.platform, filename, true)
+      : this.resolvePlatform(data.platform, filename, false);
 
     switch (data.type) {
       case "immediate":
-        return { type: "immediate", platform, channelId: data.channelId, text: data.text };
+        return { type: "immediate", platform, channelId, text: data.text };
 
       case "one-shot":
         if (!data.at) {
@@ -293,7 +305,7 @@ export class EventsWatcher {
         return {
           type: "one-shot",
           platform,
-          channelId: data.channelId,
+          channelId,
           text: data.text,
           at: data.at,
         };
@@ -308,7 +320,7 @@ export class EventsWatcher {
         return {
           type: "periodic",
           platform,
-          channelId: data.channelId,
+          channelId,
           text: data.text,
           schedule: data.schedule,
           timezone: data.timezone,
@@ -319,7 +331,11 @@ export class EventsWatcher {
     }
   }
 
-  private resolvePlatform(platformValue: unknown, filename: string): string {
+  /**
+   * Resolve the platform string. When allowAll is true (broadcast mode),
+   * a missing platform returns "*" to indicate all platforms.
+   */
+  private resolvePlatform(platformValue: unknown, filename: string, allowAll: boolean): string {
     const availablePlatforms = Object.keys(this.botsByPlatform);
 
     if (typeof platformValue === "string" && platformValue.trim().length > 0) {
@@ -334,6 +350,10 @@ export class EventsWatcher {
 
     if (availablePlatforms.length === 1) {
       return availablePlatforms[0];
+    }
+
+    if (allowAll) {
+      return "*"; // broadcast all platforms
     }
 
     throw new Error(
@@ -419,6 +439,13 @@ export class EventsWatcher {
     }
 
     const message = `[EVENT:${filename}:${event.type}:${scheduleInfo}] ${event.text}`;
+
+    // Broadcast mode: channelId === "*"
+    if (event.channelId === "*") {
+      this.executeBroadcast(filename, event, message, deleteAfter);
+      return;
+    }
+
     const bot = this.botsByPlatform[event.platform];
 
     if (!bot) {
@@ -450,6 +477,61 @@ export class EventsWatcher {
       if (deleteAfter) {
         this.deleteFile(filename);
       }
+    }
+  }
+
+  /**
+   * Broadcast a message to all known channels.
+   * If event.platform is "*", iterates every platform; otherwise only the specified one.
+   */
+  private executeBroadcast(
+    filename: string,
+    event: MamaEvent,
+    message: string,
+    deleteAfter: boolean,
+  ): void {
+    const platformEntries =
+      event.platform === "*"
+        ? Object.entries(this.botsByPlatform)
+        : ([[event.platform, this.botsByPlatform[event.platform]]] as [string, Bot][]);
+
+    let totalChannels = 0;
+    let totalEnqueued = 0;
+
+    for (const [platformName, bot] of platformEntries) {
+      if (!bot) {
+        log.logWarning(`No bot configured for broadcast platform '${platformName}'`, filename);
+        continue;
+      }
+
+      const channels = bot.getPlatformInfo().channels;
+      for (const channel of channels) {
+        totalChannels++;
+        const syntheticEvent: BotEvent = {
+          type: "mention",
+          channel: channel.id,
+          user: "EVENT",
+          text: message,
+          ts: channel.id,
+        };
+        if (bot.enqueueEvent(syntheticEvent)) {
+          totalEnqueued++;
+        }
+      }
+    }
+
+    log.logInfo(
+      `Broadcast event ${filename}: enqueued to ${totalEnqueued}/${totalChannels} channels`,
+    );
+
+    if (totalChannels === 0) {
+      log.logWarning(`Broadcast event found no channels: ${filename}`);
+    } else if (totalEnqueued === 0) {
+      log.logWarning(`Broadcast event: all queues full, discarded: ${filename}`);
+    }
+
+    if (deleteAfter) {
+      this.deleteFile(filename);
     }
   }
 

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
 import type { Bot, BotEvent } from "../src/adapter.js";
 import { EventsWatcher } from "../src/events.js";
 
-function makeBot(platform: string) {
+function makeBot(platform: string, channelIds: string[] = []) {
   const enqueueEvent = vi.fn<(event: BotEvent) => boolean>().mockReturnValue(true);
 
   const bot: Bot = {
@@ -16,7 +16,7 @@ function makeBot(platform: string) {
     getPlatformInfo: () => ({
       name: platform,
       formattingGuide: "",
-      channels: [],
+      channels: channelIds.map((id) => ({ id, name: id })),
       users: [],
     }),
   };
@@ -103,5 +103,195 @@ describe("EventsWatcher platform routing", () => {
       text: "[EVENT:deploy-reminder.json:immediate:immediate] Deploy in 10 minutes",
       ts: "CH-42",
     });
+  });
+});
+
+describe("EventsWatcher broadcast", () => {
+  let tmpDir: string;
+  let eventsDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mama-events-test-${Date.now()}`);
+    eventsDir = join(tmpDir, "events");
+    mkdirSync(eventsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── parseEvent ──────────────────────────────────────────────────────────────
+
+  test('parseEvent: channelId "*" triggers broadcast (single platform)', () => {
+    const { bot } = makeBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+    const parsed = watcher.parseEvent(
+      JSON.stringify({ type: "immediate", channelId: "*", text: "hi" }),
+      "bcast.json",
+    );
+
+    expect(parsed).toEqual({ type: "immediate", platform: "slack", channelId: "*", text: "hi" });
+  });
+
+  test("parseEvent: broadcast:true triggers broadcast (channelId omitted)", () => {
+    const { bot } = makeBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+    const parsed = watcher.parseEvent(
+      JSON.stringify({ type: "immediate", broadcast: true, text: "hi" }),
+      "bcast.json",
+    );
+
+    expect(parsed).toEqual({ type: "immediate", platform: "slack", channelId: "*", text: "hi" });
+  });
+
+  test("parseEvent: broadcast across all platforms when platform omitted (multi-bot)", () => {
+    const { bot: slackBot } = makeBot("slack");
+    const { bot: discordBot } = makeBot("discord");
+    const watcher = new EventsWatcher(eventsDir, {
+      slack: slackBot,
+      discord: discordBot,
+    }) as any;
+
+    const parsed = watcher.parseEvent(
+      JSON.stringify({ type: "immediate", channelId: "*", text: "hi" }),
+      "bcast.json",
+    );
+
+    expect(parsed.platform).toBe("*");
+    expect(parsed.channelId).toBe("*");
+  });
+
+  test("parseEvent: broadcast with explicit platform only targets that platform", () => {
+    const { bot: slackBot } = makeBot("slack");
+    const { bot: discordBot } = makeBot("discord");
+    const watcher = new EventsWatcher(eventsDir, {
+      slack: slackBot,
+      discord: discordBot,
+    }) as any;
+
+    const parsed = watcher.parseEvent(
+      JSON.stringify({ type: "immediate", channelId: "*", platform: "slack", text: "hi" }),
+      "bcast.json",
+    );
+
+    expect(parsed.platform).toBe("slack");
+    expect(parsed.channelId).toBe("*");
+  });
+
+  test("parseEvent: missing channelId without broadcast flag throws", () => {
+    const { bot: slackBot } = makeBot("slack");
+    const { bot: discordBot } = makeBot("discord");
+    const watcher = new EventsWatcher(eventsDir, {
+      slack: slackBot,
+      discord: discordBot,
+    }) as any;
+
+    expect(() =>
+      watcher.parseEvent(
+        JSON.stringify({ type: "immediate", platform: "slack", text: "hi" }),
+        "bad.json",
+      ),
+    ).toThrow(/channelId/);
+  });
+
+  // ── execute ──────────────────────────────────────────────────────────────────
+
+  test("execute: broadcasts to all channels on the specified platform", () => {
+    const { bot: slackBot, enqueueEvent: enqueueSlack } = makeBot("slack", ["C1", "C2", "C3"]);
+    const { bot: discordBot, enqueueEvent: enqueueDiscord } = makeBot("discord", ["D1"]);
+    const watcher = new EventsWatcher(eventsDir, {
+      slack: slackBot,
+      discord: discordBot,
+    }) as any;
+
+    watcher.execute("announce.json", {
+      type: "immediate",
+      platform: "slack",
+      channelId: "*",
+      text: "Hello all",
+    });
+
+    expect(enqueueSlack).toHaveBeenCalledTimes(3);
+    expect(enqueueDiscord).not.toHaveBeenCalled();
+
+    const channels = enqueueSlack.mock.calls.map((c: [BotEvent]) => c[0].channel);
+    expect(channels).toEqual(["C1", "C2", "C3"]);
+  });
+
+  test("execute: platform '*' broadcasts to every platform's channels", () => {
+    const { bot: slackBot, enqueueEvent: enqueueSlack } = makeBot("slack", ["S1", "S2"]);
+    const { bot: discordBot, enqueueEvent: enqueueDiscord } = makeBot("discord", ["D1"]);
+    const watcher = new EventsWatcher(eventsDir, {
+      slack: slackBot,
+      discord: discordBot,
+    }) as any;
+
+    watcher.execute("global.json", {
+      type: "immediate",
+      platform: "*",
+      channelId: "*",
+      text: "System notice",
+    });
+
+    expect(enqueueSlack).toHaveBeenCalledTimes(2);
+    expect(enqueueDiscord).toHaveBeenCalledTimes(1);
+  });
+
+  test("execute: broadcast message format is correct", () => {
+    const { bot, enqueueEvent } = makeBot("slack", ["CH1"]);
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+    watcher.execute("news.json", {
+      type: "immediate",
+      platform: "slack",
+      channelId: "*",
+      text: "Breaking news",
+    });
+
+    expect(enqueueEvent).toHaveBeenCalledWith({
+      type: "mention",
+      channel: "CH1",
+      user: "EVENT",
+      text: "[EVENT:news.json:immediate:immediate] Breaking news",
+      ts: "CH1",
+    });
+  });
+
+  test("execute: broadcast with no channels logs warning but does not throw", () => {
+    const { bot } = makeBot("slack", []); // no channels
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+    expect(() =>
+      watcher.execute("empty.json", {
+        type: "immediate",
+        platform: "slack",
+        channelId: "*",
+        text: "Anyone?",
+      }),
+    ).not.toThrow();
+  });
+
+  test("execute: periodic broadcast does not delete the file", () => {
+    const { bot, enqueueEvent } = makeBot("slack", ["C1"]);
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+    const deleteFile = vi.spyOn(watcher, "deleteFile");
+
+    watcher.execute(
+      "daily.json",
+      {
+        type: "periodic",
+        platform: "slack",
+        channelId: "*",
+        text: "Daily",
+        schedule: "0 9 * * *",
+        timezone: "UTC",
+      },
+      false, // deleteAfter = false
+    );
+
+    expect(enqueueEvent).toHaveBeenCalledTimes(1);
+    expect(deleteFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Allow events to be sent to all known channels by setting channelId to "*"
(or broadcast:true). Platform can be omitted to target all platforms at once.

https://claude.ai/code/session_011b3maKeQkjv5SCpLqqGd8Q