### PR TITLE
feat: polish login OAuth flow and conversation contracts

### DIFF
--- a/docs/oauth/github.md
+++ b/docs/oauth/github.md
@@ -1,0 +1,64 @@
+# GitHub OAuth Setup for mama
+
+This guide covers only three things:
+
+1. Create a GitHub OAuth App
+2. Get `Client ID` and `Client Secret`
+3. Set them as environment variables for mama
+
+## 1) Create a GitHub OAuth App
+
+Open GitHub:
+
+- `Settings` -> `Developer settings` -> `OAuth Apps` -> `New OAuth App`
+
+Fill in:
+
+- `Application name`: any name (for example: `MAMA`)
+- `Homepage URL`: your public mama link domain
+- `Authorization callback URL`: `<YOUR_MOM_LINK_URL>/oauth/callback`
+
+Example:
+
+- `MOM_LINK_URL=https://noble-attempt-tracked-asset.trycloudflare.com`
+- callback URL: `https://noble-attempt-tracked-asset.trycloudflare.com/oauth/callback`
+
+`Enable Device Flow` is not required for this flow.
+
+## 2) Get Client ID / Client Secret
+
+After creating the app:
+
+- Copy `Client ID`
+- Click `Generate a new client secret` and copy `Client Secret`
+
+## 3) Set mama environment variables
+
+Set these in the same runtime environment that starts `mama`:
+
+```bash
+export MOM_LINK_URL="https://your-public-domain"
+export GITHUB_OAUTH_CLIENT_ID="<your-client-id>"
+export GITHUB_OAUTH_CLIENT_SECRET="<your-client-secret>"
+```
+
+If using Telegram:
+
+```bash
+export MOM_TELEGRAM_BOT_TOKEN="<your-telegram-bot-token>"
+```
+
+Start or restart mama:
+
+```bash
+docker build -f docker/mama-sandbox.Dockerfile -t mama-sandbox:tools .
+mama --sandbox=image:mama-sandbox:tools /path/to/workspace
+```
+
+Then in Telegram run:
+
+```text
+/login
+```
+
+Then choose `OAuth login` and `GitHub` on the login page.

--- a/docs/oauth/google-workspace.md
+++ b/docs/oauth/google-workspace.md
@@ -1,0 +1,92 @@
+# Google Workspace CLI OAuth Setup for mama
+
+This guide covers the server-side OAuth flow for `mama /login` when you want to provision
+`googleworkspace/cli` credentials inside each user's sandbox.
+
+This flow stores an `authorized_user` JSON file in the user's vault secret store and mounts it to:
+
+```text
+/root/.config/gws/credentials.json
+```
+
+## 1) Create a Google OAuth client for mama
+
+Open Google Cloud Console:
+
+- Credentials: `https://console.cloud.google.com/apis/credentials`
+
+Create an OAuth client with these settings:
+
+- Client type: `Web application`
+- Authorized redirect URI: `<YOUR_MOM_LINK_URL>/oauth/callback`
+
+Example:
+
+- `MOM_LINK_URL=https://mama.example.com`
+- redirect URI: `https://mama.example.com/oauth/callback`
+
+If your app is in testing mode, also add each user under:
+
+- OAuth consent screen -> `Test users`
+
+Without that, Google will reject login with an access-blocked error.
+
+## 2) Set mama environment variables
+
+Set these in the same runtime environment that starts `mama`:
+
+```bash
+export MOM_LINK_URL="https://your-public-domain"
+export GOOGLE_WORKSPACE_CLI_CLIENT_ID="<your-google-oauth-client-id>"
+export GOOGLE_WORKSPACE_CLI_CLIENT_SECRET="<your-google-oauth-client-secret>"
+```
+
+Optional: override the default scope set used by the built-in `Google Workspace CLI` login option:
+
+```bash
+export MOM_GOOGLE_WORKSPACE_CLI_OAUTH_SCOPES="https://www.googleapis.com/auth/drive https://mail.google.com/ https://www.googleapis.com/auth/calendar"
+```
+
+If unset, mama uses a built-in multi-service scope set for common Workspace APIs.
+
+Start or restart mama:
+
+```bash
+docker build -f docker/mama-sandbox.Dockerfile -t mama-sandbox:tools .
+mama --sandbox=image:mama-sandbox:tools /path/to/workspace
+```
+
+## 3) Run `/login`
+
+In Slack, Telegram, or Discord:
+
+```text
+/login
+```
+
+Then choose:
+
+- `OAuth login`
+- `Google Workspace CLI`
+
+After consent succeeds, mama writes a credential file like:
+
+```json
+{
+  "client_id": "...",
+  "client_secret": "...",
+  "refresh_token": "...",
+  "type": "authorized_user"
+}
+```
+
+That file is stored in the user's vault secret store and mounted into the sandbox at:
+
+```text
+/root/.config/gws/credentials.json
+```
+
+## Notes
+
+- This is different from the local `gws auth login` flow documented in the `googleworkspace/cli` repo. That local flow commonly uses a desktop app client and localhost callback. mama needs a web callback because the browser returns to `MOM_LINK_URL/oauth/callback`.
+- If Google does not return a `refresh_token`, revoke the app's prior consent and retry `/login`. mama requests `access_type=offline` and `prompt=consent`, but Google can still suppress refresh token reuse in some cases.

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -40,8 +40,8 @@ export interface ChatAdapter {
  */
 export interface BotEvent {
   type: string;
-  /** Platform-specific channel/chat identifier */
-  channel: string;
+  /** Internal conversation identifier used by the shared runtime */
+  conversationId: string;
   /** Message timestamp or ID as string */
   ts: string;
   /** Parent message ID for threaded replies (optional) */
@@ -52,7 +52,7 @@ export interface BotEvent {
   text: string;
   /** Downloaded attachments */
   attachments?: { name: string; localPath: string }[];
-  /** Platform-computed session key; overrides default channel:thread_ts computation */
+  /** Platform-computed session key; overrides default conversation:thread_ts computation */
   sessionKey?: string;
 }
 
@@ -62,8 +62,8 @@ export interface BotEvent {
  */
 export interface Bot {
   start(): Promise<void>;
-  postMessage(channel: string, text: string): Promise<string>;
-  updateMessage(channel: string, ts: string, text: string): Promise<void>;
+  postMessage(conversationId: string, text: string): Promise<string>;
+  updateMessage(conversationId: string, ts: string, text: string): Promise<void>;
   enqueueEvent(event: BotEvent): boolean;
   getPlatformInfo(): PlatformInfo;
 }
@@ -92,18 +92,19 @@ export interface BotHandler {
   isRunning(sessionKey: string): boolean;
   getRunningSessions(): RunningSession[];
   handleEvent(event: BotEvent, bot: Bot, adapters: BotAdapters, isEvent?: boolean): Promise<void>;
-  handleStop(sessionKey: string, channelId: string, bot: Bot): Promise<void>;
+  handleStop(sessionKey: string, conversationId: string, bot: Bot): Promise<void>;
   /** Force stop a running session (bypass normal stop mechanism) */
   forceStop(sessionKey: string): void;
   /** Reset a session: abort if running, delete history, remove from cache */
-  handleNew(sessionKey: string, channelId: string, bot: Bot): Promise<void>;
+  handleNew(sessionKey: string, conversationId: string, bot: Bot): Promise<void>;
   /** Handle credential onboarding for a user login command. */
   handleLogin(
     platform: string,
     platformUserId: string,
-    channelId: string,
+    conversationId: string,
     bot: Bot,
     commandText: string,
+    isPrivateConversation: boolean,
   ): Promise<void>;
 }
 

--- a/src/adapters/discord/bot.ts
+++ b/src/adapters/discord/bot.ts
@@ -17,6 +17,7 @@ import { basename, join } from "path";
 import type { Bot, BotEvent, BotHandler, PlatformInfo } from "../../adapter.js";
 import { parseLoginCommand } from "../../login.js";
 import * as log from "../../log.js";
+import { formatAlreadyWorking, formatNothingRunning } from "../../ui-copy.js";
 import { createDiscordAdapters } from "./context.js";
 
 // ============================================================================
@@ -109,27 +110,32 @@ export class DiscordBot implements Bot {
     });
   }
 
-  async postMessage(channel: string, text: string): Promise<string> {
-    const ch = await this.fetchTextChannel(channel);
+  async postMessage(conversationId: string, text: string): Promise<string> {
+    const ch = await this.fetchTextChannel(conversationId);
     const msg = await ch.send(text);
     return msg.id;
   }
 
-  async updateMessage(channel: string, ts: string, text: string): Promise<void> {
-    await this.updateMessageRaw(channel, ts, text);
+  async updateMessage(conversationId: string, ts: string, text: string): Promise<void> {
+    await this.updateMessageRaw(conversationId, ts, text);
   }
 
   enqueueEvent(event: BotEvent): boolean {
-    const queue = this.getQueue(event.channel);
+    const queue = this.getQueue(event.conversationId);
     if (queue.size() >= 5) {
       log.logWarning(
-        `Event queue full for ${event.channel}, discarding: ${event.text.substring(0, 50)}`,
+        `Event queue full for ${event.conversationId}, discarding: ${event.text.substring(0, 50)}`,
       );
       return false;
     }
-    log.logInfo(`Enqueueing event for ${event.channel}: ${event.text.substring(0, 50)}`);
+    log.logInfo(`Enqueueing event for ${event.conversationId}: ${event.text.substring(0, 50)}`);
     queue.enqueue(() => {
-      const adapters = createDiscordAdapters(event as DiscordEvent, this, true);
+      const discordEvent: DiscordEvent = {
+        ...event,
+        type: "mention",
+        conversationId: event.conversationId,
+      };
+      const adapters = createDiscordAdapters(discordEvent, this, true);
       return this.handler.handleEvent(event, this, adapters, true);
     });
     return true;
@@ -211,9 +217,9 @@ export class DiscordBot implements Bot {
   }
 
   logToFile(channelId: string, entry: object): void {
-    const dir = join(this.workingDir, channelId);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    appendFileSync(join(dir, "log.jsonl"), `${JSON.stringify(entry)}\n`);
+    const channelDir = join(this.workingDir, channelId);
+    if (!existsSync(channelDir)) mkdirSync(channelDir, { recursive: true });
+    appendFileSync(join(channelDir, "log.jsonl"), `${JSON.stringify(entry)}\n`);
   }
 
   logBotResponse(channelId: string, text: string, ts: string): void {
@@ -251,7 +257,7 @@ export class DiscordBot implements Bot {
       const sanitizedName = attachment.name.replace(/[^a-zA-Z0-9._-]/g, "_");
       const filename = `${ts}_${sanitizedName}`;
       const localPath = `${channelId}/attachments/${filename}`;
-      const fullDir = join(this.workingDir, channelId, "attachments");
+      const attachmentsDir = join(this.workingDir, channelId, "attachments");
 
       result.push({
         name: attachment.name,
@@ -259,7 +265,7 @@ export class DiscordBot implements Bot {
       });
 
       // Download in background (fire and forget)
-      this.downloadAttachment(fullDir, filename, attachment.url).catch((err) => {
+      this.downloadAttachment(attachmentsDir, filename, attachment.url).catch((err) => {
         log.logWarning(`Failed to download Discord attachment`, `${filename}: ${err}`);
       });
     }
@@ -270,8 +276,12 @@ export class DiscordBot implements Bot {
   /**
    * Download an attachment from URL to local file
    */
-  private async downloadAttachment(dir: string, filename: string, url: string): Promise<void> {
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  private async downloadAttachment(
+    attachmentsDir: string,
+    filename: string,
+    url: string,
+  ): Promise<void> {
+    if (!existsSync(attachmentsDir)) mkdirSync(attachmentsDir, { recursive: true });
 
     try {
       const response = await fetch(url);
@@ -280,7 +290,7 @@ export class DiscordBot implements Bot {
       }
 
       const buffer = await response.arrayBuffer();
-      writeFileSync(join(dir, filename), Buffer.from(buffer));
+      writeFileSync(join(attachmentsDir, filename), Buffer.from(buffer));
     } catch (err) {
       throw new Error(`Download failed: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -363,7 +373,7 @@ export class DiscordBot implements Bot {
 
       const event: DiscordEvent = {
         type: isDM ? "dm" : "mention",
-        channel: channelId,
+        conversationId: channelId,
         ts: msgId,
         thread_ts: threadTs,
         user: userId,
@@ -388,19 +398,19 @@ export class DiscordBot implements Bot {
         if (this.handler.isRunning(sessionKey)) {
           this.handler.handleStop(sessionKey, channelId, this);
         } else {
-          await this.postMessage(channelId, "_Nothing running_");
+          await this.postMessage(channelId, formatNothingRunning("discord"));
         }
         return;
       }
 
       // Handle login command
       if (parseLoginCommand(cleanedText)) {
-        await this.handler.handleLogin("discord", userId, channelId, this, cleanedText);
+        await this.handler.handleLogin("discord", userId, channelId, this, cleanedText, isDM);
         return;
       }
 
       if (this.handler.isRunning(sessionKey)) {
-        await this.postMessage(channelId, "_Already working. Say `stop` to cancel._");
+        await this.postMessage(channelId, formatAlreadyWorking("discord", "stop"));
       } else {
         this.getQueue(sessionKey).enqueue(() => {
           const adapters = createDiscordAdapters(event, this, false);

--- a/src/adapters/discord/context.ts
+++ b/src/adapters/discord/context.ts
@@ -36,7 +36,7 @@ export function createDiscordAdapters(
 
   const message: ChatMessage = {
     id: event.ts,
-    sessionKey: event.sessionKey ?? `${event.channel}:${event.thread_ts ?? event.ts}`,
+    sessionKey: event.sessionKey ?? `${event.conversationId}:${event.thread_ts ?? event.ts}`,
     userId: event.user,
     userName: event.userName,
     text: event.text,
@@ -74,20 +74,24 @@ export function createDiscordAdapters(
           );
 
           if (messageId !== null) {
-            await bot.updateMessageRaw(event.channel, messageId, displayText);
+            await bot.updateMessageRaw(event.conversationId, messageId, displayText);
           } else {
             stopTyping();
             if (isThreaded && event.thread_ts) {
-              messageId = await bot.postInThread(event.channel, event.thread_ts, displayText);
+              messageId = await bot.postInThread(
+                event.conversationId,
+                event.thread_ts,
+                displayText,
+              );
             } else if (isRootEvent) {
-              messageId = await bot.postMessage(event.channel, displayText);
+              messageId = await bot.postMessage(event.conversationId, displayText);
             } else {
-              messageId = await bot.postReply(event.channel, event.ts, displayText);
+              messageId = await bot.postReply(event.conversationId, event.ts, displayText);
             }
           }
 
           if (messageId !== null) {
-            bot.logBotResponse(event.channel, text, messageId);
+            bot.logBotResponse(event.conversationId, text, messageId);
           }
         } catch (err) {
           log.logWarning("Discord respond error", err instanceof Error ? err.message : String(err));
@@ -103,15 +107,19 @@ export function createDiscordAdapters(
           const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
 
           if (messageId !== null) {
-            await bot.updateMessageRaw(event.channel, messageId, displayText);
+            await bot.updateMessageRaw(event.conversationId, messageId, displayText);
           } else {
             stopTyping();
             if (isThreaded && event.thread_ts) {
-              messageId = await bot.postInThread(event.channel, event.thread_ts, displayText);
+              messageId = await bot.postInThread(
+                event.conversationId,
+                event.thread_ts,
+                displayText,
+              );
             } else if (isRootEvent) {
-              messageId = await bot.postMessage(event.channel, displayText);
+              messageId = await bot.postMessage(event.conversationId, displayText);
             } else {
-              messageId = await bot.postReply(event.channel, event.ts, displayText);
+              messageId = await bot.postReply(event.conversationId, event.ts, displayText);
             }
           }
         } catch (err) {
@@ -130,9 +138,9 @@ export function createDiscordAdapters(
     setTyping: async (isTyping: boolean) => {
       if (isTyping && typingInterval === null) {
         // Send immediately and repeat every 8s (Discord clears indicator after ~10s)
-        bot.sendTyping(event.channel).catch(() => {});
+        bot.sendTyping(event.conversationId).catch(() => {});
         typingInterval = setInterval(() => {
-          bot.sendTyping(event.channel).catch(() => {});
+          bot.sendTyping(event.conversationId).catch(() => {});
         }, 8000);
       } else if (!isTyping) {
         stopTyping();
@@ -146,7 +154,7 @@ export function createDiscordAdapters(
           if (!working) stopTyping();
           if (messageId !== null) {
             const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
-            await bot.updateMessageRaw(event.channel, messageId, displayText);
+            await bot.updateMessageRaw(event.conversationId, messageId, displayText);
           }
         } catch (err) {
           log.logWarning(
@@ -159,7 +167,7 @@ export function createDiscordAdapters(
     },
 
     uploadFile: async (filePath: string, title?: string) => {
-      await bot.uploadFile(event.channel, filePath, title);
+      await bot.uploadFile(event.conversationId, filePath, title);
     },
 
     deleteResponse: async () => {
@@ -167,7 +175,7 @@ export function createDiscordAdapters(
         stopTyping();
         if (messageId !== null) {
           try {
-            await bot.deleteMessageRaw(event.channel, messageId);
+            await bot.deleteMessageRaw(event.conversationId, messageId);
           } catch {
             // Ignore errors
           }

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -8,6 +8,12 @@ import type { EventsWatcher } from "../../events.js";
 import { parseLoginCommand } from "../../login.js";
 import * as log from "../../log.js";
 import type { Attachment, ChannelStore } from "../../store.js";
+import {
+  PRODUCT_NAME,
+  formatAlreadyWorking,
+  formatForceStopped,
+  formatNothingRunning,
+} from "../../ui-copy.js";
 import { createSlackAdapters } from "./context.js";
 
 // ============================================================================
@@ -111,7 +117,7 @@ export interface SlackContext {
     userName?: string;
     channel: string;
     ts: string;
-    attachments: Array<{ local: string }>;
+    attachments: Array<{ localPath: string }>;
   };
   channelName?: string;
   channels: ChannelInfo[];
@@ -194,6 +200,22 @@ export class SlackBot implements Bot {
     this.eventsWatcher = watcher;
   }
 
+  private toBotEvent(event: SlackEvent): BotEvent {
+    return {
+      type: event.type,
+      conversationId: event.channel,
+      ts: event.ts,
+      thread_ts: event.thread_ts,
+      user: event.user,
+      text: event.text,
+      attachments: event.attachments?.map((attachment) => ({
+        name: attachment.original,
+        localPath: attachment.localPath,
+      })),
+      sessionKey: event.sessionKey,
+    };
+  }
+
   // ==========================================================================
   // Public API
   // ==========================================================================
@@ -232,16 +254,16 @@ export class SlackBot implements Bot {
     return Array.from(this.channels.values());
   }
 
-  async postMessage(channel: string, text: string): Promise<string> {
+  async postMessage(conversationId: string, text: string): Promise<string> {
     return withRetry(async () => {
-      const result = await this.webClient.chat.postMessage({ channel, text });
+      const result = await this.webClient.chat.postMessage({ channel: conversationId, text });
       return result.ts as string;
     });
   }
 
-  async updateMessage(channel: string, ts: string, text: string): Promise<void> {
+  async updateMessage(conversationId: string, ts: string, text: string): Promise<void> {
     return withRetry(async () => {
-      await this.webClient.chat.update({ channel, ts, text });
+      await this.webClient.chat.update({ channel: conversationId, ts, text });
     });
   }
 
@@ -329,9 +351,9 @@ export class SlackBot implements Bot {
    * This is the ONLY place messages are written to log.jsonl
    */
   logToFile(channel: string, entry: object): void {
-    const dir = join(this.workingDir, channel);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    appendFileSync(join(dir, "log.jsonl"), `${JSON.stringify(entry)}\n`);
+    const channelDir = join(this.workingDir, channel);
+    if (!existsSync(channelDir)) mkdirSync(channelDir, { recursive: true });
+    appendFileSync(join(channelDir, "log.jsonl"), `${JSON.stringify(entry)}\n`);
   }
 
   /**
@@ -372,16 +394,25 @@ export class SlackBot implements Bot {
    * Returns true if enqueued, false if queue is full (max 5).
    */
   enqueueEvent(event: BotEvent): boolean {
-    const queue = this.getQueue(event.channel);
+    const queue = this.getQueue(event.conversationId);
     if (queue.size() >= 5) {
       log.logWarning(
-        `Event queue full for ${event.channel}, discarding: ${event.text.substring(0, 50)}`,
+        `Event queue full for ${event.conversationId}, discarding: ${event.text.substring(0, 50)}`,
       );
       return false;
     }
-    log.logInfo(`Enqueueing event for ${event.channel}: ${event.text.substring(0, 50)}`);
+    log.logInfo(`Enqueueing event for ${event.conversationId}: ${event.text.substring(0, 50)}`);
     queue.enqueue(() => {
-      const adapters = createSlackAdapters(event as unknown as SlackEvent, this, true);
+      const slackEvent: SlackEvent = {
+        type: "mention",
+        channel: event.conversationId,
+        ts: event.ts,
+        thread_ts: event.thread_ts,
+        user: event.user,
+        text: event.text,
+        sessionKey: event.sessionKey,
+      };
+      const adapters = createSlackAdapters(slackEvent, this, true);
       return this.handler.handleEvent(event, this, adapters, true);
     });
     return true;
@@ -408,12 +439,12 @@ export class SlackBot implements Bot {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Pi Agent*\nWelcome back! Start a new task or check on running work.",
+          text: `*${PRODUCT_NAME}*\nStart a new task or check on running work.`,
         },
         accessory: {
           type: "image",
           image_url: "https://media1.tenor.com/m/lfDATg4Bhc0AAAAC/happy-cat.gif",
-          alt_text: "Pi Agent",
+          alt_text: PRODUCT_NAME,
         },
       },
     ];
@@ -517,6 +548,12 @@ export class SlackBot implements Bot {
         elements: [{ type: "mrkdwn", text: "_No scheduled jobs._" }],
       });
     } else {
+      const timestampFormatter = new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
       for (const ev of periodicEvents) {
         const channelLabel =
           ev.platform === "slack"
@@ -526,14 +563,7 @@ export class SlackBot implements Bot {
                 return `${ev.platform}:${channelName}`;
               })()
             : `${ev.platform}:${ev.channelId}`;
-        const nextStr = ev.nextRun
-          ? new Date(ev.nextRun).toLocaleString("en-US", {
-              month: "short",
-              day: "numeric",
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : "—";
+        const nextStr = ev.nextRun ? timestampFormatter.format(new Date(ev.nextRun)) : "—";
         blocks.push({
           type: "section",
           text: {
@@ -627,7 +657,7 @@ export class SlackBot implements Bot {
         if (stopTarget) {
           this.handler.handleStop(stopTarget, e.channel, this);
         } else {
-          this.postMessage(e.channel, "_Nothing running_");
+          this.postMessage(e.channel, formatNothingRunning("slack"));
         }
         ack();
         return;
@@ -635,7 +665,7 @@ export class SlackBot implements Bot {
 
       // Check for login command
       if (parseLoginCommand(slackEvent.text)) {
-        this.handler.handleLogin("slack", e.user, e.channel, this, slackEvent.text);
+        void this.handler.handleLogin("slack", e.user, e.channel, this, slackEvent.text, false);
         ack();
         return;
       }
@@ -644,17 +674,12 @@ export class SlackBot implements Bot {
       if (this.handler.isRunning(sessionKey)) {
         this.postMessage(
           e.channel,
-          "_Already working in this thread. Say `@mama stop` to cancel._",
+          formatAlreadyWorking("slack", "@mama stop", { scope: "thread" }),
         );
       } else {
         this.getQueue(sessionKey).enqueue(() => {
           const adapters = createSlackAdapters(slackEvent, this, false);
-          return this.handler.handleEvent(
-            slackEvent as unknown as import("../../adapter.js").BotEvent,
-            this,
-            adapters,
-            false,
-          );
+          return this.handler.handleEvent(this.toBotEvent(slackEvent), this, adapters, false);
         });
       }
 
@@ -729,7 +754,7 @@ export class SlackBot implements Bot {
         if (stopTarget) {
           this.handler.handleStop(stopTarget, e.channel, this);
         } else {
-          this.postMessage(e.channel, "_Nothing running_");
+          this.postMessage(e.channel, formatNothingRunning("slack"));
         }
         ack();
         return;
@@ -743,7 +768,7 @@ export class SlackBot implements Bot {
           if (this.handler.isRunning(dmSessionKey)) {
             this.handler.handleStop(dmSessionKey, e.channel, this); // Don't await, don't queue
           } else {
-            this.postMessage(e.channel, "_Nothing running_");
+            this.postMessage(e.channel, formatNothingRunning("slack"));
           }
           ack();
           return;
@@ -751,22 +776,17 @@ export class SlackBot implements Bot {
 
         // Check for login command
         if (parseLoginCommand(slackEvent.text)) {
-          this.handler.handleLogin("slack", e.user, e.channel, this, slackEvent.text);
+          void this.handler.handleLogin("slack", e.user, e.channel, this, slackEvent.text, true);
           ack();
           return;
         }
 
         if (this.handler.isRunning(dmSessionKey)) {
-          this.postMessage(e.channel, "_Already working. Say `stop` to cancel._");
+          this.postMessage(e.channel, formatAlreadyWorking("slack", "stop"));
         } else {
           this.getQueue(dmSessionKey).enqueue(() => {
             const adapters = createSlackAdapters(slackEvent, this, false);
-            return this.handler.handleEvent(
-              slackEvent as unknown as import("../../adapter.js").BotEvent,
-              this,
-              adapters,
-              false,
-            );
+            return this.handler.handleEvent(this.toBotEvent(slackEvent), this, adapters, false);
           });
         }
       }
@@ -809,7 +829,8 @@ export class SlackBot implements Bot {
       this.handler.forceStop(sessionKey);
 
       // Notify in channel
-      await this.postMessage(channelId, `_🔴 Force stopped by ${userId}_`);
+      const actorLabel = userId ? `<@${userId}>` : "someone";
+      await this.postMessage(channelId, formatForceStopped("slack", actorLabel));
 
       // Refresh home tab
       if (userId) {

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -44,7 +44,10 @@ export function createSlackAdapters(
     userId: event.user,
     userName: user?.userName,
     text: event.text,
-    attachments: (event.attachments || []).map((a) => ({ name: a.local, localPath: a.local })),
+    attachments: (event.attachments || []).map((a) => ({
+      name: a.original,
+      localPath: a.localPath,
+    })),
     threadTs: event.thread_ts,
   };
 

--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -4,6 +4,7 @@ import { Bot as GrammyBot, InputFile } from "grammy";
 import type { Bot, BotEvent, BotHandler, PlatformInfo } from "../../adapter.js";
 import { parseLoginCommand } from "../../login.js";
 import * as log from "../../log.js";
+import { formatAlreadyWorking, formatNothingRunning } from "../../ui-copy.js";
 import { createTelegramAdapters } from "./context.js";
 
 // ============================================================================
@@ -26,6 +27,14 @@ interface MessageContext {
   threadTs: string | undefined;
   sessionKey: string;
 }
+
+const TELEGRAM_COMMANDS = [
+  { command: "start", description: "Show the welcome message" },
+  { command: "help", description: "Show help" },
+  { command: "stop", description: "Stop the current task" },
+  { command: "new", description: "Start a new conversation" },
+  { command: "login", description: "Open your secure login page" },
+] as const;
 
 // ============================================================================
 // Per-channel queue for sequential processing
@@ -94,13 +103,7 @@ export class TelegramBot implements Bot {
     this.botUsername = me.username ?? null;
     this.startupTime = Date.now();
 
-    await this.client.api.setMyCommands([
-      { command: "start", description: "Welcome message" },
-      { command: "help", description: "Show available commands" },
-      { command: "stop", description: "Stop ongoing conversation" },
-      { command: "new", description: "Reset conversation history and start fresh" },
-      { command: "login", description: "Open secure login page for your vault" },
-    ]);
+    await this.client.api.setMyCommands([...TELEGRAM_COMMANDS]);
 
     this.setupEventHandlers();
 
@@ -113,14 +116,14 @@ export class TelegramBot implements Bot {
     log.logInfo(`Telegram bot started as @${this.botUsername ?? this.botUserId}`);
   }
 
-  async postMessage(channel: string, text: string): Promise<string> {
-    const result = await this.postMessageRaw(parseInt(channel), text);
+  async postMessage(conversationId: string, text: string): Promise<string> {
+    const result = await this.postMessageRaw(parseInt(conversationId), text);
     return String(result);
   }
 
-  async updateMessage(channel: string, ts: string, text: string): Promise<void> {
+  async updateMessage(conversationId: string, ts: string, text: string): Promise<void> {
     try {
-      await this.client.api.editMessageText(parseInt(channel), parseInt(ts), text, {
+      await this.client.api.editMessageText(parseInt(conversationId), parseInt(ts), text, {
         parse_mode: "HTML",
       });
     } catch (err) {
@@ -132,16 +135,21 @@ export class TelegramBot implements Bot {
   }
 
   enqueueEvent(event: BotEvent): boolean {
-    const queue = this.getQueue(event.channel);
+    const queue = this.getQueue(event.conversationId);
     if (queue.size() >= 5) {
       log.logWarning(
-        `Event queue full for ${event.channel}, discarding: ${event.text.substring(0, 50)}`,
+        `Event queue full for ${event.conversationId}, discarding: ${event.text.substring(0, 50)}`,
       );
       return false;
     }
-    log.logInfo(`Enqueueing event for ${event.channel}: ${event.text.substring(0, 50)}`);
+    log.logInfo(`Enqueueing event for ${event.conversationId}: ${event.text.substring(0, 50)}`);
     queue.enqueue(() => {
-      const adapters = createTelegramAdapters(event as TelegramEvent, this, true);
+      const telegramEvent: TelegramEvent = {
+        ...event,
+        type: "message",
+        conversationId: event.conversationId,
+      };
+      const adapters = createTelegramAdapters(telegramEvent, this, true);
       return this.handler.handleEvent(event, this, adapters, true);
     });
     return true;
@@ -193,9 +201,9 @@ export class TelegramBot implements Bot {
   }
 
   logToFile(channel: string, entry: object): void {
-    const dir = join(this.workingDir, channel);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    appendFileSync(join(dir, "log.jsonl"), `${JSON.stringify(entry)}\n`);
+    const channelDir = join(this.workingDir, channel);
+    if (!existsSync(channelDir)) mkdirSync(channelDir, { recursive: true });
+    appendFileSync(join(channelDir, "log.jsonl"), `${JSON.stringify(entry)}\n`);
   }
 
   logBotResponse(channel: string, text: string, ts: string): void {
@@ -265,9 +273,9 @@ export class TelegramBot implements Bot {
       const sanitizedName = originalName.replace(/[^a-zA-Z0-9._-]/g, "_");
       const filename = `${ts}_${sanitizedName}`;
       const localPath = `${chatId}/attachments/${filename}`;
-      const fullDir = join(this.workingDir, chatId, "attachments");
+      const attachmentsDir = join(this.workingDir, chatId, "attachments");
 
-      if (!existsSync(fullDir)) mkdirSync(fullDir, { recursive: true });
+      if (!existsSync(attachmentsDir)) mkdirSync(attachmentsDir, { recursive: true });
 
       // Construct download URL
       const downloadUrl = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
@@ -279,7 +287,7 @@ export class TelegramBot implements Bot {
       }
 
       const buffer = await response.arrayBuffer();
-      writeFileSync(join(fullDir, filename), Buffer.from(buffer));
+      writeFileSync(join(attachmentsDir, filename), Buffer.from(buffer));
 
       return {
         name: originalName,
@@ -351,9 +359,10 @@ export class TelegramBot implements Bot {
           "",
           "I'm an AI coding agent. Send me a message or use these commands:",
           "",
-          "/new — Reset conversation history and start fresh",
-          "/stop — Stop the current conversation",
-          "/help — Show available commands",
+          "/new — Start a new conversation",
+          "/stop — Stop the current task",
+          "/help — Show help",
+          "/login — Open your secure login page",
         ].join("\n"),
       );
     });
@@ -366,11 +375,11 @@ export class TelegramBot implements Bot {
         [
           "<b>Available commands:</b>",
           "",
-          "/start — Welcome message",
-          "/help — Show this help",
-          "/stop — Stop ongoing conversation",
-          "/new — Reset conversation history and start fresh",
-          "/login — Open secure login page for your vault",
+          "/start — Show the welcome message",
+          "/help — Show help",
+          "/stop — Stop the current task",
+          "/new — Start a new conversation",
+          "/login — Open your secure login page",
           "",
           "You can also send a regular message to chat with the agent.",
         ].join("\n"),
@@ -383,7 +392,7 @@ export class TelegramBot implements Bot {
       if (this.handler.isRunning(mc.sessionKey)) {
         await this.handler.handleStop(mc.sessionKey, mc.chatId, this);
       } else {
-        await this.postMessage(mc.chatId, "Nothing running.");
+        await this.postMessage(mc.chatId, formatNothingRunning("telegram"));
       }
     });
 
@@ -396,7 +405,14 @@ export class TelegramBot implements Bot {
     this.client.command("login", async (ctx) => {
       const mc = this.extractMessageContext(ctx.message);
       if (!mc) return;
-      await this.handler.handleLogin("telegram", mc.userId, mc.chatId, this, mc.text);
+      await this.handler.handleLogin(
+        "telegram",
+        mc.userId,
+        mc.chatId,
+        this,
+        mc.text,
+        mc.chatType === "private",
+      );
     });
 
     // --- Catch-all for regular (non-command) messages ---
@@ -411,7 +427,14 @@ export class TelegramBot implements Bot {
       const cleanedText = this.cleanText(mc.text);
 
       if (parseLoginCommand(cleanedText)) {
-        await this.handler.handleLogin("telegram", mc.userId, mc.chatId, this, cleanedText);
+        await this.handler.handleLogin(
+          "telegram",
+          mc.userId,
+          mc.chatId,
+          this,
+          cleanedText,
+          mc.chatType === "private",
+        );
         return;
       }
 
@@ -420,7 +443,7 @@ export class TelegramBot implements Bot {
 
       const event: TelegramEvent = {
         type: "message",
-        channel: mc.chatId,
+        conversationId: mc.chatId,
         ts: mc.msgId,
         thread_ts: mc.threadTs,
         sessionKey: mc.sessionKey,
@@ -446,13 +469,13 @@ export class TelegramBot implements Bot {
         if (this.handler.isRunning(mc.sessionKey)) {
           await this.handler.handleStop(mc.sessionKey, mc.chatId, this);
         } else {
-          await this.postMessage(mc.chatId, "Nothing running.");
+          await this.postMessage(mc.chatId, formatNothingRunning("telegram"));
         }
         return;
       }
 
       if (this.handler.isRunning(mc.sessionKey)) {
-        await this.postMessage(mc.chatId, "Already working. Say <code>/stop</code> to cancel.");
+        await this.postMessage(mc.chatId, formatAlreadyWorking("telegram", "/stop"));
       } else {
         this.getQueue(mc.sessionKey).enqueue(() => {
           const adapters = createTelegramAdapters(event, this, false);

--- a/src/adapters/telegram/context.ts
+++ b/src/adapters/telegram/context.ts
@@ -120,7 +120,7 @@ async function notifyError(
   const errMsg = err instanceof Error ? err.message : String(err);
   log.logWarning(`Telegram ${label} error`, errMsg);
   try {
-    await bot.postPlainMessage(chatId, `⚠️ 發送失敗：${errMsg}`);
+    await bot.postPlainMessage(chatId, `Delivery failed: ${errMsg}`);
   } catch {
     // ignore secondary failure
   }
@@ -147,12 +147,12 @@ export function createTelegramAdapters(
     }
   }
 
-  const chatId = parseInt(event.channel);
+  const chatId = parseInt(event.conversationId);
   const replyToId = event.thread_ts ? parseInt(event.thread_ts) : null;
 
   const message: ChatMessage = {
     id: event.ts,
-    sessionKey: event.sessionKey ?? `${event.channel}:${event.thread_ts ?? event.ts}`,
+    sessionKey: event.sessionKey ?? `${event.conversationId}:${event.thread_ts ?? event.ts}`,
     userId: event.user,
     userName: event.userName,
     text: event.text,
@@ -180,7 +180,7 @@ export function createTelegramAdapters(
 
   async function sendOrUpdate(displayText: string): Promise<void> {
     if (messageId !== null) {
-      await bot.updateMessage(event.channel, String(messageId), displayText);
+      await bot.updateMessage(event.conversationId, String(messageId), displayText);
     } else if (replyToId !== null) {
       messageId = await bot.postReply(chatId, replyToId, displayText);
     } else {
@@ -197,7 +197,7 @@ export function createTelegramAdapters(
           const displayText = truncate(accumulatedText, MAX_LENGTH, truncationNote);
           await sendOrUpdate(displayText);
           if (messageId !== null) {
-            bot.logBotResponse(event.channel, text, String(messageId));
+            bot.logBotResponse(event.conversationId, text, String(messageId));
           }
         } catch (err) {
           await notifyError(bot, chatId, "respond", err);
@@ -238,7 +238,7 @@ export function createTelegramAdapters(
     },
 
     uploadFile: async (filePath: string, title?: string) => {
-      await bot.uploadFile(event.channel, filePath, title);
+      await bot.uploadFile(event.conversationId, filePath, title);
     },
 
     deleteResponse: async () => {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -31,7 +31,7 @@ import {
   extractSessionSuffix,
   extractSessionUuid,
   forkThreadSessionFile,
-  getSessionDir,
+  getChannelSessionDir,
   getThreadSessionFile,
   openManagedSession,
   resolveChannelSessionFile,
@@ -44,7 +44,7 @@ import * as Sentry from "@sentry/node";
 export interface PendingMessage {
   userName: string;
   text: string;
-  attachments: { local: string }[];
+  attachments: { localPath: string }[];
   timestamp: number;
 }
 
@@ -71,11 +71,11 @@ function getImageMimeType(filename: string): string | undefined {
   return IMAGE_MIME_TYPES[filename.toLowerCase().split(".").pop() || ""];
 }
 
-async function getMemory(channelDir: string): Promise<string> {
+async function getMemory(conversationDir: string): Promise<string> {
   const parts: string[] = [];
 
-  // Read workspace-level memory (shared across all channels)
-  const workspaceMemoryPath = join(channelDir, "..", "MEMORY.md");
+  // Read workspace-level memory (shared across all conversations)
+  const workspaceMemoryPath = join(conversationDir, "..", "MEMORY.md");
   if (existsSync(workspaceMemoryPath)) {
     try {
       const content = (await readFile(workspaceMemoryPath, "utf-8")).trim();
@@ -87,16 +87,16 @@ async function getMemory(channelDir: string): Promise<string> {
     }
   }
 
-  // Read channel-specific memory
-  const channelMemoryPath = join(channelDir, "MEMORY.md");
-  if (existsSync(channelMemoryPath)) {
+  // Read conversation-specific memory
+  const conversationMemoryPath = join(conversationDir, "MEMORY.md");
+  if (existsSync(conversationMemoryPath)) {
     try {
-      const content = (await readFile(channelMemoryPath, "utf-8")).trim();
+      const content = (await readFile(conversationMemoryPath, "utf-8")).trim();
       if (content) {
-        parts.push(`### Channel-Specific Memory\n${content}`);
+        parts.push(`### Conversation-Specific Memory\n${content}`);
       }
     } catch (error) {
-      log.logWarning("Failed to read channel memory", `${channelMemoryPath}: ${error}`);
+      log.logWarning("Failed to read conversation memory", `${conversationMemoryPath}: ${error}`);
     }
   }
 
@@ -107,13 +107,13 @@ async function getMemory(channelDir: string): Promise<string> {
   return parts.join("\n\n");
 }
 
-function loadMamaSkills(channelDir: string, workspacePath: string): Skill[] {
+function loadMamaSkills(conversationDir: string, workspacePath: string): Skill[] {
   const skillMap = new Map<string, Skill>();
 
-  // channelDir is the host path (e.g., /Users/.../data/C0A34FL8PMH)
+  // conversationDir is the host path (e.g., /Users/.../data/C0A34FL8PMH)
   // hostWorkspacePath is the parent directory on host
   // workspacePath is the container path (e.g., /workspace)
-  const hostWorkspacePath = join(channelDir, "..");
+  const hostWorkspacePath = join(conversationDir, "..");
 
   // Helper to translate host paths to container paths
   const translatePath = (hostPath: string): string => {
@@ -132,9 +132,9 @@ function loadMamaSkills(channelDir: string, workspacePath: string): Skill[] {
     skillMap.set(skill.name, skill);
   }
 
-  // Load channel-specific skills (override workspace skills on collision)
-  const channelSkillsDir = join(channelDir, "skills");
-  for (const skill of loadSkillsFromDir({ dir: channelSkillsDir, source: "channel" }).skills) {
+  // Load conversation-specific skills (override workspace skills on collision)
+  const conversationSkillsDir = join(conversationDir, "skills");
+  for (const skill of loadSkillsFromDir({ dir: conversationSkillsDir, source: "channel" }).skills) {
     skill.filePath = translatePath(skill.filePath);
     skill.baseDir = translatePath(skill.baseDir);
     skillMap.set(skill.name, skill);
@@ -145,18 +145,18 @@ function loadMamaSkills(channelDir: string, workspacePath: string): Skill[] {
 
 function buildSystemPrompt(
   workspacePath: string,
-  channelId: string,
+  conversationId: string,
   currentUserId: string | undefined,
   memory: string,
   sandboxConfig: SandboxConfig,
   platform: PlatformInfo,
   skills: Skill[],
 ): string {
-  const channelPath = `${workspacePath}/${channelId}`;
+  const conversationPath = `${workspacePath}/${conversationId}`;
   const isContainer = sandboxConfig.type === "container" || sandboxConfig.type === "image";
   const isFirecracker = sandboxConfig.type === "firecracker";
 
-  // Format channel mappings
+  // Format platform conversation mappings
   const channelMappings =
     platform.channels.length > 0
       ? platform.channels.map((c) => `${c.id}\t#${c.name}`).join("\n")
@@ -206,18 +206,18 @@ ${envDescription}
 ${workspacePath}/
 ├── MEMORY.md                    # Global memory (all channels)
 ├── skills/                      # Global CLI tools you create
-└── ${channelId}/                # This channel
-    ├── MEMORY.md                # Channel-specific memory
+└── ${conversationId}/           # This conversation
+    ├── MEMORY.md                # Conversation-specific memory
     ├── log.jsonl                # Message history (no tool results)
     ├── attachments/             # User-shared files
     ├── scratch/                 # Your working directory
-    └── skills/                  # Channel-specific tools
+    └── skills/                  # Conversation-specific tools
 
 ## Skills (Custom CLI Tools)
 You can create reusable CLI tools for recurring tasks (email, APIs, data processing, etc.).
 
 ### Creating Skills
-Store in \`${workspacePath}/skills/<name>/\` (global) or \`${channelPath}/skills/<name>/\` (channel-specific).
+Store in \`${workspacePath}/skills/<name>/\` (global) or \`${conversationPath}/skills/<name>/\` (conversation-specific).
 Each skill directory needs a \`SKILL.md\` with YAML frontmatter:
 
 \`\`\`markdown
@@ -244,20 +244,20 @@ You can schedule events that wake you up at specific times or when external thin
 
 **Immediate** - Triggers as soon as harness sees the file. Use in scripts/webhooks to signal external events.
 \`\`\`json
-{"type": "immediate", "platform": "${platform.name}", "channelId": "${channelId}", "userId": "<requester userId>", "text": "New GitHub issue opened"}
+{"type": "immediate", "platform": "${platform.name}", "channelId": "${conversationId}", "userId": "<requester userId>", "text": "New GitHub issue opened"}
 \`\`\`
 
 **One-shot** - Triggers once at a specific time. Use for reminders.
 \`\`\`json
-{"type": "one-shot", "platform": "${platform.name}", "channelId": "${channelId}", "userId": "<requester userId>", "text": "Remind Mario about dentist", "at": "2025-12-15T09:00:00+01:00"}
+{"type": "one-shot", "platform": "${platform.name}", "channelId": "${conversationId}", "userId": "<requester userId>", "text": "Remind Mario about dentist", "at": "2025-12-15T09:00:00+01:00"}
 \`\`\`
 
 **Periodic** - Triggers on a cron schedule. Use for recurring tasks.
 \`\`\`json
-{"type": "periodic", "platform": "${platform.name}", "channelId": "${channelId}", "userId": "<requester userId>", "text": "Check inbox and summarize", "schedule": "0 9 * * 1-5", "timezone": "${Intl.DateTimeFormat().resolvedOptions().timeZone}"}
+{"type": "periodic", "platform": "${platform.name}", "channelId": "${conversationId}", "userId": "<requester userId>", "text": "Check inbox and summarize", "schedule": "0 9 * * 1-5", "timezone": "${Intl.DateTimeFormat().resolvedOptions().timeZone}"}
 \`\`\`
 
-Set \`userId\` to the platform userId of whoever asked for the event (look it up in the user mappings above). When the event fires, tool execution will route to that user's vault so their credentials are available.
+Set \`userId\` to the platform userId of whoever asked for the event (look it up in the user mappings above). When the event fires, tool execution will route to the sandbox vault selection for that user so the right credentials are available. In shared container mode, all events use the container's single shared vault.
 
 ### Cron Format
 \`minute hour day-of-month month day-of-week\`
@@ -278,14 +278,14 @@ Do not use \`bash\` or \`write\` to hand-create JSON files in \`/events\` unless
 
 Current conversation defaults:
 - \`platform\`: \`${platform.name}\`
-- \`channelId\`: \`${channelId}\`
+- \`channelId\`: \`${conversationId}\`
 - \`userId\`: \`${currentUserId ?? "unknown"}\`
 
 Manual file creation is fallback only:
 Use unique filenames to avoid overwriting existing events. Include a timestamp or random suffix:
 \`\`\`bash
 cat > ${workspacePath}/events/dentist-reminder-$(date +%s).json << 'EOF'
-{"type": "one-shot", "platform": "${platform.name}", "channelId": "${channelId}", "userId": "<requester userId>", "text": "Dentist tomorrow", "at": "2025-12-14T09:00:00+01:00"}
+{"type": "one-shot", "platform": "${platform.name}", "channelId": "${conversationId}", "userId": "<requester userId>", "text": "Dentist tomorrow", "at": "2025-12-14T09:00:00+01:00"}
 EOF
 \`\`\`
 Or check if file exists first before creating.
@@ -314,7 +314,7 @@ Maximum 5 events can be queued. Don't create excessive immediate or periodic eve
 ## Memory
 Write to MEMORY.md files to persist context across conversations.
 - Global (${workspacePath}/MEMORY.md): skills, preferences, project info
-- Channel (${channelPath}/MEMORY.md): channel-specific decisions, ongoing work
+- Conversation (${conversationPath}/MEMORY.md): conversation-specific decisions, ongoing work
 Update when you learn something important or when asked to remember something.
 
 ### Current Memory
@@ -422,17 +422,17 @@ function formatToolArgsForSlack(_toolName: string, args: Record<string, unknown>
 // ============================================================================
 
 /**
- * Create a new AgentRunner for a channel.
+ * Create a new AgentRunner for a conversation.
  * Sets up the session and subscribes to events once.
  *
- * Runner caching is handled by the caller (channelStates in main.ts).
+ * Runner caching is handled by the caller (conversationStates in main.ts).
  * This is a stateless factory function.
  */
 export async function createRunner(
   sandboxConfig: SandboxConfig,
   sessionKey: string,
-  channelId: string,
-  channelDir: string,
+  conversationId: string,
+  conversationDir: string,
   workspaceDir: string,
   vaultManager?: VaultManager,
   bindingStore?: UserBindingStore,
@@ -448,7 +448,11 @@ export async function createRunner(
   });
 
   const executionResolver =
-    vaultManager && (vaultManager.isEnabled() || !!bindingStore || sandboxConfig.type === "image")
+    vaultManager &&
+    (vaultManager.isEnabled() ||
+      !!bindingStore ||
+      sandboxConfig.type === "image" ||
+      sandboxConfig.type === "container")
       ? new ActorExecutionResolver(sandboxConfig, vaultManager, bindingStore, provisioner)
       : undefined;
   let activeExecutor: Executor =
@@ -466,7 +470,7 @@ export async function createRunner(
       return activeExecutor.getSandboxConfig();
     },
   };
-  const workspaceBase = channelDir.replace(`/${channelId}`, "");
+  const workspaceBase = conversationDir.replace(`/${conversationId}`, "");
   // Compute workspace path from the current executor. This may change per run.
   const getWorkspacePath = () => executor.getWorkspacePath(workspaceBase);
   let workspacePath = getWorkspacePath();
@@ -481,8 +485,8 @@ export async function createRunner(
   const model = (getModel as any)(agentConfig.provider, agentConfig.model);
 
   // Initial system prompt (will be updated each run with fresh memory/channels/users/skills)
-  const memory = await getMemory(channelDir);
-  const skills = loadMamaSkills(channelDir, workspacePath);
+  const memory = await getMemory(conversationDir);
+  const skills = loadMamaSkills(conversationDir, workspacePath);
   const emptyPlatform: PlatformInfo = {
     name: "slack",
     formattingGuide: "",
@@ -491,7 +495,7 @@ export async function createRunner(
   };
   const systemPrompt = buildSystemPrompt(
     workspacePath,
-    channelId,
+    conversationId,
     undefined,
     memory,
     sandboxConfig,
@@ -499,45 +503,45 @@ export async function createRunner(
     skills,
   );
 
-  // Create session manager and settings manager
-  // Channel sessions use {channelDir}/sessions/current.
-  // Thread sessions use fixed files: {channelDir}/sessions/{threadTs}.jsonl
-  const sessionDir = getSessionDir(channelDir, sessionKey);
+  // Create session manager and settings manager.
+  // Top-level conversation sessions use {conversationDir}/sessions/current.
+  // Thread sessions use fixed files: {conversationDir}/sessions/{threadTs}.jsonl.
+  const sessionDir = getChannelSessionDir(conversationDir);
   const isThread = sessionKey.includes(":");
 
   let sessionManager!: SessionManager;
-  let contextFile!: string;
+  let sessionFile!: string;
 
   if (isThread) {
-    const threadFile = getThreadSessionFile(channelDir, sessionKey);
+    const threadFile = getThreadSessionFile(conversationDir, sessionKey);
     const existing = tryResolveThreadSession(threadFile);
     if (existing) {
-      contextFile = existing;
-      sessionManager = openManagedSession(contextFile, sessionDir, channelDir);
+      sessionFile = existing;
+      sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
     } else {
-      const channelSource = resolveChannelSessionFile(channelDir);
-      if (channelSource) {
+      const conversationSource = resolveChannelSessionFile(conversationDir);
+      if (conversationSource) {
         try {
-          contextFile = forkThreadSessionFile(channelSource, threadFile, channelDir);
-          sessionManager = openManagedSession(contextFile, sessionDir, channelDir);
+          sessionFile = forkThreadSessionFile(conversationSource, threadFile, conversationDir);
+          sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
         } catch {
-          contextFile = createManagedSessionFileAtPath(threadFile, channelDir);
-          sessionManager = openManagedSession(contextFile, sessionDir, channelDir);
+          sessionFile = createManagedSessionFileAtPath(threadFile, conversationDir);
+          sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
         }
       } else {
-        contextFile = createManagedSessionFileAtPath(threadFile, channelDir);
-        sessionManager = openManagedSession(contextFile, sessionDir, channelDir);
+        sessionFile = createManagedSessionFileAtPath(threadFile, conversationDir);
+        sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
       }
     }
   } else {
-    // Channel/DM session: normal resolve
-    contextFile = resolveManagedSessionFile(sessionDir, channelDir);
-    sessionManager = openManagedSession(contextFile, sessionDir, channelDir);
+    // Top-level conversation session: resolve the current session file.
+    sessionFile = resolveManagedSessionFile(sessionDir, conversationDir);
+    sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
   }
-  const sessionUuid = extractSessionUuid(contextFile);
+  const sessionUuid = extractSessionUuid(sessionFile);
   // Used for Slack thread filtering — for non-Slack platforms this is effectively a no-op
   const rootTs = extractSessionSuffix(sessionKey);
-  const settingsManager = createMamaSettingsManager(join(channelDir, ".."));
+  const settingsManager = createMamaSettingsManager(join(conversationDir, ".."));
 
   // Create AuthStorage and ModelRegistry
   // Auth stored outside workspace so agent can't access it
@@ -569,7 +573,7 @@ export async function createRunner(
   if (loadedSession.messages.length > 0) {
     agent.state.messages = loadedSession.messages;
     log.logInfo(
-      `[${channelId}] Loaded ${loadedSession.messages.length} messages from context.jsonl`,
+      `[${conversationId}] Loaded ${loadedSession.messages.length} messages from session file`,
     );
   }
 
@@ -586,14 +590,14 @@ export async function createRunner(
     const extResult = resourceLoader.getExtensions();
     if (extResult.errors.length > 0) {
       for (const err of extResult.errors) {
-        log.logWarning(`[${channelId}] Extension load error: ${err.path}`, err.error);
+        log.logWarning(`[${conversationId}] Extension load error: ${err.path}`, err.error);
       }
     }
     log.logInfo(
-      `[${channelId}] Loaded ${extResult.extensions.length} extension(s): ${extResult.extensions.map((e) => e.path).join(", ")}`,
+      `[${conversationId}] Loaded ${extResult.extensions.length} extension(s): ${extResult.extensions.map((e) => e.path).join(", ")}`,
     );
   } catch (error) {
-    log.logWarning(`[${channelId}] Failed to load resources`, String(error));
+    log.logWarning(`[${conversationId}] Failed to load resources`, String(error));
   }
 
   const baseToolsOverride = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
@@ -613,9 +617,9 @@ export async function createRunner(
   const runState = {
     responseCtx: null as ChatResponseContext | null,
     logCtx: null as {
-      channelId: string;
+      conversationId: string;
       userName?: string;
-      channelName?: string;
+      conversationName?: string;
       sessionId?: string;
     } | null,
     queue: null as {
@@ -646,7 +650,7 @@ export async function createRunner(
     if (!runState.responseCtx || !runState.logCtx || !runState.queue) return;
 
     const { responseCtx, logCtx, queue, pendingTools } = runState;
-    const baseAttrs = { channel_id: logCtx.channelId, session_id: logCtx.sessionId };
+    const baseAttrs = { channel_id: logCtx.conversationId, session_id: logCtx.sessionId };
 
     if (event.type === "tool_execution_start") {
       const agentEvent = event as AgentEvent & { type: "tool_execution_start" };
@@ -881,11 +885,11 @@ export async function createRunner(
       responseCtx: ChatResponseContext,
       platform: PlatformInfo,
     ): Promise<{ stopReason: string; errorMessage?: string }> {
-      // Extract channelId from sessionKey (format: "channelId:rootTs" or just "channelId")
-      const sessionChannel = message.sessionKey.split(":")[0];
+      // Extract conversationId from sessionKey (format: "conversationId:rootTs" or just "conversationId")
+      const sessionConversationId = message.sessionKey.split(":")[0];
 
-      // Ensure channel directory exists
-      await mkdir(channelDir, { recursive: true });
+      // Ensure the conversation directory exists
+      await mkdir(conversationDir, { recursive: true });
 
       // Refresh vault config and clear executor cache so credential changes
       // (env file updates, vault.json edits, token rotations) take effect.
@@ -909,34 +913,34 @@ export async function createRunner(
         : { scope: "top-level" as const, rootTs };
       const syncedCount = await syncLogToSessionManager(
         sessionManager,
-        channelDir,
+        conversationDir,
         message.id,
         undefined,
         threadFilter,
       );
       if (syncedCount > 0) {
-        log.logInfo(`[${channelId}] Synced ${syncedCount} messages from log.jsonl`);
+        log.logInfo(`[${conversationId}] Synced ${syncedCount} messages from log.jsonl`);
       }
 
-      // Reload messages from context.jsonl
-      // This picks up any messages synced above
+      // Reload messages from the session file.
+      // This picks up any messages synced above.
       const reloadedSession = sessionManager.buildSessionContext();
       if (reloadedSession.messages.length > 0) {
         agent.state.messages = reloadedSession.messages;
         log.logInfo(
-          `[${channelId}] Reloaded ${reloadedSession.messages.length} messages from context`,
+          `[${conversationId}] Reloaded ${reloadedSession.messages.length} messages from context`,
         );
       }
 
       // Update system prompt with fresh memory, channel/user info, and skills
       // Use the actual executor's sandbox config, not the initial config,
       // to ensure accurate environment description for the model
-      const memory = await getMemory(channelDir);
-      const skills = loadMamaSkills(channelDir, workspacePath);
+      const memory = await getMemory(conversationDir);
+      const skills = loadMamaSkills(conversationDir, workspacePath);
       const actualSandboxConfig = executor.getSandboxConfig();
       const systemPrompt = buildSystemPrompt(
         workspacePath,
-        channelId,
+        conversationId,
         message.userId,
         memory,
         actualSandboxConfig,
@@ -947,21 +951,26 @@ export async function createRunner(
 
       // Set up file upload function
       setUploadFunction(async (filePath: string, title?: string) => {
-        const hostPath = translateToHostPath(filePath, channelDir, workspacePath, channelId);
+        const hostPath = translateToHostPath(
+          filePath,
+          conversationDir,
+          workspacePath,
+          conversationId,
+        );
         await responseCtx.uploadFile(hostPath, title);
       });
       setEventContext({
         platform: platform.name,
-        channelId,
+        conversationId,
         userId: message.userId,
       });
 
       // Reset per-run state
       runState.responseCtx = responseCtx;
       runState.logCtx = {
-        channelId: sessionChannel,
+        conversationId: sessionConversationId,
         userName: message.userName,
-        channelName: undefined,
+        conversationName: undefined,
         sessionId: sessionUuid,
       };
       runState.pendingTools.clear();
@@ -1037,7 +1046,7 @@ export async function createRunner(
       const nonImagePaths: string[] = [];
 
       for (const a of message.attachments || []) {
-        // a.localPath is the path relative to the workspace (same as old a.local)
+        // a.localPath is the path relative to the workspace
         const fullPath = `${workspacePath}/${a.localPath}`;
         const mimeType = getImageMimeType(a.localPath);
 
@@ -1067,11 +1076,14 @@ export async function createRunner(
         newUserMessage: userMessage,
         imageAttachmentCount: imageAttachments.length,
       };
-      await writeFile(join(channelDir, "last_prompt.jsonl"), JSON.stringify(debugContext, null, 2));
+      await writeFile(
+        join(conversationDir, "last_prompt.jsonl"),
+        JSON.stringify(debugContext, null, 2),
+      );
       addLifecycleBreadcrumb("agent.prompt.sent", {
         provider: model.provider,
         model: agentConfig.model,
-        channel_id: sessionChannel,
+        channel_id: sessionConversationId,
         session_id: sessionUuid,
         attachment_count: message.attachments?.length ?? 0,
         image_attachment_count: imageAttachments.length,
@@ -1153,7 +1165,7 @@ export async function createRunner(
         const runMetricAttributes = metricAttributes({
           provider: model.provider,
           model: agentConfig.model,
-          channel_id: sessionChannel,
+          channel_id: sessionConversationId,
           session_id: sessionUuid,
           stop_reason: runState.stopReason,
           llm_calls: runState.llmCallCount,
@@ -1226,17 +1238,17 @@ export async function createRunner(
  */
 function translateToHostPath(
   containerPath: string,
-  channelDir: string,
+  conversationDir: string,
   workspacePath: string,
-  channelId: string,
+  conversationId: string,
 ): string {
   if (workspacePath === "/workspace") {
-    const prefix = `/workspace/${channelId}/`;
+    const prefix = `/workspace/${conversationId}/`;
     if (containerPath.startsWith(prefix)) {
-      return join(channelDir, containerPath.slice(prefix.length));
+      return join(conversationDir, containerPath.slice(prefix.length));
     }
     if (containerPath.startsWith("/workspace/")) {
-      return join(channelDir, "..", containerPath.slice("/workspace/".length));
+      return join(conversationDir, "..", containerPath.slice("/workspace/".length));
     }
   }
   return containerPath;

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,9 +1,9 @@
 /**
  * Context management for mama.
  *
- * Mama uses two files per channel:
- * - context.jsonl: Structured API messages for LLM context (same format as coding-agent sessions)
- * - log.jsonl: Human-readable channel history for grep (no tool results)
+ * Mama uses two data sources per conversation:
+ * - sessions/*.jsonl: Structured session history for the agent context
+ * - log.jsonl: Human-readable conversation history for grep (no tool results)
  *
  * This module provides:
  * - syncLogToSessionManager: Syncs messages from log.jsonl to SessionManager
@@ -64,11 +64,11 @@ export interface ThreadFilter {
 /**
  * Sync user messages from log.jsonl to SessionManager.
  *
- * This ensures that messages logged while mama wasn't running (channel chatter,
+ * This ensures that messages logged while mama wasn't running (conversation chatter,
  * backfilled messages, messages while busy) are added to the LLM context.
  *
  * @param sessionManager - The SessionManager to sync to
- * @param channelDir - Path to channel directory containing log.jsonl
+ * @param conversationDir - Path to the conversation directory containing log.jsonl
  * @param excludeSlackTs - Slack timestamp of current message (will be added via prompt(), not sync)
  * @param timeRange - Optional time range to filter log entries (defaults to last 10 days)
  * @param threadFilter - Optional thread filter to scope sync to a specific thread
@@ -76,7 +76,7 @@ export interface ThreadFilter {
  */
 export async function syncLogToSessionManager(
   sessionManager: SessionManager,
-  channelDir: string,
+  conversationDir: string,
   excludeSlackTs?: string,
   timeRange?: TimeRange,
   threadFilter?: ThreadFilter,
@@ -85,7 +85,7 @@ export async function syncLogToSessionManager(
   const now = Date.now();
   const defaultStart = now - DEFAULT_SYNC_DAYS * 24 * 60 * 60 * 1000;
   const range = timeRange ?? { start: defaultStart, end: now };
-  const logFile = join(channelDir, "log.jsonl");
+  const logFile = join(conversationDir, "log.jsonl");
 
   if (!existsSync(logFile)) return 0;
 
@@ -125,7 +125,7 @@ export async function syncLogToSessionManager(
       // Thread filtering: only sync messages belonging to this session's thread
       if (threadFilter) {
         if (threadFilter.scope === "top-level") {
-          // Persistent channel/chat sessions should only ingest top-level messages.
+          // Persistent top-level sessions should only ingest top-level messages.
           // This avoids pulling in unrelated replies from other threads.
           if (logMsg.threadTs) {
             continue;

--- a/src/events.ts
+++ b/src/events.ts
@@ -22,7 +22,7 @@ export interface ImmediateEvent {
   type: "immediate";
   platform: string;
   channelId: string;
-  /** Creator userId — routes tool execution to this user's vault when fired. */
+  /** Creator userId — routes tool execution to the sandbox's vault selection for that user when fired. */
   userId?: string;
   text: string;
 }
@@ -447,10 +447,11 @@ export class EventsWatcher {
     // reminders share context, but use a unique synthetic message id because
     // some adapters treat `ts`/message id as a reply target.
     // `user` falls back to "EVENT" when the event file omits a creator; vault
-    // routing then resolves to an empty auto-created entry (no credentials).
+    // routing then resolves to an empty auto-created entry or shared container vault
+    // with no credentials configured yet.
     const syntheticEvent: BotEvent = {
       type: "mention",
-      channel: event.channelId,
+      conversationId: event.channelId,
       user: event.userId ?? "EVENT",
       text: message,
       ts: `event:${filename}`,

--- a/src/link-server.ts
+++ b/src/link-server.ts
@@ -9,12 +9,13 @@ import {
   type OAuthService,
 } from "./login.js";
 import * as log from "./log.js";
+import { PRODUCT_NAME } from "./ui-copy.js";
 import { defaultVaultTargetPath, type VaultManager } from "./vault.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 /** Called after a binding is written, to notify the user in chat */
-export type NotifyFn = (platform: string, channelId: string, message: string) => Promise<void>;
+export type NotifyFn = (platform: string, conversationId: string, message: string) => Promise<void>;
 
 interface LinkCompleteBody {
   token: string;
@@ -88,8 +89,8 @@ export function startLinkServer(
 
       const title = oauthServiceHint ? `${oauthServiceHint.label} OAuth` : "Store Secret";
       const helpText = oauthServiceHint
-        ? `Authorize ${oauthServiceHint.label} and store tokens in your personal vault.`
-        : "Set any environment variable key/value pair in your personal vault.";
+        ? `Authorize ${oauthServiceHint.label} and store tokens in your vault.`
+        : "Set any environment variable key/value pair in your vault.";
       const secretLabel = "Secret value";
       const placeholder = "sk-...";
       const initialEnvKey = "";
@@ -218,6 +219,258 @@ function esc(s: string): string {
   );
 }
 
+const sharedPageStyles = `
+  :root {
+    color-scheme: light;
+    --bg: #f5f1e8;
+    --panel: rgba(255, 255, 255, 0.9);
+    --panel-border: rgba(28, 30, 33, 0.08);
+    --text: #1c1e21;
+    --muted: #5d5f64;
+    --button: #1c1e21;
+    --button-hover: #2c3035;
+    --button-disabled: #8f949b;
+    --field-border: #c9cfd6;
+    --field-focus: #1c1e21;
+    --ok-bg: #dff4e4;
+    --ok-text: #1f5b34;
+    --err-bg: #fde2e2;
+    --err-text: #8a2f2f;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    padding: 32px 20px;
+    display: grid;
+    place-items: center;
+    background:
+      radial-gradient(circle at top, rgba(255, 255, 255, 0.7), transparent 45%),
+      linear-gradient(180deg, #faf7f0 0%, var(--bg) 100%);
+    color: var(--text);
+    font-family:
+      "SF Pro Text",
+      "Segoe UI",
+      system-ui,
+      sans-serif;
+  }
+
+  .shell {
+    width: min(100%, 560px);
+  }
+
+  .card {
+    padding: 28px;
+    border: 1px solid var(--panel-border);
+    border-radius: 20px;
+    background: var(--panel);
+    box-shadow: 0 18px 48px rgba(28, 30, 33, 0.08);
+    backdrop-filter: blur(8px);
+  }
+
+  .eyebrow {
+    margin: 0 0 10px;
+    color: var(--muted);
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin: 0 0 10px;
+    font-size: clamp(1.5rem, 2vw, 1.8rem);
+    line-height: 1.15;
+    text-wrap: balance;
+  }
+
+  p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.98rem;
+    line-height: 1.5;
+  }
+
+  .stack > * + * {
+    margin-top: 14px;
+  }
+
+  .form {
+    margin-top: 24px;
+  }
+
+  .form > * + * {
+    margin-top: 18px;
+  }
+
+  label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 0.92rem;
+    font-weight: 650;
+  }
+
+  input,
+  select,
+  button {
+    font: inherit;
+  }
+
+  input,
+  select {
+    width: 100%;
+    padding: 12px 14px;
+    border: 1px solid var(--field-border);
+    border-radius: 12px;
+    background: #fff;
+    color: var(--text);
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--field-focus);
+    outline-offset: 2px;
+  }
+
+  button {
+    width: 100%;
+    margin-top: 24px;
+    padding: 13px 18px;
+    border: none;
+    border-radius: 12px;
+    background: var(--button);
+    color: #fff;
+    cursor: pointer;
+    transition: background-color 160ms ease;
+  }
+
+  button:hover {
+    background: var(--button-hover);
+  }
+
+  button:disabled {
+    background: var(--button-disabled);
+    cursor: default;
+  }
+
+  .mode {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 22px;
+  }
+
+  .mode label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    padding: 10px 12px;
+    border: 1px solid var(--field-border);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.85);
+    font-weight: 500;
+  }
+
+  .mode input {
+    width: auto;
+    margin: 0;
+  }
+
+  .panel {
+    display: none;
+  }
+
+  .panel.active {
+    display: block;
+  }
+
+  .panel-note {
+    margin-top: 10px;
+    font-size: 0.92rem;
+  }
+
+  .result,
+  .status {
+    margin-top: 20px;
+    padding: 14px 16px;
+    border-radius: 14px;
+    font-size: 0.95rem;
+  }
+
+  .result {
+    display: none;
+  }
+
+  .result.ok,
+  .status.ok {
+    background: var(--ok-bg);
+    color: var(--ok-text);
+  }
+
+  .result.err,
+  .status.err {
+    background: var(--err-bg);
+    color: var(--err-text);
+  }
+
+  .close-note {
+    margin-top: 14px;
+    font-size: 0.92rem;
+  }
+
+  @media (max-width: 640px) {
+    body {
+      padding: 20px 14px;
+    }
+
+    .card {
+      padding: 22px;
+      border-radius: 16px;
+    }
+  }
+`;
+
+function renderPageDocument(title: string, body: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${esc(title)} — ${PRODUCT_NAME}</title>
+  <style>${sharedPageStyles}</style>
+</head>
+<body>
+  <main class="shell">
+    <section class="card">
+      ${body}
+    </section>
+  </main>
+</body>
+</html>`;
+}
+
+function renderStatusPage(
+  title: string,
+  message: string,
+  tone: "ok" | "err",
+  options?: { closeNote?: boolean },
+): string {
+  const closeNote = options?.closeNote ? '<p class="close-note">You can close this tab.</p>' : "";
+  return renderPageDocument(
+    title,
+    `<div class="stack">
+      <p class="eyebrow">${PRODUCT_NAME}</p>
+      <h1>${esc(title)}</h1>
+      <div class="status ${tone}">${esc(message)}</div>
+      ${closeNote}
+    </div>`,
+  );
+}
+
 function renderCredentialPage(
   token: string,
   title: string,
@@ -236,32 +489,10 @@ function renderCredentialPage(
     })
     .join("\n");
 
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Login — mama</title>
-  <style>
-    body { font-family: system-ui, sans-serif; max-width: 520px; margin: 80px auto; padding: 0 20px; color: #1a1a1a; text-align: center; }
-    h1 { font-size: 1.4rem; margin-bottom: 8px; }
-    p { color: #555; font-size: 0.95rem; }
-    label { display: block; margin-top: 20px; margin-bottom: 6px; text-align: left; font-weight: 600; font-size: 0.9rem; }
-    input, select { width: 100%; box-sizing: border-box; padding: 12px; font-size: 1rem; border: 1px solid #ccc; border-radius: 8px; }
-    button { margin-top: 24px; padding: 12px 32px; font-size: 1rem; background: #1a1a1a; color: #fff; border: none; border-radius: 8px; cursor: pointer; }
-    button:hover { background: #333; }
-    button:disabled { background: #999; cursor: default; }
-    #result { margin-top: 20px; padding: 12px; border-radius: 6px; display: none; }
-    #result.ok { background: #d3f9d8; color: #1a4d2e; }
-    #result.err { background: #ffc9c9; color: #5c1a1a; }
-    .mode { margin-top: 20px; text-align: left; }
-    .mode label { display: inline-flex; align-items: center; margin-right: 18px; font-weight: 500; }
-    .mode input { width: auto; margin-right: 6px; }
-    .panel { display: none; }
-    .panel.active { display: block; }
-  </style>
-</head>
-<body>
+  return renderPageDocument(
+    "Login",
+    `<div class="stack">
+  <p class="eyebrow">${PRODUCT_NAME}</p>
   <h1>${esc(title)}</h1>
   <p>Your personal sandbox is already provisioned automatically.</p>
   <p>${esc(helpText)}</p>
@@ -270,21 +501,23 @@ function renderCredentialPage(
     <label><input type="radio" name="mode" value="oauth" ${defaultMode === "oauth" ? "checked" : ""}> OAuth login</label>
   </div>
 
+  <div class="form">
   <div id="api-panel" class="panel">
     <label for="envKey">Environment key</label>
-    <input id="envKey" type="text" placeholder="OPENAI_API_KEY" value="${esc(initialEnvKey)}" autocomplete="off">
+    <input id="envKey" type="text" name="envKey" placeholder="OPENAI_API_KEY" value="${esc(initialEnvKey)}" autocomplete="off">
     <label for="credential">${esc(secretLabel)}</label>
-    <input id="credential" type="password" placeholder="${esc(placeholder)}" autocomplete="off">
+    <input id="credential" type="password" name="credential" placeholder="${esc(placeholder)}" autocomplete="off">
   </div>
 
   <div id="oauth-panel" class="panel">
     <label for="oauthService">OAuth service</label>
-    <select id="oauthService">${oauthOptions}</select>
-    <p style="text-align:left;margin-top:10px">You'll be redirected to the selected service's authorization page.</p>
+    <select id="oauthService" name="oauthService">${oauthOptions}</select>
+    <p class="panel-note">You'll be redirected to the selected service's authorization page.</p>
   </div>
 
   <button id="btn" onclick="connect()">Continue</button>
-  <div id="result"></div>
+  <div id="result" class="result" aria-live="polite"></div>
+  </div>
   <script>
     const envKeyPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -295,7 +528,7 @@ function renderCredentialPage(
     function showResult(message, ok) {
       const result = document.getElementById('result');
       result.style.display = 'block';
-      result.className = ok ? 'ok' : 'err';
+      result.className = ok ? 'result ok' : 'result err';
       result.textContent = message;
     }
 
@@ -375,24 +608,16 @@ function renderCredentialPage(
       }
     }
   </script>
-</body>
-</html>`;
+</div>`,
+  );
 }
 
 function renderErrorPage(message: string): string {
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
-<title>Link Error — mama</title>
-<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;padding:0 20px;color:#1a1a1a}
-.box{background:#ffc9c9;color:#5c1a1a;padding:16px;border-radius:8px}</style>
-</head><body><div class="box">${esc(message)}</div></body></html>`;
+  return renderStatusPage("Login Error", message, "err");
 }
 
 function renderSuccessPage(message: string): string {
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
-<title>Linked — mama</title>
-<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;padding:0 20px;color:#1a1a1a}
-.box{background:#d3f9d8;color:#1a4d2e;padding:16px;border-radius:8px}</style>
-</head><body><div class="box">${esc(message)} You can close this tab.</div></body></html>`;
+  return renderStatusPage("Connected", message, "ok", { closeNote: true });
 }
 
 // ── API-key completion ────────────────────────────────────────────────────────
@@ -443,18 +668,33 @@ async function handleLinkComplete(
     return;
   }
 
-  vaultManager.upsertEnv(linkToken.vaultId, { [envKey]: credential });
+  try {
+    vaultManager.upsertEnv(linkToken.vaultId, { [envKey]: credential });
+  } catch (error) {
+    log.logWarning(
+      `Failed to persist ${envKey} for ${linkToken.platform}/${linkToken.platformUserId}`,
+      error instanceof Error ? error.message : String(error),
+    );
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        error:
+          "Failed to store credential on server. Please fix the server issue and run /login again.",
+      }),
+    );
+    return;
+  }
 
   log.logInfo(
     `Stored ${envKey} for ${linkToken.platform}/${linkToken.platformUserId} in vault:${linkToken.vaultId}`,
   );
 
   res.writeHead(200, { "Content-Type": "application/json" });
-  res.end(JSON.stringify({ ok: true, message: `${envKey} stored successfully in your vault.` }));
+  res.end(JSON.stringify({ ok: true, message: `${envKey} stored successfully in vault.` }));
 
   notify(
     linkToken.platform,
-    linkToken.channelId,
+    linkToken.conversationId,
     `${envKey} stored successfully in vault \`${linkToken.vaultId}\`.`,
   ).catch((err: Error) => {
     log.logWarning("Failed to notify user after credential login", err.message);
@@ -660,18 +900,32 @@ async function handleOAuthCallback(
   }
 
   const storedTargets: string[] = [];
-  if (Object.keys(updates).length > 0) {
-    vaultManager.upsertEnv(linkToken.vaultId, updates);
-    storedTargets.push(...Object.keys(updates).sort());
-  }
-  if (fileOutput?.type === "authorized_user" && refreshToken) {
-    vaultManager.upsertFile(
-      linkToken.vaultId,
-      fileOutput.relativePath,
-      renderAuthorizedUserCredential(clientId, clientSecret, refreshToken),
-      fileOutput.targetPath,
+  try {
+    if (Object.keys(updates).length > 0) {
+      vaultManager.upsertEnv(linkToken.vaultId, updates);
+      storedTargets.push(...Object.keys(updates).sort());
+    }
+    if (fileOutput?.type === "authorized_user" && refreshToken) {
+      vaultManager.upsertFile(
+        linkToken.vaultId,
+        fileOutput.relativePath,
+        renderAuthorizedUserCredential(clientId, clientSecret, refreshToken),
+        fileOutput.targetPath,
+      );
+      if (mountedPath) storedTargets.push(mountedPath);
+    }
+  } catch (error) {
+    log.logWarning(
+      `Failed to persist OAuth credentials for ${linkToken.platform}/${linkToken.platformUserId}`,
+      error instanceof Error ? error.message : String(error),
     );
-    if (mountedPath) storedTargets.push(mountedPath);
+    res.writeHead(500, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(
+      renderErrorPage(
+        "OAuth tokens were received but could not be stored on the server. Fix the server issue and run /login again.",
+      ),
+    );
+    return;
   }
 
   log.logInfo(
@@ -680,7 +934,7 @@ async function handleOAuthCallback(
 
   notify(
     linkToken.platform,
-    linkToken.channelId,
+    linkToken.conversationId,
     `${service.label} OAuth stored (${storedTargets.join(", ")}) in vault \`${linkToken.vaultId}\`.`,
   ).catch((err: Error) => {
     log.logWarning("Failed to notify user after OAuth login", err.message);

--- a/src/link-token.ts
+++ b/src/link-token.ts
@@ -8,8 +8,8 @@ export interface LinkToken {
   platformUserId: string;
   vaultId: string;
   providerId: string;
-  /** Channel/chat to notify when binding completes */
-  channelId: string;
+  /** Conversation to notify when binding completes */
+  conversationId: string;
   expiresAt: number;
   used: boolean;
 }
@@ -28,7 +28,7 @@ export class InMemoryLinkTokenStore {
   create(
     platform: "slack" | "discord" | "telegram",
     platformUserId: string,
-    channelId: string,
+    conversationId: string,
     vaultId: string,
     providerId: string,
   ): LinkToken {
@@ -45,7 +45,7 @@ export class InMemoryLinkTokenStore {
       platformUserId,
       vaultId,
       providerId,
-      channelId,
+      conversationId,
       expiresAt: Date.now() + TTL_MS,
       used: false,
     };

--- a/src/log.ts
+++ b/src/log.ts
@@ -35,9 +35,9 @@ function createGcpStream(): Writable {
 }
 
 export interface LogContext {
-  channelId: string;
+  conversationId: string;
   userName?: string;
-  channelName?: string; // For display like #dev-team vs C16HET4EQ
+  conversationName?: string; // For display like #dev-team vs C16HET4EQ
   sessionId?: string;
 }
 
@@ -70,9 +70,9 @@ export function __resetLoggerForTest(): void {
 }
 
 function ctxFields(ctx: LogContext): Record<string, string> {
-  const out: Record<string, string> = { channel: ctx.channelId };
+  const out: Record<string, string> = { channel: ctx.conversationId };
   if (ctx.userName) out.user = ctx.userName;
-  if (ctx.channelName) out.channelName = ctx.channelName;
+  if (ctx.conversationName) out.channelName = ctx.conversationName;
   if (ctx.sessionId) out.sessionId = ctx.sessionId;
   return out;
 }
@@ -87,12 +87,12 @@ function timestamp(): string {
 
 function formatContext(ctx: LogContext): string {
   const session = ctx.sessionId ? `:${ctx.sessionId}` : "";
-  if (ctx.channelId.startsWith("D")) {
-    return `[DM:${ctx.userName || ctx.channelId}${session}]`;
+  if (ctx.conversationId.startsWith("D")) {
+    return `[DM:${ctx.userName || ctx.conversationId}${session}]`;
   }
-  const channel = ctx.channelName || ctx.channelId;
+  const conversation = ctx.conversationName || ctx.conversationId;
   const user = ctx.userName || "unknown";
-  return `[${channel.startsWith("#") ? channel : `#${channel}`}:${user}${session}]`;
+  return `[${conversation.startsWith("#") ? conversation : `#${conversation}`}:${user}${session}]`;
 }
 
 function truncate(text: string, maxLen: number): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import { type AgentRunner, createRunner } from "./agent.js";
 import {
   createManagedSessionFile,
   createManagedSessionFileAtPath,
-  getSessionDir,
+  getChannelSessionDir,
   getThreadSessionFile,
 } from "./session-store.js";
 import { downloadChannel } from "./download.js";
@@ -27,11 +27,12 @@ import { parseLoginCommand } from "./login.js";
 import { InMemoryLinkTokenStore } from "./link-token.js";
 import { DockerContainerManager } from "./provisioner.js";
 import { SandboxError, parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
+import { formatNothingRunning, formatStopping } from "./ui-copy.js";
 import { FileVaultManager } from "./vault.js";
 import { ensureSettingsFile } from "./config.js";
 import {
   createManagedVaultEntry,
-  ensureImageSandboxVault,
+  ensureSandboxVaultEntry,
   resolveActorVaultKey,
 } from "./vault-routing.js";
 import { addLifecycleBreadcrumb, applyRunScope } from "./sentry.js";
@@ -209,12 +210,20 @@ try {
 
 const vaultManager = new FileVaultManager(stateDir);
 if (vaultManager.isEnabled()) {
-  console.log("  Vault system enabled. Per-user credential routing active.");
+  console.log(
+    sandbox.type === "container"
+      ? "  Vault system enabled. Shared container vault active."
+      : "  Vault system enabled. Per-user credential routing active.",
+  );
 }
 
 const bindingStore = new FileUserBindingStore(stateDir);
 if (bindingStore.isEnabled()) {
-  console.log("  Binding store enabled. Platform user → vault routing active.");
+  console.log(
+    sandbox.type === "container"
+      ? "  Binding store enabled. Shared container mode ignores per-user vault bindings."
+      : "  Binding store enabled. Platform user → vault routing active.",
+  );
 }
 
 const provisioner =
@@ -226,10 +235,10 @@ const linkTokenStore = new InMemoryLinkTokenStore();
 setInterval(() => linkTokenStore.purge(), 5 * 60 * 1000).unref();
 
 // ============================================================================
-// State (per channel)
+// State (per conversation)
 // ============================================================================
 
-interface ChannelState {
+interface ConversationState {
   running: boolean;
   runner: AgentRunner;
   stopRequested: boolean;
@@ -239,7 +248,7 @@ interface ChannelState {
   lastActivityAt?: number;
 }
 
-const channelStates = new Map<string, ChannelState>();
+const conversationStates = new Map<string, ConversationState>();
 
 /** Track in-flight runs for graceful shutdown */
 const inFlightRuns = new Set<Promise<void>>();
@@ -281,9 +290,8 @@ function ensureLoginVault(platform: string, platformUserId: string): string {
     platformUserId,
   );
 
-  if (sandbox.type === "image") {
-    ensureImageSandboxVault(sandbox, vaultManager, platform, platformUserId, vaultId);
-  } else {
+  ensureSandboxVaultEntry(sandbox, vaultManager, platform, platformUserId, vaultId);
+  if (sandbox.type !== "image" && sandbox.type !== "container") {
     vaultManager.addEntry(
       vaultId,
       createManagedVaultEntry(platform, platformUserId, vaultId, false),
@@ -293,18 +301,18 @@ function ensureLoginVault(platform: string, platformUserId: string): string {
   return vaultId;
 }
 
-async function getState(channelId: string, sessionKey?: string): Promise<ChannelState> {
-  const key = sessionKey ?? channelId;
-  let state = channelStates.get(key);
+async function getState(conversationId: string, sessionKey?: string): Promise<ConversationState> {
+  const key = sessionKey ?? conversationId;
+  let state = conversationStates.get(key);
   if (!state) {
-    const channelDir = join(workingDir, channelId);
+    const conversationDir = join(workingDir, conversationId);
     state = {
       running: false,
       runner: await createRunner(
         sandbox,
         key,
-        channelId,
-        channelDir,
+        conversationId,
+        conversationDir,
         workingDir,
         vaultManager,
         bindingStore,
@@ -314,7 +322,7 @@ async function getState(channelId: string, sessionKey?: string): Promise<Channel
       stopRequested: false,
       lastAccessedAt: Date.now(),
     };
-    channelStates.set(key, state);
+    conversationStates.set(key, state);
   } else {
     state.lastAccessedAt = Date.now();
   }
@@ -322,21 +330,21 @@ async function getState(channelId: string, sessionKey?: string): Promise<Channel
 }
 
 /**
- * Evict idle sessions from channelStates to bound memory usage.
+ * Evict idle sessions from conversationStates to bound memory usage.
  * Called after each handleEvent completes.
  */
 function evictIdleSessions(): void {
   const now = Date.now();
 
-  for (const [key, state] of channelStates) {
+  for (const [key, state] of conversationStates) {
     if (!state.running && now - state.lastAccessedAt > IDLE_TIMEOUT_MS) {
-      channelStates.delete(key);
+      conversationStates.delete(key);
     }
   }
 
-  if (channelStates.size > MAX_SESSIONS) {
+  if (conversationStates.size > MAX_SESSIONS) {
     const idleSessions: Array<{ key: string; lastAccessedAt: number }> = [];
-    for (const [key, state] of channelStates) {
+    for (const [key, state] of conversationStates) {
       if (!state.running) {
         idleSessions.push({ key, lastAccessedAt: state.lastAccessedAt });
       }
@@ -344,9 +352,9 @@ function evictIdleSessions(): void {
 
     idleSessions.sort((a, b) => a.lastAccessedAt - b.lastAccessedAt);
 
-    const toEvict = channelStates.size - MAX_SESSIONS;
+    const toEvict = conversationStates.size - MAX_SESSIONS;
     for (let i = 0; i < toEvict && i < idleSessions.length; i++) {
-      channelStates.delete(idleSessions[i].key);
+      conversationStates.delete(idleSessions[i].key);
     }
   }
 }
@@ -357,13 +365,13 @@ function evictIdleSessions(): void {
 
 const handler: BotHandler = {
   isRunning(sessionKey: string): boolean {
-    const state = channelStates.get(sessionKey);
+    const state = conversationStates.get(sessionKey);
     return !!state?.running;
   },
 
   getRunningSessions() {
     const sessions: import("./adapter.js").RunningSession[] = [];
-    for (const [sessionKey, state] of channelStates) {
+    for (const [sessionKey, state] of conversationStates) {
       if (state.running && state.startedAt) {
         // Get current step from runner
         const currentStep = state.runner.getCurrentStep();
@@ -378,20 +386,20 @@ const handler: BotHandler = {
     return sessions;
   },
 
-  async handleStop(sessionKey: string, channelId: string, bot: Bot): Promise<void> {
-    const state = channelStates.get(sessionKey);
+  async handleStop(sessionKey: string, conversationId: string, bot: Bot): Promise<void> {
+    const state = conversationStates.get(sessionKey);
     if (state?.running) {
       state.stopRequested = true;
       state.runner.abort();
-      const ts = await bot.postMessage(channelId, "_Stopping..._");
+      const ts = await bot.postMessage(conversationId, formatStopping(bot));
       state.stopMessageTs = ts;
     } else {
-      await bot.postMessage(channelId, "_Nothing running_");
+      await bot.postMessage(conversationId, formatNothingRunning(bot));
     }
   },
 
   forceStop(sessionKey: string): void {
-    const state = channelStates.get(sessionKey);
+    const state = conversationStates.get(sessionKey);
     if (state?.running) {
       log.logInfo(`[Force Stop] Force stopping session: ${sessionKey}`);
       state.stopRequested = true;
@@ -400,59 +408,86 @@ const handler: BotHandler = {
     }
   },
 
-  async handleNew(sessionKey: string, channelId: string, bot: Bot): Promise<void> {
-    const state = channelStates.get(sessionKey);
+  async handleNew(sessionKey: string, conversationId: string, bot: Bot): Promise<void> {
+    const state = conversationStates.get(sessionKey);
     if (state?.running) {
       state.stopRequested = true;
       state.runner.abort();
     }
 
     // Channel sessions rotate via current pointer. Thread sessions reset in place.
-    const channelDir = join(workingDir, channelId);
+    const conversationDir = join(workingDir, conversationId);
     if (sessionKey.includes(":")) {
-      createManagedSessionFileAtPath(getThreadSessionFile(channelDir, sessionKey), channelDir);
+      createManagedSessionFileAtPath(
+        getThreadSessionFile(conversationDir, sessionKey),
+        conversationDir,
+      );
     } else {
-      createManagedSessionFile(getSessionDir(channelDir, sessionKey), channelDir);
+      createManagedSessionFile(getChannelSessionDir(conversationDir), conversationDir);
     }
 
     // Remove from in-memory cache
-    channelStates.delete(sessionKey);
+    conversationStates.delete(sessionKey);
 
-    log.logInfo(`[${channelId}] Session reset: ${sessionKey}`);
-    await bot.postMessage(channelId, "Conversation reset. Send a new message to start fresh.");
+    log.logInfo(`[${conversationId}] Session reset: ${sessionKey}`);
+    await bot.postMessage(conversationId, "Conversation reset. Send a new message to start fresh.");
   },
 
   async handleLogin(
     platform: string,
     platformUserId: string,
-    channelId: string,
+    conversationId: string,
     bot: Bot,
     commandText: string,
+    isPrivateConversation: boolean,
   ): Promise<void> {
     const parsed = parseLoginCommand(commandText);
     if (!parsed) {
       return;
     }
 
+    if (!isPrivateConversation) {
+      await bot.postMessage(
+        conversationId,
+        "为了保护你的凭证，`/login` 只能在与机器人的私聊中使用。请先私信机器人，再重新执行 `/login`。",
+      );
+      return;
+    }
+
     const baseUrl = normalizeLoginBaseUrl();
     if (!baseUrl) {
       await bot.postMessage(
-        channelId,
+        conversationId,
         "Login is not configured. Set `MOM_LINK_URL` or `MOM_LINK_PORT` on the server.",
       );
       return;
     }
 
-    const vaultId = ensureLoginVault(platform, platformUserId);
+    let vaultId: string;
+    try {
+      vaultId = ensureLoginVault(platform, platformUserId);
+    } catch (error) {
+      log.logWarning(
+        `[${conversationId}] Failed to prepare login vault for ${platform}/${platformUserId}`,
+        error instanceof Error ? error.message : String(error),
+      );
+      await bot.postMessage(
+        conversationId,
+        "Login setup failed on the server. 请稍后重试，或联系管理员检查 vault 存储权限。",
+      );
+      return;
+    }
+
     const loginLabel = "credential";
+    const vaultLabel = sandbox.type === "container" ? "the shared container vault" : "your vault";
     await bot.postMessage(
-      channelId,
-      `Open this link to store ${loginLabel} in your personal vault ` +
+      conversationId,
+      `Open this link to store ${loginLabel} in ${vaultLabel} ` +
         `(expires in 15 minutes):\n${baseUrl}/link?token=${
           linkTokenStore.create(
             platform as "slack" | "discord" | "telegram",
             platformUserId,
-            channelId,
+            conversationId,
             vaultId,
             "",
           ).token
@@ -469,13 +504,13 @@ const handler: BotHandler = {
     // Don't accept new events during shutdown
     if (isShuttingDown) {
       log.logInfo(
-        `[${event.channel}] Rejected event during shutdown: ${event.text.substring(0, 50)}`,
+        `[${event.conversationId}] Rejected event during shutdown: ${event.text.substring(0, 50)}`,
       );
       return;
     }
 
-    const sessionKey = event.sessionKey ?? `${event.channel}:${event.thread_ts ?? event.ts}`;
-    const state = await getState(event.channel, sessionKey);
+    const sessionKey = event.sessionKey ?? `${event.conversationId}:${event.thread_ts ?? event.ts}`;
+    const state = await getState(event.conversationId, sessionKey);
 
     // Start run
     state.running = true;
@@ -483,21 +518,25 @@ const handler: BotHandler = {
     state.startedAt = Date.now();
     state.lastActivityAt = Date.now();
 
-    log.logInfo(`[${event.channel}] Starting run: ${event.text.substring(0, 50)}`);
+    log.logInfo(`[${event.conversationId}] Starting run: ${event.text.substring(0, 50)}`);
 
     // Wrap in-flight run tracking
     Sentry.metrics.count("agent.run.started", 1, {
-      attributes: { channel: event.channel },
+      attributes: { channel: event.conversationId },
     });
     Sentry.metrics.gauge("agent.sessions.active", inFlightRuns.size + 1);
 
     const runPromise = Sentry.startSpan(
-      { name: "agent.run", op: "agent", attributes: { channelId: event.channel, sessionKey } },
+      {
+        name: "agent.run",
+        op: "agent",
+        attributes: { channelId: event.conversationId, sessionKey },
+      },
       async () => {
         return Sentry.withScope(async (scope) => {
           const { message, responseCtx, platform } = adapters;
           applyRunScope(scope, {
-            conversationId: event.channel,
+            conversationId: event.conversationId,
             sessionKey,
             messageId: message.id,
             platform: platform.name,
@@ -507,7 +546,7 @@ const handler: BotHandler = {
             isEvent: _isEvent,
           });
           addLifecycleBreadcrumb("agent.run.started", {
-            channel_id: event.channel,
+            channel_id: event.conversationId,
             platform: platform.name,
             has_attachments: (message.attachments?.length ?? 0) > 0,
           });
@@ -522,20 +561,20 @@ const handler: BotHandler = {
             Sentry.metrics.distribution("agent.run.duration", durationMs, {
               unit: "millisecond",
               attributes: {
-                channel: event.channel,
+                channel: event.conversationId,
                 platform: platform.name,
                 stop_reason: result.stopReason,
               },
             });
             Sentry.metrics.count("agent.run.completed", 1, {
               attributes: {
-                channel: event.channel,
+                channel: event.conversationId,
                 platform: platform.name,
                 stop_reason: result.stopReason,
               },
             });
             addLifecycleBreadcrumb("agent.run.completed", {
-              channel_id: event.channel,
+              channel_id: event.conversationId,
               platform: platform.name,
               stop_reason: result.stopReason,
               duration_ms: durationMs,
@@ -543,15 +582,15 @@ const handler: BotHandler = {
 
             if (result.stopReason === "aborted" && state.stopRequested) {
               if (state.stopMessageTs) {
-                await bot.updateMessage(event.channel, state.stopMessageTs, "_Stopped_");
+                await bot.updateMessage(event.conversationId, state.stopMessageTs, "_Stopped_");
                 state.stopMessageTs = undefined;
               } else {
-                await bot.postMessage(event.channel, "_Stopped_");
+                await bot.postMessage(event.conversationId, "_Stopped_");
               }
             }
           } catch (err) {
             scope.setContext("agent_run_error", {
-              channelId: event.channel,
+              conversationId: event.conversationId,
               sessionKey,
               platform: adapters.platform.name,
               messageId: adapters.message.id,
@@ -559,10 +598,10 @@ const handler: BotHandler = {
             });
             Sentry.captureException(err);
             Sentry.metrics.count("agent.run.errors", 1, {
-              attributes: { channel: event.channel, platform: adapters.platform.name },
+              attributes: { channel: event.conversationId, platform: adapters.platform.name },
             });
             log.logWarning(
-              `[${event.channel}] Run error`,
+              `[${event.conversationId}] Run error`,
               err instanceof Error ? err.message : String(err),
             );
           } finally {
@@ -600,10 +639,15 @@ log.logStartup(workingDir, sandboxDesc);
 
 // Start link callback server if port is configured
 if (MOM_LINK_PORT) {
-  startLinkServer(MOM_LINK_PORT, linkTokenStore, vaultManager, async (platform, channelId, msg) => {
-    const bot = botsByPlatform[platform];
-    if (bot) await bot.postMessage(channelId, msg);
-  });
+  startLinkServer(
+    MOM_LINK_PORT,
+    linkTokenStore,
+    vaultManager,
+    async (platform, conversationId, msg) => {
+      const bot = botsByPlatform[platform];
+      if (bot) await bot.postMessage(conversationId, msg);
+    },
+  );
 }
 
 // Create platform bots

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -8,7 +8,7 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
  * Channel sessions use a current pointer within this directory.
  * Thread sessions are stored as fixed files within the same directory.
  */
-export function getSessionDir(channelDir: string, _sessionKey: string): string {
+export function getChannelSessionDir(channelDir: string): string {
   return join(channelDir, "sessions");
 }
 
@@ -122,13 +122,6 @@ function writeSessionHeader(sessionFile: string, cwd: string, sessionId = random
 }
 
 /**
- * Returns the channel-level session directory: {channelDir}/sessions/
- */
-export function getChannelSessionDir(channelDir: string): string {
-  return join(channelDir, "sessions");
-}
-
-/**
  * Returns the fixed session file path for a Slack thread.
  */
 export function getThreadSessionFile(channelDir: string, sessionKey: string): string {
@@ -167,8 +160,14 @@ function getCurrentSessionPath(sessionDir: string): string | null {
  * Returns null if no current pointer exists or the pointed file has no valid session header.
  */
 export function tryResolveCurrentSession(sessionDir: string): string | null {
-  const fullPath = getCurrentSessionPath(sessionDir);
-  if (fullPath && existsSync(fullPath) && hasSessionHeader(fullPath)) return fullPath;
+  const currentSessionPath = getCurrentSessionPath(sessionDir);
+  if (
+    currentSessionPath &&
+    existsSync(currentSessionPath) &&
+    hasSessionHeader(currentSessionPath)
+  ) {
+    return currentSessionPath;
+  }
   return null;
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,7 +5,7 @@ import * as log from "./log.js";
 
 export interface Attachment {
   original: string; // original filename from uploader
-  local: string; // path relative to working dir (e.g., "C12345/attachments/1732531234567_file.png")
+  localPath: string; // path relative to working dir (e.g., "C12345/attachments/1732531234567_file.png")
 }
 
 export interface LoggedMessage {
@@ -54,11 +54,11 @@ export class ChannelStore {
    * Get or create the directory for a channel/DM
    */
   getChannelDir(channelId: string): string {
-    const dir = join(this.workingDir, channelId);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+    const channelDir = join(this.workingDir, channelId);
+    if (!existsSync(channelDir)) {
+      mkdirSync(channelDir, { recursive: true });
     }
-    return dir;
+    return channelDir;
   }
 
   /**
@@ -96,7 +96,7 @@ export class ChannelStore {
 
       attachments.push({
         original: file.name,
-        local: localPath,
+        localPath,
       });
 
       // Queue for background download
@@ -214,9 +214,9 @@ export class ChannelStore {
     const filePath = join(this.workingDir, localPath);
 
     // Ensure directory exists
-    const dir = join(this.workingDir, localPath.substring(0, localPath.lastIndexOf("/")));
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+    const parentDir = join(this.workingDir, localPath.substring(0, localPath.lastIndexOf("/")));
+    if (!existsSync(parentDir)) {
+      mkdirSync(parentDir, { recursive: true });
     }
 
     const response = await fetch(url, {

--- a/src/tools/event.ts
+++ b/src/tools/event.ts
@@ -33,7 +33,7 @@ const eventSchema = Type.Object({
 
 interface EventToolContext {
   platform: string;
-  channelId: string;
+  conversationId: string;
   userId: string;
 }
 
@@ -83,7 +83,7 @@ export function createEventTool(workspaceDir: string): {
     name: "event",
     label: "event",
     description:
-      "Schedule an immediate, one-shot, or periodic event for the current conversation. This automatically writes to the correct events directory and fills the current platform, channel, and requester userId.",
+      "Schedule an immediate, one-shot, or periodic event for the current conversation. This automatically writes to the correct events directory and fills the current platform, conversation, and requester userId.",
     parameters: eventSchema,
     execute: async (_toolCallId: string, params: EventToolParams, signal?: AbortSignal) => {
       if (signal?.aborted) {
@@ -131,7 +131,7 @@ export function createEventTool(workspaceDir: string): {
 function buildEventPayload(params: EventToolParams, context: EventToolContext): EventPayload {
   const base = {
     platform: context.platform,
-    channelId: context.channelId,
+    channelId: context.conversationId,
     userId: context.userId,
     text: params.text,
   };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,7 +13,7 @@ export function createMamaTools(
 ): {
   tools: AgentTool<any>[];
   setUploadFunction: (fn: (filePath: string, title?: string) => Promise<void>) => void;
-  setEventContext: (context: { platform: string; channelId: string; userId: string }) => void;
+  setEventContext: (context: { platform: string; conversationId: string; userId: string }) => void;
 } {
   const { tool: attachTool, setUploadFunction } = createAttachTool();
   const { tool: eventTool, setEventContext } = createEventTool(workspaceDir);

--- a/src/ui-copy.ts
+++ b/src/ui-copy.ts
@@ -1,0 +1,47 @@
+import type { Bot, PlatformInfo } from "./adapter.js";
+
+export const PRODUCT_NAME = "mama";
+
+type PlatformSource = Bot | PlatformInfo | string;
+
+function resolvePlatformName(source: PlatformSource): string {
+  if (typeof source === "string") return source;
+  if ("getPlatformInfo" in source) return source.getPlatformInfo().name;
+  return source.name;
+}
+
+function supportsHtmlFormatting(platformName: string): boolean {
+  return platformName === "telegram";
+}
+
+function formatItalic(platformName: string, text: string): string {
+  return supportsHtmlFormatting(platformName) ? text : `_${text}_`;
+}
+
+function formatCode(platformName: string, text: string): string {
+  return supportsHtmlFormatting(platformName) ? `<code>${text}</code>` : `\`${text}\``;
+}
+
+export function formatNothingRunning(source: PlatformSource): string {
+  return formatItalic(resolvePlatformName(source), "Nothing running.");
+}
+
+export function formatStopping(source: PlatformSource): string {
+  return formatItalic(resolvePlatformName(source), "Stopping…");
+}
+
+export function formatAlreadyWorking(
+  source: PlatformSource,
+  stopCommand: string,
+  options?: { scope?: "thread" },
+): string {
+  const platformName = resolvePlatformName(source);
+  const command = formatCode(platformName, stopCommand);
+  const prefix =
+    options?.scope === "thread" ? "Already working in this thread." : "Already working.";
+  return formatItalic(platformName, `${prefix} Send ${command} to cancel.`);
+}
+
+export function formatForceStopped(source: PlatformSource, actorLabel: string): string {
+  return formatItalic(resolvePlatformName(source), `Force stopped by ${actorLabel}.`);
+}

--- a/src/vault.test.ts
+++ b/src/vault.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileVaultManager } from "./vault.js";
+
+describe("FileVaultManager", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  function createStateDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "mama-vault-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it("reuses the base firecracker workspace hostPath for user overrides", () => {
+    const stateDir = createStateDir();
+    const vaultsDir = join(stateDir, "vaults");
+    mkdirSync(vaultsDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(vaultsDir, "vault.json"),
+      JSON.stringify(
+        {
+          vaults: {
+            alice: {
+              displayName: "Alice",
+              sandbox: { type: "firecracker", vmId: "alice-vm", sshUser: "root", sshPort: 2222 },
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+      { encoding: "utf-8", mode: 0o600 },
+    );
+
+    const manager = new FileVaultManager(stateDir);
+    expect(
+      manager.getSandboxConfig("alice", {
+        type: "firecracker",
+        vmId: "shared-vm",
+        hostPath: "/real/workspace",
+        sshUser: "root",
+        sshPort: 22,
+      }),
+    ).toEqual({
+      type: "firecracker",
+      vmId: "alice-vm",
+      hostPath: "/real/workspace",
+      sshUser: "root",
+      sshPort: 2222,
+    });
+  });
+
+  it("rejects firecracker overrides when the base sandbox is not firecracker", () => {
+    const stateDir = createStateDir();
+    const vaultsDir = join(stateDir, "vaults");
+    mkdirSync(vaultsDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(vaultsDir, "vault.json"),
+      JSON.stringify(
+        {
+          vaults: {
+            alice: {
+              displayName: "Alice",
+              sandbox: { type: "firecracker", vmId: "alice-vm" },
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+      { encoding: "utf-8", mode: 0o600 },
+    );
+
+    const manager = new FileVaultManager(stateDir);
+    expect(() =>
+      manager.getSandboxConfig("alice", { type: "image", image: "alpine:3.20" }),
+    ).toThrow(/base sandbox is "image"/);
+  });
+
+  it("throws on invalid secret file paths instead of silently succeeding", () => {
+    const stateDir = createStateDir();
+    const manager = new FileVaultManager(stateDir);
+    manager.addEntry("alice", { displayName: "Alice" });
+
+    expect(() => manager.upsertFile("alice", "../credentials.txt", "secret")).toThrow(
+      /invalid relative secret file path/,
+    );
+  });
+});

--- a/test/discord-context.test.ts
+++ b/test/discord-context.test.ts
@@ -32,7 +32,7 @@ function makeDiscordBot(overrides: Partial<DiscordBot> = {}): DiscordBot {
 function makeEvent(overrides: Partial<DiscordEvent> = {}): DiscordEvent {
   return {
     type: "mention",
-    channel: "CH001",
+    conversationId: "CH001",
     ts: "MSG001",
     user: "U001",
     text: "hello",

--- a/test/event-tool.test.ts
+++ b/test/event-tool.test.ts
@@ -22,7 +22,7 @@ describe("event tool", () => {
     const { tool, setEventContext } = createEventTool(workspaceDir);
     setEventContext({
       platform: "telegram",
-      channelId: "574247312",
+      conversationId: "574247312",
       userId: "574247312",
     });
 

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -98,7 +98,7 @@ describe("EventsWatcher platform routing", () => {
     expect(enqueueDiscord).toHaveBeenCalledTimes(1);
     expect(enqueueDiscord).toHaveBeenCalledWith({
       type: "mention",
-      channel: "CH-42",
+      conversationId: "CH-42",
       user: "EVENT",
       text: "[EVENT:deploy-reminder.json:immediate:immediate] Deploy in 10 minutes",
       ts: "event:deploy-reminder.json",

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -8,7 +8,7 @@ import {
   createManagedSessionFileAtPath,
   createNewSessionFile,
   forkThreadSessionFile,
-  getSessionDir,
+  getChannelSessionDir,
   getThreadSessionFile,
   openManagedSession,
   resolveChannelSessionFile,
@@ -83,13 +83,13 @@ function seedManagedSession(
   return sessionFile;
 }
 
-describe("getSessionDir", () => {
+describe("getChannelSessionDir", () => {
   test("channel session key uses shared sessions directory", () => {
-    expect(getSessionDir(channelDir, "C123")).toBe(join(channelDir, "sessions"));
+    expect(getChannelSessionDir(channelDir)).toBe(join(channelDir, "sessions"));
   });
 
   test("thread session key also uses shared sessions directory", () => {
-    expect(getSessionDir(channelDir, "C123:1000.0001")).toBe(join(channelDir, "sessions"));
+    expect(getChannelSessionDir(channelDir)).toBe(join(channelDir, "sessions"));
   });
 });
 
@@ -103,14 +103,14 @@ describe("getThreadSessionFile", () => {
 
 describe("resolveSessionFile", () => {
   test("creates new placeholder session file when none exists", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const file = resolveSessionFile(sessionDir);
     expect(existsSync(file)).toBe(true);
     expect(file).toContain(join(channelDir, "sessions"));
   });
 
   test("returns existing current session file on second call", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const file1 = resolveSessionFile(sessionDir);
     writeFileSync(file1, '{"type":"session","id":"test"}\n');
     const file2 = resolveSessionFile(sessionDir);
@@ -125,7 +125,7 @@ describe("tryResolveThreadSession", () => {
   });
 
   test("ignores empty placeholder files without a valid header", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     mkdirSync(sessionDir, { recursive: true });
     writeFileSync(threadFile, "", "utf-8");
@@ -133,7 +133,7 @@ describe("tryResolveThreadSession", () => {
   });
 
   test("returns fixed thread file path when a valid session exists", () => {
-    const sessionDir = getSessionDir(channelDir, "C123:1000.0001");
+    const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     const created = seedManagedSession(threadFile, sessionDir, channelDir, "thread msg");
     expect(tryResolveThreadSession(threadFile)).toBe(created);
@@ -147,7 +147,7 @@ describe("resolveChannelSessionFile", () => {
   });
 
   test("returns current channel session file when it exists", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const created = createManagedSessionFile(sessionDir, channelDir);
     expect(resolveChannelSessionFile(channelDir)).toBe(created);
   });
@@ -155,7 +155,7 @@ describe("resolveChannelSessionFile", () => {
 
 describe("managed session initialization", () => {
   test("channel session filename uses a short UUID suffix", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const sessionFile = createManagedSessionFile(sessionDir, channelDir);
     const filename = sessionFile.split("/").pop()!;
     const suffix = filename.replace(".jsonl", "").split("_").pop()!;
@@ -164,7 +164,7 @@ describe("managed session initialization", () => {
   });
 
   test("creates a channel session with the provided cwd", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const sessionFile = resolveManagedSessionFile(sessionDir, channelDir);
     const sessionManager = openManagedSession(sessionFile, sessionDir, channelDir);
 
@@ -182,7 +182,7 @@ describe("managed session initialization", () => {
   });
 
   test("creates a fixed-path thread session with the provided cwd", () => {
-    const sessionDir = getSessionDir(channelDir, "C123:1000.0001");
+    const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
     const sessionManager = openManagedSession(threadFile, sessionDir, channelDir);
@@ -202,7 +202,7 @@ describe("managed session initialization", () => {
 
 describe("thread fork", () => {
   test("forked thread session has a different session ID than channel session", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
     const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
     channelSM.appendMessage(makeUserMessage("hello channel"));
@@ -219,7 +219,7 @@ describe("thread fork", () => {
   });
 
   test("second thread access reuses the same fixed thread file", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
     const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
     channelSM.appendMessage(makeUserMessage("channel msg"));
@@ -241,7 +241,7 @@ describe("thread fork", () => {
   });
 
   test("different threads get independent session IDs", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
     const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
     channelSM.appendMessage(makeUserMessage("shared"));
@@ -270,7 +270,7 @@ describe("thread fork", () => {
   });
 
   test("fresh thread file can be created without a channel source", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
     const threadSM = openManagedSession(threadFile, sessionDir, channelDir);
@@ -281,7 +281,7 @@ describe("thread fork", () => {
 
 describe("session-scoped /new reset", () => {
   test("channel /new rotates channel current pointer and keeps thread session intact", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = createManagedSessionFile(sessionDir, channelDir);
     const originalChannel = openManagedSession(channelFile, sessionDir, channelDir);
     originalChannel.appendMessage(makeUserMessage("channel"));
@@ -299,7 +299,7 @@ describe("session-scoped /new reset", () => {
   });
 
   test("thread /new resets the same fixed file and keeps channel plus sibling thread intact", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = createManagedSessionFile(sessionDir, channelDir);
     const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
     channelSM.appendMessage(makeUserMessage("channel"));
@@ -324,7 +324,7 @@ describe("session-scoped /new reset", () => {
 
 describe("persistence across restart", () => {
   test("thread session survives simulated restart via fixed file path", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     seedManagedSession(threadFile, sessionDir, channelDir, "thread specific");
 
@@ -335,7 +335,7 @@ describe("persistence across restart", () => {
 
 describe("placeholder sessions", () => {
   test("createNewSessionFile still updates current pointer for channel placeholder files", () => {
-    const sessionDir = getSessionDir(channelDir, "C123");
+    const sessionDir = getChannelSessionDir(channelDir);
     const placeholder = createNewSessionFile(sessionDir);
     expect(tryResolveCurrentSession(sessionDir)).toBeNull();
     expect(existsSync(placeholder)).toBe(true);

--- a/test/telegram-context.test.ts
+++ b/test/telegram-context.test.ts
@@ -29,7 +29,7 @@ function makeTelegramBot(overrides: Partial<TelegramBot> = {}): TelegramBot {
 function makeEvent(overrides: Partial<TelegramEvent> = {}): TelegramEvent {
   return {
     type: "message",
-    channel: "123456",
+    conversationId: "123456",
     ts: "1001",
     user: "U001",
     text: "hello",


### PR DESCRIPTION
## Summary
- harden the hosted `/login` + OAuth callback flow and add setup docs for GitHub / Google Workspace
- unify the remaining runtime naming around `conversationId` and shared conversation contracts across adapters
- centralize user-facing copy for stop/login responses and tighten related adapter tests

## Validation
- npm test
- npm run build
