### PR TITLE
feat: add LINE adapter with webhook support

### DIFF
--- a/src/adapters/line/bot.ts
+++ b/src/adapters/line/bot.ts
@@ -1,0 +1,475 @@
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { Bot, BotEvent, BotHandler, PlatformInfo } from "../../adapter.js";
+import * as log from "../../log.js";
+import { createLineAdapters } from "./context.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LineEvent extends BotEvent {
+  type: "message" | "command";
+  userName?: string;
+  replyToken?: string;
+}
+
+// Webhook event types (simplified)
+interface WebhookMessageEvent {
+  type: "message";
+  mode: string;
+  timestamp: number;
+  webhookEventId: string;
+  replyToken?: string;
+  source: { type: string; userId?: string; groupId?: string; roomId?: string };
+  message: {
+    id: string;
+    type: string;
+    text?: string;
+    fileName?: string;
+    fileSize?: number;
+  };
+}
+
+interface WebhookPostbackEvent {
+  type: "postback";
+  mode: string;
+  timestamp: number;
+  webhookEventId: string;
+  replyToken?: string;
+  source: { type: string; userId?: string };
+  postback: { data: string };
+}
+
+type WebhookEvent = WebhookMessageEvent | WebhookPostbackEvent;
+
+interface WebhookRequestBody {
+  destination?: string;
+  events: WebhookEvent[];
+}
+
+// ============================================================================
+// Per-channel queue for sequential processing
+// ============================================================================
+
+type QueuedWork = () => Promise<void>;
+
+class ChannelQueue {
+  private queue: QueuedWork[] = [];
+  private processing = false;
+
+  enqueue(work: QueuedWork): void {
+    this.queue.push(work);
+    this.processNext();
+  }
+
+  size(): number {
+    return this.queue.length;
+  }
+
+  private async processNext(): Promise<void> {
+    if (this.processing || this.queue.length === 0) return;
+    this.processing = true;
+    const work = this.queue.shift()!;
+    try {
+      await work();
+    } catch (err) {
+      log.logWarning("LINE queue error", err instanceof Error ? err.message : String(err));
+    }
+    this.processing = false;
+    this.processNext();
+  }
+}
+
+// ============================================================================
+// LineBot
+// ============================================================================
+
+export class LineBot implements Bot {
+  private handler: BotHandler;
+  private workingDir: string;
+  private channelSecret: string;
+  private channelAccessToken: string;
+  private botUserId: string | null = null;
+  private queues = new Map<string, ChannelQueue>();
+  private startupTime: number = 0;
+
+  constructor(
+    handler: BotHandler,
+    config: { channelSecret: string; channelAccessToken: string; workingDir: string },
+  ) {
+    this.handler = handler;
+    this.workingDir = config.workingDir;
+    this.channelSecret = config.channelSecret;
+    this.channelAccessToken = config.channelAccessToken;
+  }
+
+  // ==========================================================================
+  // LINE API Helper
+  // ==========================================================================
+
+  private async lineApi<T>(endpoint: string, body?: object): Promise<T> {
+    const response = await fetch(`https://api.line.me/v2/bot${endpoint}`, {
+      method: body ? "POST" : "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.channelAccessToken}`,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`LINE API error: ${response.status} - ${error}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  // ==========================================================================
+  // Public API (implements Bot)
+  // ==========================================================================
+
+  async start(): Promise<void> {
+    this.startupTime = Date.now();
+    log.logConnected();
+    log.logInfo("LINE bot started");
+  }
+
+  async postMessage(channel: string, text: string): Promise<string> {
+    const result = await this.lineApi<{ sentMessages: { id: string }[] }>("/message/reply", {
+      replyToken: channel,
+      messages: [{ type: "text", text: text }],
+    });
+    return result.sentMessages[0]?.id ?? "unknown";
+  }
+
+  async updateMessage(channel: string, _ts: string, text: string): Promise<void> {
+    // LINE doesn't support message editing
+    // We'll just push a new message instead
+    await this.lineApi("/message/push", {
+      to: channel,
+      messages: [{ type: "text", text: text }],
+    });
+  }
+
+  enqueueEvent(event: BotEvent): boolean {
+    const queue = this.getQueue(event.channel);
+    if (queue.size() >= 5) {
+      log.logWarning(
+        `Event queue full for ${event.channel}, discarding: ${event.text.substring(0, 50)}`,
+      );
+      return false;
+    }
+    log.logInfo(`Enqueueing event for ${event.channel}: ${event.text.substring(0, 50)}`);
+    queue.enqueue(() => {
+      const adapters = createLineAdapters(event as LineEvent, this, true);
+      return this.handler.handleEvent(event, this, adapters, true);
+    });
+    return true;
+  }
+
+  getPlatformInfo(): PlatformInfo {
+    return {
+      name: "line",
+      formattingGuide:
+        "## LINE Formatting\nText is plain. For bold/italic, use Unicode alternatives or emoji.\nCode blocks are not supported in LINE.",
+      channels: [],
+      users: [],
+    };
+  }
+
+  // ==========================================================================
+  // Internal helpers (used by context.ts)
+  // ==========================================================================
+
+  async replyMessage(replyToken: string, text: string): Promise<void> {
+    await this.lineApi("/message/reply", {
+      replyToken: replyToken,
+      messages: [{ type: "text", text: text }],
+    });
+  }
+
+  async pushMessage(userId: string, text: string): Promise<void> {
+    await this.lineApi("/message/push", {
+      to: userId,
+      messages: [{ type: "text", text: text }],
+    });
+  }
+
+  async deleteMessage(_channelId: string, _messageId: string): Promise<void> {
+    // LINE doesn't have a delete message API for the bot's own messages
+    // This is a no-op
+  }
+
+  logToFile(channelId: string, entry: object): void {
+    const dir = join(this.workingDir, channelId);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    appendFileSync(join(dir, "log.jsonl"), `${JSON.stringify(entry)}\n`);
+  }
+
+  logBotResponse(channelId: string, text: string, ts: string): void {
+    this.logToFile(channelId, {
+      date: new Date().toISOString(),
+      ts,
+      user: "bot",
+      text,
+      attachments: [],
+      isBot: true,
+    });
+  }
+
+  /**
+   * Process attachments from a LINE message
+   * Downloads files and returns metadata
+   */
+  async processAttachments(
+    userId: string,
+    events: WebhookEvent[],
+  ): Promise<{ name: string; localPath: string }[]> {
+    const downloads: Array<Promise<{ name: string; localPath: string } | null>> = [];
+
+    for (const event of events) {
+      if (event.type !== "message" || !event.message) continue;
+
+      const msg = event.message;
+
+      // Handle images, videos, audio, files
+      if (["image", "video", "audio", "file"].includes(msg.type)) {
+        downloads.push(this.processLineFile(userId, msg.id, msg));
+      }
+    }
+
+    const attachments = await Promise.all(downloads);
+    return attachments.filter(
+      (attachment): attachment is { name: string; localPath: string } => attachment !== null,
+    );
+  }
+
+  /**
+   * Download a file from LINE and return attachment metadata
+   */
+  private async processLineFile(
+    userId: string,
+    messageId: string,
+    msg: { type: string; fileName?: string },
+  ): Promise<{ name: string; localPath: string } | null> {
+    const typeExt: Record<string, string> = {
+      image: "jpg",
+      video: "mp4",
+      audio: "m4a",
+      file: "bin",
+    };
+    const ext = typeExt[msg.type] || "bin";
+    const originalName = msg.fileName ?? `message_${messageId}.${ext}`;
+
+    try {
+      // Get binary content from LINE
+      const response = await fetch(`https://api.line.me/v2/bot/message/${messageId}/content`, {
+        headers: { Authorization: `Bearer ${this.channelAccessToken}` },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const buffer = Buffer.from(await response.arrayBuffer());
+
+      // Generate local filename
+      const ts = Date.now();
+      const sanitizedName = originalName.replace(/[^a-zA-Z0-9._-]/g, "_");
+      const filename = `${ts}_${sanitizedName}`;
+      const localPath = `${userId}/attachments/${filename}`;
+      const fullDir = join(this.workingDir, userId, "attachments");
+
+      if (!existsSync(fullDir)) mkdirSync(fullDir, { recursive: true });
+
+      writeFileSync(join(fullDir, filename), buffer);
+
+      return {
+        name: originalName,
+        localPath: localPath,
+      };
+    } catch (err) {
+      log.logWarning(`Failed to process LINE file`, `${originalName}: ${err}`);
+      return null;
+    }
+  }
+
+  /**
+   * Handle incoming webhook events from LINE
+   */
+  handleWebhook(body: WebhookRequestBody): void {
+    const events = body.events;
+    if (!events || events.length === 0) return;
+
+    for (const event of events) {
+      this.processEvent(event);
+    }
+  }
+
+  private processEvent(event: WebhookEvent): void {
+    // Skip events from before startup
+    if (event.timestamp && event.timestamp < this.startupTime) return;
+
+    // Only handle message events and postback events
+    if (event.type !== "message" && event.type !== "postback") return;
+
+    // Type guard for message events
+    if (event.type === "message") {
+      this.processMessageEvent(event);
+    } else if (event.type === "postback") {
+      this.processPostbackEvent(event);
+    }
+  }
+
+  private processMessageEvent(event: WebhookMessageEvent): void {
+    // Get user and channel info
+    const userId = event.source?.userId ?? "unknown";
+    const channelId = userId;
+    const messageId = event.message?.id ?? event.timestamp?.toString() ?? Date.now().toString();
+
+    // Skip messages from bots
+    if (event.source?.type === "bot") return;
+
+    let text = "";
+
+    const msg = event.message;
+    if (msg.type === "text") {
+      text = msg.text ?? "";
+    } else if (["image", "video", "audio", "file"].includes(msg.type)) {
+      text = `[${msg.type} message]`;
+    }
+
+    // Clean text
+    text = text.trim();
+    if (!text) return;
+
+    const sessionKey = userId;
+    const replyToken = event.replyToken;
+
+    const lineEvent: LineEvent = {
+      type: "message",
+      channel: channelId,
+      ts: messageId,
+      thread_ts: undefined,
+      sessionKey: sessionKey,
+      user: userId,
+      userName: userId,
+      text: text,
+      attachments: [],
+      replyToken: replyToken,
+    };
+
+    this.logToFile(channelId, {
+      date: new Date().toISOString(),
+      ts: messageId,
+      user: userId,
+      userName: userId,
+      text: text,
+      attachments: [],
+      isBot: false,
+    });
+
+    this.handleCommandOrEnqueue(lineEvent, userId, channelId, async () => {
+      const processedAttachments = await this.processAttachments(userId, [event]);
+      lineEvent.attachments = processedAttachments;
+      const adapters = createLineAdapters(lineEvent, this, false);
+      await this.handler.handleEvent(lineEvent, this, adapters, false);
+    });
+  }
+
+  private processPostbackEvent(event: WebhookPostbackEvent): void {
+    const userId = event.source?.userId ?? "unknown";
+    const channelId = userId;
+    const messageId = event.timestamp?.toString() ?? Date.now().toString();
+
+    const text = event.postback?.data ?? "";
+
+    const lineEvent: LineEvent = {
+      type: "message",
+      channel: channelId,
+      ts: messageId,
+      thread_ts: undefined,
+      sessionKey: userId,
+      user: userId,
+      userName: userId,
+      text: text,
+      attachments: [],
+      replyToken: event.replyToken,
+    };
+
+    this.logToFile(channelId, {
+      date: new Date().toISOString(),
+      ts: messageId,
+      user: userId,
+      userName: userId,
+      text: text,
+      attachments: [],
+      isBot: false,
+    });
+
+    this.handleCommandOrEnqueue(lineEvent, userId, channelId, async () => {
+      const adapters = createLineAdapters(lineEvent, this, false);
+      await this.handler.handleEvent(lineEvent, this, adapters, false);
+    });
+  }
+
+  private handleCommandOrEnqueue(
+    lineEvent: LineEvent,
+    sessionKey: string,
+    channelId: string,
+    onEnqueue: () => Promise<void>,
+  ): void {
+    const text = lineEvent.text;
+
+    if (text === "/stop" || text.toLowerCase() === "stop") {
+      if (this.handler.isRunning(sessionKey)) {
+        this.handler.handleStop(sessionKey, channelId, this);
+      } else {
+        this.postMessage(channelId, "_Nothing running_");
+      }
+      return;
+    }
+
+    if (text === "/new" || text.toLowerCase() === "new") {
+      this.handler.handleNew(sessionKey, channelId, this);
+      return;
+    }
+
+    if (text === "/help" || text === "/start") {
+      this.postMessage(
+        channelId,
+        [
+          "Welcome!",
+          "",
+          "I'm an AI coding agent. Send me a message or use these commands:",
+          "",
+          "/new — Reset conversation history and start fresh",
+          "/stop — Stop the current conversation",
+          "/help — Show available commands",
+        ].join("\n"),
+      );
+      return;
+    }
+
+    if (this.handler.isRunning(sessionKey)) {
+      this.postMessage(channelId, "_Already working. Say /stop to cancel._");
+    } else {
+      this.getQueue(sessionKey).enqueue(onEnqueue);
+    }
+  }
+
+  // ==========================================================================
+  // Private - Queue Management
+  // ==========================================================================
+
+  private getQueue(channelId: string): ChannelQueue {
+    let queue = this.queues.get(channelId);
+    if (!queue) {
+      queue = new ChannelQueue();
+      this.queues.set(channelId, queue);
+    }
+    return queue;
+  }
+}

--- a/src/adapters/line/context.ts
+++ b/src/adapters/line/context.ts
@@ -1,0 +1,142 @@
+import type { ChatMessage, ChatResponseContext, PlatformInfo } from "../../adapter.js";
+import * as log from "../../log.js";
+import type { LineBot, LineEvent } from "./bot.js";
+
+export const LINE_FORMATTING_GUIDE = `## LINE Formatting
+Text is plain. For bold/italic, use Unicode alternatives or emoji.
+Code blocks are not supported in LINE.
+Do NOT use Markdown syntax - LINE doesn't support it.`;
+
+async function notifyError(
+  bot: LineBot,
+  userId: string,
+  label: string,
+  err: unknown,
+): Promise<void> {
+  const errMsg = err instanceof Error ? err.message : String(err);
+  log.logWarning(`LINE ${label} error`, errMsg);
+  try {
+    await bot.pushMessage(userId, `⚠️ 發送失敗：${errMsg}`);
+  } catch {
+    // ignore secondary failure
+  }
+}
+
+export function createLineAdapters(
+  event: LineEvent,
+  bot: LineBot,
+  _isEvent?: boolean,
+): {
+  message: ChatMessage;
+  responseCtx: ChatResponseContext;
+  platform: PlatformInfo;
+} {
+  let messageSent = false;
+  let accumulatedText = "";
+  let updatePromise = Promise.resolve();
+
+  const userId = event.channel;
+
+  const message: ChatMessage = {
+    id: event.ts,
+    sessionKey: event.sessionKey ?? event.channel,
+    userId: event.user,
+    userName: event.userName,
+    text: event.text,
+    attachments: event.attachments,
+    threadTs: event.thread_ts,
+  };
+
+  const platform: PlatformInfo = {
+    name: "line",
+    formattingGuide: LINE_FORMATTING_GUIDE,
+    channels: [],
+    users: [],
+  };
+
+  // LINE message length limit is 5000 chars for push messages
+  const MAX_LENGTH = 4800;
+  const truncationNote = "\n\n(message truncated, ask me to elaborate on specific parts)";
+
+  function truncate(text: string, limit: number, note: string): string {
+    if (text.length > limit) {
+      return text.substring(0, limit - note.length) + note;
+    }
+    return text;
+  }
+
+  async function sendResponse(text: string): Promise<void> {
+    const displayText = truncate(text, MAX_LENGTH, truncationNote);
+    if (event.replyToken && !messageSent) {
+      // First message - use reply
+      await bot.replyMessage(event.replyToken, displayText);
+      messageSent = true;
+    } else {
+      // Subsequent messages - use push
+      await bot.pushMessage(userId, displayText);
+    }
+  }
+
+  const responseCtx: ChatResponseContext = {
+    respond: async (text: string) => {
+      updatePromise = updatePromise.then(async () => {
+        try {
+          accumulatedText = accumulatedText ? `${accumulatedText}\n${text}` : text;
+          await sendResponse(accumulatedText);
+          bot.logBotResponse(event.channel, text, event.ts);
+        } catch (err) {
+          await notifyError(bot, userId, "respond", err);
+        }
+      });
+      await updatePromise;
+    },
+
+    replaceResponse: async (text: string) => {
+      updatePromise = updatePromise.then(async () => {
+        try {
+          accumulatedText = truncate(text, MAX_LENGTH, truncationNote);
+          // LINE doesn't support edit, so we just send a new message
+          await bot.pushMessage(userId, accumulatedText);
+        } catch (err) {
+          await notifyError(bot, userId, "replaceResponse", err);
+        }
+      });
+      await updatePromise;
+    },
+
+    // LINE has no threads — discard thread-only messages
+    respondInThread: async (_text: string) => {},
+
+    setTyping: async (_isTyping: boolean) => {
+      // LINE doesn't have a typing indicator API like Telegram
+      // Could use LINE's SIMULTANEOUSLY_SEND_MESSAGE hint but it's more complex
+    },
+
+    setWorking: async (_working: boolean) => {
+      // No special handling needed
+    },
+
+    uploadFile: async (filePath: string, title?: string) => {
+      // LINE file upload requires using the Upload Rich Menu Image API or similar
+      // For now, we'll just send a text message with the file path
+      const fileName = title ?? filePath.split("/").pop() ?? "file";
+      await bot.pushMessage(userId, `[File ready: ${fileName}]\n${filePath}`);
+    },
+
+    deleteResponse: async () => {
+      updatePromise = updatePromise.then(async () => {
+        if (messageSent) {
+          try {
+            await bot.deleteMessage(event.channel, event.ts);
+          } catch {
+            // Ignore errors
+          }
+          messageSent = false;
+        }
+      });
+      await updatePromise;
+    },
+  };
+
+  return { message, responseCtx, platform };
+}

--- a/src/adapters/line/index.ts
+++ b/src/adapters/line/index.ts
@@ -1,0 +1,2 @@
+export * from "./bot.js";
+export * from "./context.js";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { join, resolve } from "path";
+import { createServer, type Server } from "http";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join as pathJoin } from "path";
@@ -8,6 +9,7 @@ import type { Bot, BotAdapters, BotEvent, BotHandler } from "./adapter.js";
 import { DiscordBot } from "./adapters/discord/index.js";
 import { TelegramBot } from "./adapters/telegram/index.js";
 import { SlackBot as SlackBotClass } from "./adapters/slack/index.js";
+import { LineBot } from "./adapters/line/index.js";
 import { type AgentRunner, createRunner } from "./agent.js";
 import {
   createManagedSessionFile,
@@ -49,12 +51,15 @@ const MOM_SLACK_APP_TOKEN = process.env.MOM_SLACK_APP_TOKEN;
 const MOM_SLACK_BOT_TOKEN = process.env.MOM_SLACK_BOT_TOKEN;
 const MOM_TELEGRAM_BOT_TOKEN = process.env.MOM_TELEGRAM_BOT_TOKEN;
 const MOM_DISCORD_BOT_TOKEN = process.env.MOM_DISCORD_BOT_TOKEN;
+const MOM_LINE_CHANNEL_SECRET = process.env.MOM_LINE_CHANNEL_SECRET;
+const MOM_LINE_CHANNEL_ACCESS_TOKEN = process.env.MOM_LINE_CHANNEL_ACCESS_TOKEN;
 
 interface ParsedArgs {
   workingDir?: string;
   sandbox: SandboxConfig;
   downloadChannel?: string;
   showVersion?: boolean;
+  webhookPort?: number;
 }
 
 function parseArgs(): ParsedArgs {
@@ -63,6 +68,7 @@ function parseArgs(): ParsedArgs {
   let workingDir: string | undefined;
   let downloadChannelId: string | undefined;
   let showVersion = false;
+  let webhookPort: number | undefined;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -76,6 +82,16 @@ function parseArgs(): ParsedArgs {
       downloadChannelId = arg.slice("--download=".length);
     } else if (arg === "--download") {
       downloadChannelId = args[++i];
+    } else if (arg === "--webhook-port") {
+      const port = parseInt(args[++i] || "8080", 10);
+      if (!isNaN(port) && port > 0 && port < 65536) {
+        webhookPort = port;
+      }
+    } else if (arg.startsWith("--webhook-port=")) {
+      const port = parseInt(arg.slice("--webhook-port=".length), 10);
+      if (!isNaN(port) && port > 0 && port < 65536) {
+        webhookPort = port;
+      }
     } else if (!arg.startsWith("-")) {
       workingDir = arg;
     }
@@ -86,6 +102,7 @@ function parseArgs(): ParsedArgs {
     sandbox,
     downloadChannel: downloadChannelId,
     showVersion,
+    webhookPort,
   };
 }
 
@@ -122,13 +139,15 @@ const { workingDir, sandbox } = { workingDir: parsedArgs.workingDir, sandbox: pa
 const hasSlack = !!(MOM_SLACK_APP_TOKEN && MOM_SLACK_BOT_TOKEN);
 const hasTelegram = !!MOM_TELEGRAM_BOT_TOKEN;
 const hasDiscord = !!MOM_DISCORD_BOT_TOKEN;
+const hasLine = !!(MOM_LINE_CHANNEL_SECRET && MOM_LINE_CHANNEL_ACCESS_TOKEN);
 
-if (!hasSlack && !hasTelegram && !hasDiscord) {
+if (!hasSlack && !hasTelegram && !hasDiscord && !hasLine) {
   console.error(
     "No platform tokens found. Set one of:\n" +
       "  Slack:    MOM_SLACK_APP_TOKEN + MOM_SLACK_BOT_TOKEN\n" +
       "  Telegram: MOM_TELEGRAM_BOT_TOKEN\n" +
-      "  Discord:  MOM_DISCORD_BOT_TOKEN",
+      "  Discord:  MOM_DISCORD_BOT_TOKEN\n" +
+      "  LINE:     MOM_LINE_CHANNEL_SECRET + MOM_LINE_CHANNEL_ACCESS_TOKEN",
   );
   process.exit(1);
 }
@@ -392,6 +411,48 @@ if (hasDiscord) {
   botsByPlatform.discord = discordBot;
   log.logInfo("Platform: Discord");
 }
+if (hasLine) {
+  const lineBot = new LineBot(handler, {
+    channelSecret: MOM_LINE_CHANNEL_SECRET!,
+    channelAccessToken: MOM_LINE_CHANNEL_ACCESS_TOKEN!,
+    workingDir,
+  });
+  bots.push(lineBot);
+  botsByPlatform.line = lineBot;
+  log.logInfo("Platform: LINE");
+}
+
+// Webhook server for LINE (if enabled)
+let webhookServer: Server | null = null;
+if (hasLine && parsedArgs.webhookPort) {
+  webhookServer = createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/webhook") {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk.toString();
+      });
+      req.on("end", () => {
+        try {
+          const lineBotInstance = botsByPlatform.line as LineBot;
+          const data = JSON.parse(body);
+          lineBotInstance.handleWebhook(data);
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("OK");
+        } catch {
+          res.writeHead(400, { "Content-Type": "text/plain" });
+          res.end("Bad Request");
+        }
+      });
+    } else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not Found");
+    }
+  });
+
+  webhookServer.listen(parsedArgs.webhookPort, () => {
+    log.logInfo(`LINE webhook server listening on port ${parsedArgs.webhookPort}`);
+  });
+}
 
 // Start events watcher with explicit platform routing
 const eventsWatcher = createEventsWatcher(workingDir, botsByPlatform);
@@ -417,6 +478,10 @@ async function shutdown(): Promise<void> {
   }
 
   eventsWatcher.stop();
+
+  if (webhookServer) {
+    webhookServer.close();
+  }
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

- Implement LINE bot using LINE Messaging API (native fetch)
- Support text, image, video, audio, and file attachments
- Add webhook HTTP server with --webhook-port flag
- Support /start, /help, /stop, /new commands
- Channel queue for sequential message processing
- LINE-specific context with reply/push message support

## Changes

- New files: src/adapters/line/bot.ts, context.ts, index.ts
- Modified: src/main.ts

## Environment Variables

- MOM_LINE_CHANNEL_SECRET
- MOM_LINE_CHANNEL_ACCESS_TOKEN

## Usage

