### PR TITLE
feat(telegram): native slash commands + private chat session fix

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -52,6 +52,8 @@ export interface BotEvent {
   text: string;
   /** Downloaded attachments */
   attachments?: { name: string; localPath: string }[];
+  /** Platform-computed session key; overrides default channel:thread_ts computation */
+  sessionKey?: string;
 }
 
 /**
@@ -97,6 +99,8 @@ export interface BotHandler {
   resolveSessionKey(rawKey: string): string;
   /** Register an alias so that "channel:botReplyTs" resolves to the original sessionKey */
   registerThreadAlias(aliasKey: string, sessionKey: string): void;
+  /** Reset a session: abort if running, delete history, remove from cache */
+  handleNew(sessionKey: string, channelId: string, bot: Bot): Promise<void>;
 }
 
 /** @deprecated Use BotHandler */

--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -14,6 +14,18 @@ export interface TelegramEvent extends BotEvent {
   userName?: string;
 }
 
+interface MessageContext {
+  msg: any;
+  text: string;
+  chatId: string;
+  chatType: string;
+  userId: string;
+  userName: string;
+  msgId: string;
+  threadTs: string | undefined;
+  sessionKey: string;
+}
+
 // ============================================================================
 // Per-channel queue for sequential processing
 // ============================================================================
@@ -80,6 +92,13 @@ export class TelegramBot implements Bot {
     this.botUserId = String(me.id);
     this.botUsername = me.username ?? null;
     this.startupTime = Date.now();
+
+    await this.client.api.setMyCommands([
+      { command: "start", description: "Welcome message" },
+      { command: "help", description: "Show available commands" },
+      { command: "stop", description: "Stop ongoing conversation" },
+      { command: "new", description: "Reset conversation history and start fresh" },
+    ]);
 
     this.setupEventHandlers();
 
@@ -279,6 +298,29 @@ export class TelegramBot implements Bot {
     return queue;
   }
 
+  private extractMessageContext(msg: any): MessageContext | null {
+    if (!msg) return null;
+    if (msg.date * 1000 < this.startupTime) return null;
+    if (msg.from?.is_bot) return null;
+
+    const text = msg.text ?? msg.caption ?? "";
+    if (!text && !msg.document && !msg.photo) return null;
+
+    const chatId = String(msg.chat.id);
+    const chatType = msg.chat.type;
+    const userId = String(msg.from?.id ?? "unknown");
+    const userName = msg.from?.username ?? msg.from?.first_name ?? userId;
+    const msgId = String(msg.message_id);
+    const replyToId = msg.reply_to_message?.message_id;
+    const threadTs = replyToId ? String(replyToId) : undefined;
+
+    // Private chats: single session per chat (no per-message splitting)
+    // Groups: per-thread sessions (use reply chain or unique message id)
+    const sessionKey = chatType === "private" ? chatId : `${chatId}:${threadTs ?? msgId}`;
+
+    return { msg, text, chatId, chatType, userId, userName, msgId, threadTs, sessionKey };
+  }
+
   private isAddressedToBot(text: string, chatType: string): boolean {
     if (chatType === "private") return true;
     if (!this.botUsername) return false;
@@ -291,72 +333,110 @@ export class TelegramBot implements Bot {
   }
 
   private setupEventHandlers(): void {
+    // --- Slash commands (registered before catch-all so grammY intercepts them) ---
+
+    this.client.command("start", async (ctx) => {
+      const mc = this.extractMessageContext(ctx.message);
+      if (!mc) return;
+      await this.postMessageRaw(
+        parseInt(mc.chatId),
+        [
+          "<b>Welcome!</b>",
+          "",
+          "I'm an AI coding agent. Send me a message or use these commands:",
+          "",
+          "/new — Reset conversation history and start fresh",
+          "/stop — Stop the current conversation",
+          "/help — Show available commands",
+        ].join("\n"),
+      );
+    });
+
+    this.client.command("help", async (ctx) => {
+      const mc = this.extractMessageContext(ctx.message);
+      if (!mc) return;
+      await this.postMessageRaw(
+        parseInt(mc.chatId),
+        [
+          "<b>Available commands:</b>",
+          "",
+          "/start — Welcome message",
+          "/help — Show this help",
+          "/stop — Stop ongoing conversation",
+          "/new — Reset conversation history and start fresh",
+          "",
+          "You can also send a regular message to chat with the agent.",
+        ].join("\n"),
+      );
+    });
+
+    this.client.command("stop", async (ctx) => {
+      const mc = this.extractMessageContext(ctx.message);
+      if (!mc) return;
+      if (this.handler.isRunning(mc.sessionKey)) {
+        await this.handler.handleStop(mc.sessionKey, mc.chatId, this);
+      } else {
+        await this.postMessage(mc.chatId, "Nothing running.");
+      }
+    });
+
+    this.client.command("new", async (ctx) => {
+      const mc = this.extractMessageContext(ctx.message);
+      if (!mc) return;
+      await this.handler.handleNew(mc.sessionKey, mc.chatId, this);
+    });
+
+    // --- Catch-all for regular (non-command) messages ---
+
     this.client.on("message", async (ctx) => {
-      const msg = ctx.message;
+      const mc = this.extractMessageContext(ctx.message);
+      if (!mc) return;
 
-      // Skip messages from before startup (Telegram replays recent messages on poll start)
-      if (msg.date * 1000 < this.startupTime) return;
-      // Skip bot messages
-      if (msg.from?.is_bot) return;
+      // In groups, only respond when addressed to bot
+      if (!this.isAddressedToBot(mc.text, mc.chatType)) return;
 
-      const text = msg.text ?? msg.caption ?? "";
-      if (!text && !msg.document && !msg.photo) return;
+      const cleanedText = this.cleanText(mc.text);
 
-      const chatId = String(msg.chat.id);
-      const chatType = msg.chat.type;
-      const userId = String(msg.from?.id ?? "unknown");
-      const userName = msg.from?.username ?? msg.from?.first_name ?? userId;
-      const msgId = String(msg.message_id);
-
-      // Determine thread: if this is a reply, use parent message_id as thread_ts
-      const replyToId = msg.reply_to_message?.message_id;
-      const threadTs = replyToId ? String(replyToId) : undefined;
-
-      // Check if addressed to bot
-      if (!this.isAddressedToBot(text, chatType)) return;
-
-      const cleanedText = this.cleanText(text);
-      const sessionKey = `${chatId}:${threadTs ?? msgId}`;
-
-      // Process attachments (starts download in background)
-      const processedAttachments = await this.processAttachments(chatId, msg);
+      // Process attachments
+      const processedAttachments = await this.processAttachments(mc.chatId, mc.msg);
 
       const event: TelegramEvent = {
         type: "message",
-        channel: chatId,
-        ts: msgId,
-        thread_ts: threadTs,
-        user: userId,
-        userName,
+        channel: mc.chatId,
+        ts: mc.msgId,
+        thread_ts: mc.threadTs,
+        sessionKey: mc.sessionKey,
+        user: mc.userId,
+        userName: mc.userName,
         text: cleanedText,
         attachments: processedAttachments,
       };
 
       // Log the message
-      this.logToFile(chatId, {
-        date: new Date(msg.date * 1000).toISOString(),
-        ts: msgId,
-        user: userId,
-        userName,
+      this.logToFile(mc.chatId, {
+        date: new Date(mc.msg.date * 1000).toISOString(),
+        ts: mc.msgId,
+        user: mc.userId,
+        userName: mc.userName,
         text: cleanedText,
         attachments: processedAttachments,
         isBot: false,
       });
 
-      // Handle /stop command
-      if (cleanedText.toLowerCase() === "/stop" || cleanedText.toLowerCase() === "stop") {
-        if (this.handler.isRunning(sessionKey)) {
-          this.handler.handleStop(sessionKey, chatId, this);
+      // Handle bare "stop" text (backward compat)
+      if (cleanedText.toLowerCase() === "stop") {
+        if (this.handler.isRunning(mc.sessionKey)) {
+          await this.handler.handleStop(mc.sessionKey, mc.chatId, this);
         } else {
-          this.postMessage(chatId, "Nothing running.");
+          await this.postMessage(mc.chatId, "Nothing running.");
         }
         return;
       }
 
-      if (this.handler.isRunning(sessionKey)) {
-        this.postMessage(chatId, "Already working. Say <code>stop</code> to cancel.");
+      if (this.handler.isRunning(mc.sessionKey)) {
+        await this.postMessage(mc.chatId, "Already working. Say <code>/stop</code> to cancel.");
       } else {
-        this.getQueue(sessionKey).enqueue(() => {
+        this.getQueue(mc.sessionKey).enqueue(() => {
           const adapters = createTelegramAdapters(event, this, false);
           return this.handler.handleEvent(event, this, adapters, false);
         });

--- a/src/adapters/telegram/context.ts
+++ b/src/adapters/telegram/context.ts
@@ -32,7 +32,7 @@ export function createTelegramAdapters(
 
   const message: ChatMessage = {
     id: event.ts,
-    sessionKey: `${event.channel}:${event.thread_ts ?? event.ts}`,
+    sessionKey: event.sessionKey ?? `${event.channel}:${event.thread_ts ?? event.ts}`,
     userId: event.user,
     userName: event.userName,
     text: event.text,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { join, resolve } from "path";
-import { readFileSync } from "fs";
+import { readFileSync, rmSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join as pathJoin } from "path";
 import type { Bot, BotAdapters, BotEvent, BotHandler } from "./adapter.js";
@@ -154,6 +154,12 @@ const channelStates = new Map<string, ChannelState>();
  */
 const threadAliases = new Map<string, string>();
 
+function deleteAliasesForSession(sessionKey: string): void {
+  for (const [alias, target] of threadAliases) {
+    if (target === sessionKey) threadAliases.delete(alias);
+  }
+}
+
 /** Track in-flight runs for graceful shutdown */
 const inFlightRuns = new Set<Promise<void>>();
 
@@ -193,10 +199,7 @@ function evictIdleSessions(): void {
   for (const [key, state] of channelStates) {
     if (!state.running && now - state.lastAccessedAt > IDLE_TIMEOUT_MS) {
       channelStates.delete(key);
-      // Clean up aliases pointing to this session
-      for (const [alias, target] of threadAliases) {
-        if (target === key) threadAliases.delete(alias);
-      }
+      deleteAliasesForSession(key);
     }
   }
 
@@ -214,9 +217,7 @@ function evictIdleSessions(): void {
     for (let i = 0; i < toEvict && i < idleSessions.length; i++) {
       const evictedKey = idleSessions[i].key;
       channelStates.delete(evictedKey);
-      for (const [alias, target] of threadAliases) {
-        if (target === evictedKey) threadAliases.delete(alias);
-      }
+      deleteAliasesForSession(evictedKey);
     }
   }
 }
@@ -278,6 +279,27 @@ const handler: BotHandler = {
     threadAliases.set(aliasKey, sessionKey);
   },
 
+  async handleNew(sessionKey: string, channelId: string, bot: Bot): Promise<void> {
+    const state = channelStates.get(sessionKey);
+    if (state?.running) {
+      state.stopRequested = true;
+      state.runner.abort();
+    }
+
+    // Delete session directory on disk
+    const rootTs = sessionKey.includes(":") ? sessionKey.split(":").pop()! : sessionKey;
+    const sessionDir = join(workingDir, channelId, "sessions", rootTs);
+    rmSync(sessionDir, { recursive: true, force: true });
+
+    // Remove from in-memory cache
+    channelStates.delete(sessionKey);
+
+    deleteAliasesForSession(sessionKey);
+
+    log.logInfo(`[${channelId}] Session reset: ${sessionKey}`);
+    await bot.postMessage(channelId, "Conversation reset. Send a new message to start fresh.");
+  },
+
   async handleEvent(
     event: BotEvent,
     bot: Bot,
@@ -292,7 +314,7 @@ const handler: BotHandler = {
       return;
     }
 
-    const rawSessionKey = `${event.channel}:${event.thread_ts ?? event.ts}`;
+    const rawSessionKey = event.sessionKey ?? `${event.channel}:${event.thread_ts ?? event.ts}`;
     const sessionKey = this.resolveSessionKey(rawSessionKey);
     const state = await getState(event.channel, sessionKey);
 

--- a/test/telegram-bot.test.ts
+++ b/test/telegram-bot.test.ts
@@ -14,8 +14,103 @@ function makeHandler(): BotHandler {
     forceStop: vi.fn(),
     resolveSessionKey: vi.fn((key: string) => key),
     registerThreadAlias: vi.fn(),
+    handleNew: vi.fn(),
   };
 }
+
+// Helper: build a fake Telegram message object
+function makeMessage(overrides: Record<string, any> = {}) {
+  return {
+    message_id: 100,
+    date: Math.floor(Date.now() / 1000) + 10,
+    chat: { id: 123, type: "private" },
+    from: { id: 42, is_bot: false, username: "alice", first_name: "Alice" },
+    text: "hello",
+    ...overrides,
+  };
+}
+
+describe("TelegramBot extractMessageContext", () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = join(tmpdir(), `mama-telegram-ctx-${Date.now()}`);
+    mkdirSync(workingDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  test("returns null for null/undefined message", () => {
+    const bot = new TelegramBot(makeHandler(), { token: "T", workingDir });
+    const extract = (bot as any).extractMessageContext.bind(bot);
+    expect(extract(null)).toBeNull();
+    expect(extract(undefined)).toBeNull();
+  });
+
+  test("returns null for messages before startup time", () => {
+    const bot = new TelegramBot(makeHandler(), { token: "T", workingDir });
+    (bot as any).startupTime = Date.now() + 60_000;
+    const extract = (bot as any).extractMessageContext.bind(bot);
+    const msg = makeMessage({ date: Math.floor(Date.now() / 1000) });
+    expect(extract(msg)).toBeNull();
+  });
+
+  test("returns null for bot messages", () => {
+    const bot = new TelegramBot(makeHandler(), { token: "T", workingDir });
+    (bot as any).startupTime = 0;
+    const extract = (bot as any).extractMessageContext.bind(bot);
+    const msg = makeMessage({ from: { id: 1, is_bot: true, username: "bot" } });
+    expect(extract(msg)).toBeNull();
+  });
+
+  test("private chat: sessionKey is just chatId (single session)", () => {
+    const bot = new TelegramBot(makeHandler(), { token: "T", workingDir });
+    (bot as any).startupTime = 0;
+    const extract = (bot as any).extractMessageContext.bind(bot);
+
+    const msg1 = makeMessage({ message_id: 100 });
+    const msg2 = makeMessage({ message_id: 200 });
+    expect(extract(msg1).sessionKey).toBe("123");
+    expect(extract(msg2).sessionKey).toBe("123");
+    // Both produce the same sessionKey — same session!
+    expect(extract(msg1).sessionKey).toBe(extract(msg2).sessionKey);
+  });
+
+  test("group chat: sessionKey includes msgId (per-message session)", () => {
+    const bot = new TelegramBot(makeHandler(), { token: "T", workingDir });
+    (bot as any).startupTime = 0;
+    const extract = (bot as any).extractMessageContext.bind(bot);
+
+    const msg = makeMessage({ chat: { id: 999, type: "group" }, message_id: 50 });
+    expect(extract(msg).sessionKey).toBe("999:50");
+  });
+
+  test("group chat: reply uses threadTs in sessionKey", () => {
+    const bot = new TelegramBot(makeHandler(), { token: "T", workingDir });
+    (bot as any).startupTime = 0;
+    const extract = (bot as any).extractMessageContext.bind(bot);
+
+    const msg = makeMessage({
+      chat: { id: 999, type: "group" },
+      message_id: 60,
+      reply_to_message: { message_id: 50 },
+    });
+    expect(extract(msg).sessionKey).toBe("999:50");
+  });
+
+  test("private chat reply still uses chatId as sessionKey", () => {
+    const bot = new TelegramBot(makeHandler(), { token: "T", workingDir });
+    (bot as any).startupTime = 0;
+    const extract = (bot as any).extractMessageContext.bind(bot);
+
+    const msg = makeMessage({ reply_to_message: { message_id: 50 } });
+    expect(extract(msg).sessionKey).toBe("123");
+    // threadTs is still set for reply targeting
+    expect(extract(msg).threadTs).toBe("50");
+  });
+});
 
 describe("TelegramBot attachments", () => {
   let workingDir: string;


### PR DESCRIPTION
## Summary
- Register `/start`, `/help`, `/stop`, `/new` via grammY's `bot.command()` API — commands appear in Telegram's "/" autocomplete menu
- `/new` resets session history (deletes `context.jsonl` on disk and evicts the runner from memory cache)
- Fix private chat session key to use `chatId` only instead of `chatId:msgId`, so all DM messages share one session instead of each message creating a new one
- Extract `deleteAliasesForSession()` helper to deduplicate 3 identical alias cleanup loops in `main.ts`
- Add `await` to previously fire-and-forget `postMessage` calls in command handlers

## Changed files
- `src/adapter.ts` — `BotEvent.sessionKey` field, `BotHandler.handleNew()` method
- `src/adapters/telegram/bot.ts` — slash command handlers, `extractMessageContext()`, private chat session key logic
- `src/adapters/telegram/context.ts` — respect `event.sessionKey`
- `src/main.ts` — `handleNew` implementation, `deleteAliasesForSession` helper, use `event.sessionKey`
- `test/telegram-bot.test.ts` — tests for `extractMessageContext` (private/group session keys)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 146 tests pass
- [x] Manual DM test: messages share single session, `/new` resets, agent remembers context within session

Closes #13, Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)