### PR TITLE
feat(vault): route execution through actor vaults

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -434,6 +434,7 @@ export async function createRunner(
 
   const executionResolver =
     vaultManager &&
+    sandboxConfig.type !== "host" &&
     (vaultManager.isEnabled() || !!bindingStore || sandboxConfig.type === "container")
       ? new ActorExecutionResolver(sandboxConfig, vaultManager, bindingStore)
       : undefined;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,9 +19,12 @@ import { join } from "path";
 import type { ChatMessage, ChatResponseContext, PlatformInfo } from "./adapter.js";
 import { loadAgentConfig } from "./config.js";
 import { createMamaSettingsManager, syncLogToSessionManager } from "./context.js";
+import { ActorExecutionResolver } from "./execution-resolver.js";
 import * as log from "./log.js";
-import { createExecutor, type SandboxConfig } from "./sandbox.js";
+import type { UserBindingStore } from "./bindings.js";
+import { createExecutor, type Executor, type SandboxConfig } from "./sandbox.js";
 import { addLifecycleBreadcrumb, metricAttributes } from "./sentry.js";
+import type { VaultManager } from "./vault.js";
 import {
   createManagedSessionFileAtPath,
   extractSessionSuffix,
@@ -418,6 +421,8 @@ export async function createRunner(
   channelId: string,
   channelDir: string,
   workspaceDir: string,
+  vaultManager?: VaultManager,
+  bindingStore?: UserBindingStore,
 ): Promise<AgentRunner> {
   const agentConfig = loadAgentConfig(workspaceDir);
 
@@ -427,8 +432,29 @@ export async function createRunner(
     logLevel: agentConfig.logLevel,
   });
 
-  const executor = createExecutor(sandboxConfig);
-  const workspacePath = executor.getWorkspacePath(channelDir.replace(`/${channelId}`, ""));
+  const executionResolver =
+    vaultManager &&
+    (vaultManager.isEnabled() || !!bindingStore || sandboxConfig.type === "container")
+      ? new ActorExecutionResolver(sandboxConfig, vaultManager, bindingStore)
+      : undefined;
+  let activeExecutor: Executor =
+    executionResolver !== undefined
+      ? createExecutor({ type: "host" })
+      : createExecutor(sandboxConfig);
+  const executor: Executor = {
+    exec(command, options) {
+      return activeExecutor.exec(command, options);
+    },
+    getWorkspacePath(hostPath) {
+      return activeExecutor.getWorkspacePath(hostPath);
+    },
+    getSandboxConfig() {
+      return activeExecutor.getSandboxConfig();
+    },
+  };
+  const workspaceBase = channelDir.replace(`/${channelId}`, "");
+  const getWorkspacePath = () => executor.getWorkspacePath(workspaceBase);
+  let workspacePath = getWorkspacePath();
 
   // Create tools (per-runner, with per-runner upload function setter)
   const { tools, setUploadFunction } = createMamaTools(executor);
@@ -845,6 +871,15 @@ export async function createRunner(
       // Ensure channel directory exists
       await mkdir(channelDir, { recursive: true });
 
+      if (executionResolver) {
+        executionResolver.refresh();
+        activeExecutor = await executionResolver.resolve({
+          platform: platform.name,
+          userId: message.userId,
+        });
+        workspacePath = getWorkspacePath();
+      }
+
       // Sync messages from log.jsonl that arrived while we were offline or busy
       // Exclude the current message (it will be added via prompt())
       // Default sync range is 10 days (handled by syncLogToSessionManager)
@@ -880,7 +915,7 @@ export async function createRunner(
         workspacePath,
         channelId,
         memory,
-        sandboxConfig,
+        executor.getSandboxConfig(),
         platform,
         skills,
       );

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,0 +1,118 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+
+export interface UserBinding {
+  platform: "slack" | "discord" | "telegram";
+  platformUserId: string;
+  /** Internal identity (matches vault key in vault.json, or a backend user ID) */
+  internalUserId: string;
+  /** Key in vault.json that holds this user's credentials */
+  vaultId: string;
+  /** Optional future field for explicit execution target override */
+  executionTargetId?: string;
+  status: "pending" | "active" | "revoked";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BindingsConfig {
+  bindings: UserBinding[];
+}
+
+export interface UserBindingStore {
+  /** Resolve active binding for a platform user; returns undefined if not found or revoked */
+  resolve(platform: string, platformUserId: string): UserBinding | undefined;
+  /** List all bindings */
+  list(): UserBinding[];
+  /** Upsert a binding (insert or update by platform + platformUserId) */
+  upsert(binding: UserBinding): void;
+  /** Revoke a binding by setting status to "revoked" */
+  revoke(platform: string, platformUserId: string): void;
+  /** Re-read bindings.json from disk */
+  reload(): void;
+  /** Whether bindings.json exists and was loaded successfully */
+  isEnabled(): boolean;
+}
+
+/** File-backed binding store. Reads and writes `vaults/bindings.json`. */
+export class FileUserBindingStore implements UserBindingStore {
+  private config: BindingsConfig | null = null;
+  private readonly configPath: string;
+
+  constructor(stateDir: string) {
+    this.configPath = join(stateDir, "vaults", "bindings.json");
+    this.reload();
+  }
+
+  reload(): void {
+    if (!existsSync(this.configPath)) {
+      this.config = null;
+      return;
+    }
+    try {
+      const raw = readFileSync(this.configPath, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (!parsed || !Array.isArray(parsed.bindings)) {
+        console.error("bindings: malformed bindings.json — expected { bindings: [...] }");
+        this.config = null;
+        return;
+      }
+      this.config = parsed as BindingsConfig;
+    } catch (err) {
+      console.error(`bindings: failed to read ${this.configPath}:`, err);
+      this.config = null;
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.config !== null;
+  }
+
+  resolve(platform: string, platformUserId: string): UserBinding | undefined {
+    if (!this.config) return undefined;
+    return this.config.bindings.find(
+      (b) =>
+        b.platform === platform && b.platformUserId === platformUserId && b.status === "active",
+    );
+  }
+
+  list(): UserBinding[] {
+    return this.config?.bindings ?? [];
+  }
+
+  upsert(binding: UserBinding): void {
+    if (!this.config) {
+      this.config = { bindings: [] };
+    }
+    const idx = this.config.bindings.findIndex(
+      (b) => b.platform === binding.platform && b.platformUserId === binding.platformUserId,
+    );
+    if (idx >= 0) {
+      this.config.bindings[idx] = binding;
+    } else {
+      this.config.bindings.push(binding);
+    }
+    this.persist();
+  }
+
+  revoke(platform: string, platformUserId: string): void {
+    if (!this.config) return;
+    const binding = this.config.bindings.find(
+      (b) => b.platform === platform && b.platformUserId === platformUserId,
+    );
+    if (binding) {
+      binding.status = "revoked";
+      binding.updatedAt = new Date().toISOString();
+      this.persist();
+    }
+  }
+
+  private persist(): void {
+    try {
+      mkdirSync(dirname(this.configPath), { recursive: true });
+      writeFileSync(this.configPath, JSON.stringify(this.config, null, 2) + "\n", "utf-8");
+    } catch (err) {
+      console.error(`bindings: failed to write ${this.configPath}:`, err);
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,7 @@ export function resolveWorkspaceDirFromArgv(args = process.argv.slice(2)): strin
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
-    if (arg === "--sandbox" || arg === "--download") {
+    if (arg === "--sandbox" || arg === "--download" || arg === "--state-dir") {
       i += 1;
       continue;
     }
@@ -67,7 +67,11 @@ export function resolveWorkspaceDirFromArgv(args = process.argv.slice(2)): strin
       continue;
     }
 
-    if (arg.startsWith("--sandbox=") || arg.startsWith("--download=")) {
+    if (
+      arg.startsWith("--sandbox=") ||
+      arg.startsWith("--download=") ||
+      arg.startsWith("--state-dir=")
+    ) {
       continue;
     }
 

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -1,0 +1,44 @@
+import type { UserBindingStore } from "./bindings.js";
+import { createExecutor, type Executor, type SandboxConfig } from "./sandbox.js";
+import type { VaultManager } from "./vault.js";
+import { ensureSandboxVaultEntry, resolveActorVaultKey } from "./vault-routing.js";
+
+export interface ActorContext {
+  platform: string;
+  userId: string;
+}
+
+export class ActorExecutionResolver {
+  constructor(
+    private baseConfig: SandboxConfig,
+    private vaultManager: VaultManager,
+    private bindingStore?: UserBindingStore,
+  ) {}
+
+  refresh(): void {
+    this.vaultManager.reload();
+    this.bindingStore?.reload();
+  }
+
+  async resolve(context: ActorContext): Promise<Executor> {
+    const vaultKey = resolveActorVaultKey(
+      this.baseConfig,
+      this.vaultManager,
+      this.bindingStore,
+      context.platform,
+      context.userId,
+    );
+    ensureSandboxVaultEntry(
+      this.baseConfig,
+      this.vaultManager,
+      context.platform,
+      context.userId,
+      vaultKey,
+    );
+
+    const vault = this.vaultManager.resolve(vaultKey);
+    const config = this.vaultManager.getSandboxConfig(vaultKey, this.baseConfig);
+    const env = vault && Object.keys(vault.env).length > 0 ? vault.env : undefined;
+    return createExecutor(config, env);
+  }
+}

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -38,7 +38,8 @@ export class ActorExecutionResolver {
 
     const vault = this.vaultManager.resolve(vaultKey);
     const config = this.vaultManager.getSandboxConfig(vaultKey, this.baseConfig);
-    const env = vault && Object.keys(vault.env).length > 0 ? vault.env : undefined;
+    const env =
+      config.type !== "host" && vault && Object.keys(vault.env).length > 0 ? vault.env : undefined;
     return createExecutor(config, env);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,8 @@
 import "./instrument.js";
 
 import { join, resolve } from "path";
-import { readFileSync } from "fs";
+import { mkdirSync, readFileSync, statSync } from "fs";
+import { homedir } from "os";
 import { fileURLToPath } from "url";
 import { dirname, join as pathJoin } from "path";
 import type { Bot, BotAdapters, BotEvent, BotHandler } from "./adapter.js";
@@ -20,7 +21,9 @@ import {
 import { downloadChannel } from "./download.js";
 import { createEventsWatcher } from "./events.js";
 import * as log from "./log.js";
+import { FileUserBindingStore } from "./bindings.js";
 import { SandboxError, parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
+import { FileVaultManager } from "./vault.js";
 import { addLifecycleBreadcrumb, applyRunScope } from "./sentry.js";
 import { ChannelStore } from "./store.js";
 import * as Sentry from "@sentry/node";
@@ -56,6 +59,7 @@ const MOM_DISCORD_BOT_TOKEN = process.env.MOM_DISCORD_BOT_TOKEN;
 
 interface ParsedArgs {
   workingDir?: string;
+  stateDir?: string;
   sandbox: SandboxConfig;
   downloadChannel?: string;
   showVersion?: boolean;
@@ -65,6 +69,7 @@ function parseArgs(): ParsedArgs {
   const args = process.argv.slice(2);
   let sandbox: SandboxConfig = { type: "host" };
   let workingDir: string | undefined;
+  let stateDirArg: string | undefined;
   let downloadChannelId: string | undefined;
   let showVersion = false;
 
@@ -76,6 +81,10 @@ function parseArgs(): ParsedArgs {
       sandbox = parseSandboxArg(arg.slice("--sandbox=".length));
     } else if (arg === "--sandbox") {
       sandbox = parseSandboxArg(args[++i] || "");
+    } else if (arg.startsWith("--state-dir=")) {
+      stateDirArg = arg.slice("--state-dir=".length);
+    } else if (arg === "--state-dir") {
+      stateDirArg = args[++i];
     } else if (arg.startsWith("--download=")) {
       downloadChannelId = arg.slice("--download=".length);
     } else if (arg === "--download") {
@@ -87,10 +96,51 @@ function parseArgs(): ParsedArgs {
 
   return {
     workingDir: workingDir ? resolve(workingDir) : undefined,
+    stateDir: stateDirArg ? resolve(stateDirArg) : undefined,
     sandbox,
     downloadChannel: downloadChannelId,
     showVersion,
   };
+}
+
+const WORLD_WRITABLE_MODE = 0o002;
+
+function ensureSecureStateDir(path: string): void {
+  let stat;
+  try {
+    stat = statSync(path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      mkdirSync(path, { recursive: true, mode: 0o700 });
+      return;
+    }
+    console.error(`Error: cannot access --state-dir ${path}: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  if (!stat.isDirectory()) {
+    console.error(`Error: --state-dir ${path} exists but is not a directory`);
+    process.exit(1);
+  }
+
+  if (stat.mode & WORLD_WRITABLE_MODE) {
+    console.error(
+      `Error: --state-dir ${path} is world-writable (mode ${(stat.mode & 0o777).toString(8)}). ` +
+        `Credentials stored there would be exposed to other local users. ` +
+        `Fix with: chmod 0700 ${path}`,
+    );
+    process.exit(1);
+  }
+
+  const euid = typeof process.geteuid === "function" ? process.geteuid() : undefined;
+  if (euid !== undefined && stat.uid !== euid) {
+    console.error(
+      `Error: --state-dir ${path} is owned by uid ${stat.uid} but mama is running as uid ${euid}. ` +
+        `Run mama as the directory owner or point --state-dir at a directory you own.`,
+    );
+    process.exit(1);
+  }
 }
 
 function handleStartupError(error: unknown): never {
@@ -129,13 +179,15 @@ if (parsedArgs.downloadChannel) {
 // Normal bot mode - require working dir
 if (!parsedArgs.workingDir) {
   console.error(
-    "Usage: mama [--sandbox=host|container:<name>|firecracker:<vm-id>:<host-path>] <working-directory>",
+    "Usage: mama [--state-dir=<dir>] [--sandbox=host|container:<name>|firecracker:<vm-id>:<host-path>] <working-directory>",
   );
   console.error("       mama --download <channel-id>");
   process.exit(1);
 }
 
 const { workingDir, sandbox } = { workingDir: parsedArgs.workingDir, sandbox: parsedArgs.sandbox };
+const stateDir = parsedArgs.stateDir ?? join(homedir(), ".mama");
+ensureSecureStateDir(stateDir);
 
 // Validate platform tokens
 const hasSlack = !!(MOM_SLACK_APP_TOKEN && MOM_SLACK_BOT_TOKEN);
@@ -156,6 +208,24 @@ try {
   await validateSandbox(sandbox);
 } catch (error) {
   handleStartupError(error);
+}
+
+const vaultManager = new FileVaultManager(stateDir);
+if (vaultManager.isEnabled()) {
+  console.log(
+    sandbox.type === "container"
+      ? "  Vault system enabled. Shared container vault active."
+      : "  Vault system enabled. Per-user credential routing active.",
+  );
+}
+
+const bindingStore = new FileUserBindingStore(stateDir);
+if (bindingStore.isEnabled()) {
+  console.log(
+    sandbox.type === "container"
+      ? "  Binding store enabled. Shared container mode ignores per-user vault bindings."
+      : "  Binding store enabled. Platform user → vault routing active.",
+  );
 }
 
 // ============================================================================
@@ -192,7 +262,15 @@ async function getState(channelId: string, sessionKey?: string): Promise<Channel
     const channelDir = join(workingDir, channelId);
     state = {
       running: false,
-      runner: await createRunner(sandbox, key, channelId, channelDir, workingDir),
+      runner: await createRunner(
+        sandbox,
+        key,
+        channelId,
+        channelDir,
+        workingDir,
+        vaultManager,
+        bindingStore,
+      ),
       stopRequested: false,
       lastAccessedAt: Date.now(),
     };

--- a/src/main.ts
+++ b/src/main.ts
@@ -214,8 +214,10 @@ const vaultManager = new FileVaultManager(stateDir);
 if (vaultManager.isEnabled()) {
   console.log(
     sandbox.type === "container"
-      ? "  Vault system enabled. Shared container vault active."
-      : "  Vault system enabled. Per-user credential routing active.",
+      ? "  Vault system enabled. Container vault active."
+      : sandbox.type === "firecracker"
+        ? "  Vault system enabled. Per-user credential routing active."
+        : "  Vault system enabled. Host mode will not inject vault env.",
   );
 }
 
@@ -223,8 +225,10 @@ const bindingStore = new FileUserBindingStore(stateDir);
 if (bindingStore.isEnabled()) {
   console.log(
     sandbox.type === "container"
-      ? "  Binding store enabled. Shared container mode ignores per-user vault bindings."
-      : "  Binding store enabled. Platform user → vault routing active.",
+      ? "  Binding store enabled. Container mode uses the container vault."
+      : sandbox.type === "firecracker"
+        ? "  Binding store enabled. Platform user → vault routing active."
+        : "  Binding store enabled. Host mode will not inject vault env.",
   );
 }
 

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -1,3 +1,6 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type {
   ContainerSandboxConfig,
   ExecOptions,
@@ -8,6 +11,9 @@ import type {
 import { SandboxError } from "./errors.js";
 import { execSimple, shellEscape } from "./utils.js";
 import { HostExecutor } from "./host.js";
+
+const PRIVATE_DIR_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
 
 export function parseContainerSandboxArg(value: string): ContainerSandboxConfig | undefined {
   if (!value.startsWith("container:")) {
@@ -54,17 +60,45 @@ export async function validateContainerSandbox(config: ContainerSandboxConfig): 
   console.log(`  Container '${config.container}' is running.`);
 }
 
+export function buildContainerExecCommand(
+  container: string,
+  command: string,
+  envFilePath?: string,
+): string {
+  const envPart = envFilePath ? `--env-file ${shellEscape(envFilePath)} ` : "";
+  return `docker exec ${envPart}-w /workspace ${container} sh -c ${shellEscape(command)}`;
+}
+
 export class ContainerExecutor implements Executor {
-  constructor(private container: string) {}
+  constructor(
+    private container: string,
+    private env?: Record<string, string>,
+    private ensureReady?: () => Promise<void>,
+  ) {}
 
   async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
-    const dockerCmd = `docker exec ${this.container} sh -c ${shellEscape(command)}`;
+    if (this.ensureReady) {
+      await this.ensureReady();
+    } else {
+      await ensureContainerRunning(this.container);
+    }
+
     const hostExecutor = new HostExecutor();
-    return hostExecutor.exec(dockerCmd, options);
+    const temp = this.env ? createSecureEnvFile(this.env) : undefined;
+    try {
+      const dockerCmd = buildContainerExecCommand(this.container, command, temp?.envFilePath);
+      return await hostExecutor.exec(dockerCmd, options);
+    } finally {
+      temp?.cleanup();
+    }
   }
 
   getWorkspacePath(_hostPath: string): string {
     return "/workspace";
+  }
+
+  getSandboxConfig(): ContainerSandboxConfig {
+    return { type: "container", container: this.container };
   }
 }
 
@@ -72,5 +106,48 @@ export const containerSandboxAdapter: SandboxAdapter<ContainerSandboxConfig> = {
   type: "container",
   parse: parseContainerSandboxArg,
   validate: validateContainerSandbox,
-  createExecutor: (config) => new ContainerExecutor(config.container),
+  createExecutor: (config, env, ensureReady) =>
+    new ContainerExecutor(config.container, env, ensureReady),
 };
+
+async function ensureContainerRunning(container: string): Promise<void> {
+  try {
+    const running = await execSimple("docker", ["inspect", "-f", "{{.State.Running}}", container]);
+    if (running.trim() === "true") {
+      return;
+    }
+    await execSimple("docker", ["start", container]);
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Container "${container}" is not available. ` +
+        `Expected a pre-existing container or image provisioning to keep it running.\n${details}`.trim(),
+    );
+  }
+}
+
+function createSecureEnvFile(env: Record<string, string>): {
+  envFilePath: string;
+  cleanup: () => void;
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), "mama-docker-env-"));
+  chmodSync(tempDir, PRIVATE_DIR_MODE);
+  const envFilePath = join(tempDir, "env.list");
+  const content =
+    Object.entries(env)
+      .map(([key, value]) => `${key}=${sanitizeEnvValue(value)}`)
+      .join("\n") + "\n";
+  writeFileSync(envFilePath, content, { encoding: "utf-8", mode: PRIVATE_FILE_MODE });
+  chmodSync(envFilePath, PRIVATE_FILE_MODE);
+
+  return {
+    envFilePath,
+    cleanup: () => {
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function sanitizeEnvValue(value: string): string {
+  return value.replace(/\r?\n/g, "");
+}

--- a/src/sandbox/firecracker.ts
+++ b/src/sandbox/firecracker.ts
@@ -1,3 +1,4 @@
+import { spawn } from "child_process";
 import type {
   ExecOptions,
   ExecResult,
@@ -6,8 +7,8 @@ import type {
   SandboxAdapter,
 } from "./types.js";
 import { SandboxError } from "./errors.js";
-import { execSimple, shellEscape } from "./utils.js";
 import { HostExecutor } from "./host.js";
+import { execSimple, killProcessTree, shellEscape } from "./utils.js";
 
 export function parseFirecrackerSandboxArg(value: string): FirecrackerSandboxConfig | undefined {
   if (!value.startsWith("firecracker:")) {
@@ -94,28 +95,145 @@ export class FirecrackerExecutor implements Executor {
     private hostPath: string,
     private sshUser: string = "root",
     private sshPort: number = 22,
+    private env?: Record<string, string>,
   ) {}
 
   async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
-    // Use direct SSH to execute command in the Firecracker VM.
-    // The workspace inside the VM is expected to be mounted at /workspace.
-    const sshCmd =
-      this.sshPort === 22
-        ? `ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ${this.sshUser}@${this.vmId} sh -c ${shellEscape(command)}`
-        : `ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -p ${this.sshPort} ${this.sshUser}@${this.vmId} sh -c ${shellEscape(command)}`;
-    const hostExecutor = new HostExecutor();
-    return hostExecutor.exec(sshCmd, options);
+    if (!this.env || Object.keys(this.env).length === 0) {
+      const sshCmd =
+        this.sshPort === 22
+          ? `ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ${this.sshUser}@${this.vmId} sh -c ${shellEscape(command)}`
+          : `ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -p ${this.sshPort} ${this.sshUser}@${this.vmId} sh -c ${shellEscape(command)}`;
+      const hostExecutor = new HostExecutor();
+      return hostExecutor.exec(sshCmd, options);
+    }
+
+    return new Promise((resolve, reject) => {
+      const sshArgs = ["-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=10"];
+      if (this.sshPort !== 22) {
+        sshArgs.push("-p", String(this.sshPort));
+      }
+      sshArgs.push(`${this.sshUser}@${this.vmId}`, "sh", "-se");
+
+      const child = spawn("ssh", sshArgs, {
+        detached: true,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let timedOut = false;
+      let settled = false;
+
+      const timeoutHandle =
+        options?.timeout && options.timeout > 0
+          ? setTimeout(() => {
+              timedOut = true;
+              if (child.pid) killProcessTree(child.pid);
+            }, options.timeout * 1000)
+          : undefined;
+
+      const onAbort = () => {
+        if (child.pid) killProcessTree(child.pid);
+      };
+
+      if (options?.signal) {
+        if (options.signal.aborted) {
+          onAbort();
+        } else {
+          options.signal.addEventListener("abort", onAbort, { once: true });
+        }
+      }
+
+      child.on("error", (error) => {
+        if (settled) return;
+        settled = true;
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        if (options?.signal) {
+          options.signal.removeEventListener("abort", onAbort);
+        }
+        reject(error);
+      });
+
+      child.stdout?.on("data", (data) => {
+        stdout += data.toString();
+        if (stdout.length > 10 * 1024 * 1024) {
+          stdout = stdout.slice(0, 10 * 1024 * 1024);
+        }
+      });
+
+      child.stderr?.on("data", (data) => {
+        stderr += data.toString();
+        if (stderr.length > 10 * 1024 * 1024) {
+          stderr = stderr.slice(0, 10 * 1024 * 1024);
+        }
+      });
+
+      child.stdin?.on("error", (error) => {
+        stderr += `${error.message}\n`;
+      });
+      child.stdin?.end(buildRemoteScript(command, this.env));
+
+      child.on("close", (code) => {
+        if (settled) return;
+        settled = true;
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        if (options?.signal) {
+          options.signal.removeEventListener("abort", onAbort);
+        }
+
+        if (options?.signal?.aborted) {
+          reject(new Error(`${stdout}\n${stderr}\nCommand aborted`.trim()));
+          return;
+        }
+
+        if (timedOut) {
+          reject(
+            new Error(
+              `${stdout}\n${stderr}\nCommand timed out after ${options?.timeout} seconds`.trim(),
+            ),
+          );
+          return;
+        }
+
+        resolve({ stdout, stderr, code: code ?? 0 });
+      });
+    });
   }
 
   getWorkspacePath(_hostPath: string): string {
     return "/workspace";
   }
+
+  getSandboxConfig(): FirecrackerSandboxConfig {
+    return {
+      type: "firecracker",
+      vmId: this.vmId,
+      hostPath: this.hostPath,
+      sshUser: this.sshUser,
+      sshPort: this.sshPort,
+    };
+  }
+}
+
+function buildRemoteScript(command: string, env?: Record<string, string>): string {
+  const exports = env
+    ? Object.entries(env)
+        .map(([key, value]) => {
+          if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+            throw new SandboxError(`Invalid environment variable name for firecracker: ${key}`);
+          }
+          return `export ${key}=${shellEscape(value)}`;
+        })
+        .join("\n") + "\n"
+    : "";
+  return `${exports}${command}\n`;
 }
 
 export const firecrackerSandboxAdapter: SandboxAdapter<FirecrackerSandboxConfig> = {
   type: "firecracker",
   parse: parseFirecrackerSandboxArg,
   validate: validateFirecrackerSandbox,
-  createExecutor: (config) =>
-    new FirecrackerExecutor(config.vmId, config.hostPath, config.sshUser, config.sshPort),
+  createExecutor: (config, env) =>
+    new FirecrackerExecutor(config.vmId, config.hostPath, config.sshUser, config.sshPort, env),
 };

--- a/src/sandbox/host.ts
+++ b/src/sandbox/host.ts
@@ -20,6 +20,8 @@ export async function validateHostSandbox(_config: HostSandboxConfig): Promise<v
 }
 
 export class HostExecutor implements Executor {
+  constructor(private env?: Record<string, string>) {}
+
   async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve, reject) => {
       const shell = process.platform === "win32" ? "cmd" : "sh";
@@ -28,6 +30,7 @@ export class HostExecutor implements Executor {
       const child = spawn(shell, [...shellArgs, command], {
         detached: true,
         stdio: ["ignore", "pipe", "pipe"],
+        ...(this.env && { env: { ...process.env, ...this.env } }),
       });
 
       let stdout = "";
@@ -96,11 +99,15 @@ export class HostExecutor implements Executor {
   getWorkspacePath(hostPath: string): string {
     return hostPath;
   }
+
+  getSandboxConfig(): HostSandboxConfig {
+    return { type: "host" };
+  }
 }
 
 export const hostSandboxAdapter: SandboxAdapter<HostSandboxConfig> = {
   type: "host",
   parse: parseHostSandboxArg,
   validate: validateHostSandbox,
-  createExecutor: () => new HostExecutor(),
+  createExecutor: (_config, env) => new HostExecutor(env),
 };

--- a/src/sandbox/host.ts
+++ b/src/sandbox/host.ts
@@ -20,8 +20,6 @@ export async function validateHostSandbox(_config: HostSandboxConfig): Promise<v
 }
 
 export class HostExecutor implements Executor {
-  constructor(private env?: Record<string, string>) {}
-
   async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve, reject) => {
       const shell = process.platform === "win32" ? "cmd" : "sh";
@@ -30,7 +28,6 @@ export class HostExecutor implements Executor {
       const child = spawn(shell, [...shellArgs, command], {
         detached: true,
         stdio: ["ignore", "pipe", "pipe"],
-        ...(this.env && { env: { ...process.env, ...this.env } }),
       });
 
       let stdout = "";
@@ -109,5 +106,5 @@ export const hostSandboxAdapter: SandboxAdapter<HostSandboxConfig> = {
   type: "host",
   parse: parseHostSandboxArg,
   validate: validateHostSandbox,
-  createExecutor: (_config, env) => new HostExecutor(env),
+  createExecutor: () => new HostExecutor(),
 };

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -32,6 +32,7 @@ export type {
 export { ContainerExecutor, FirecrackerExecutor, HostExecutor };
 export { SandboxError } from "./errors.js";
 export {
+  buildContainerExecCommand,
   containerSandboxAdapter,
   parseContainerSandboxArg,
   validateContainerSandbox,
@@ -87,10 +88,14 @@ export async function validateSandbox(config: SandboxConfig): Promise<void> {
 /**
  * Create an executor that runs commands on host, in a Docker container, or in a Firecracker VM.
  */
-export function createExecutor(config: SandboxConfig): Executor {
+export function createExecutor(
+  config: SandboxConfig,
+  env?: Record<string, string>,
+  ensureReady?: () => Promise<void>,
+): Executor {
   const adapter = sandboxAdapterByType.get(config.type);
   if (!adapter) {
     throw new SandboxError(`Error: Unsupported sandbox type '${config.type}'`);
   }
-  return adapter.createExecutor(config);
+  return adapter.createExecutor(config, env, ensureReady);
 }

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -29,6 +29,11 @@ export interface Executor {
    * Container/Firecracker: returns /workspace.
    */
   getWorkspacePath(hostPath: string): string;
+
+  /**
+   * Get the current sandbox config used by this executor.
+   */
+  getSandboxConfig(): SandboxConfig;
 }
 
 export interface ExecOptions {
@@ -46,5 +51,9 @@ export interface SandboxAdapter<TConfig extends SandboxConfig = SandboxConfig> {
   type: TConfig["type"];
   parse(value: string): TConfig | undefined;
   validate(config: TConfig): Promise<void>;
-  createExecutor(config: TConfig): Executor;
+  createExecutor(
+    config: TConfig,
+    env?: Record<string, string>,
+    ensureReady?: () => Promise<void>,
+  ): Executor;
 }

--- a/src/vault-routing.ts
+++ b/src/vault-routing.ts
@@ -1,0 +1,70 @@
+import type { UserBindingStore } from "./bindings.js";
+import type { SandboxConfig } from "./sandbox.js";
+import type { VaultEntry, VaultManager } from "./vault.js";
+
+export function resolveActorVaultKey(
+  baseConfig: SandboxConfig,
+  vaultManager: Pick<VaultManager, "hasEntry">,
+  bindingStore: Pick<UserBindingStore, "resolve"> | undefined,
+  platform: string,
+  userId: string,
+): string {
+  if (baseConfig.type === "container") {
+    return containerSharedVaultId(baseConfig.container);
+  }
+
+  const binding = bindingStore?.resolve(platform, userId);
+  if (binding) {
+    return binding.vaultId;
+  }
+
+  if (vaultManager.hasEntry(userId)) {
+    return userId;
+  }
+
+  return userId;
+}
+
+export function createManagedVaultEntry(
+  platform: string,
+  userId: string,
+  _vaultKey: string,
+): VaultEntry {
+  return {
+    displayName: `${platform}:${userId}`,
+    platform: asVaultPlatform(platform),
+  };
+}
+
+export function containerSharedVaultId(containerName: string): string {
+  return `container-${containerName}`;
+}
+
+export function createSharedContainerVaultEntry(containerName: string): VaultEntry {
+  return {
+    displayName: `container:${containerName}`,
+  };
+}
+
+export function ensureSandboxVaultEntry(
+  baseConfig: SandboxConfig,
+  vaultManager: Pick<VaultManager, "addEntry">,
+  _platform: string,
+  _userId: string,
+  vaultKey: string,
+): void {
+  if (baseConfig.type === "container") {
+    vaultManager.addEntry(vaultKey, createSharedContainerVaultEntry(baseConfig.container));
+    return;
+  }
+
+  // Host and firecracker modes should not create credential entries merely
+  // because a user sent a message. `/login` owns first-time vault creation.
+}
+
+function asVaultPlatform(platform: string): VaultEntry["platform"] | undefined {
+  if (platform === "slack" || platform === "discord" || platform === "telegram") {
+    return platform;
+  }
+  return undefined;
+}

--- a/test/bindings.test.ts
+++ b/test/bindings.test.ts
@@ -1,0 +1,61 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { FileUserBindingStore } from "../src/bindings.js";
+
+describe("FileUserBindingStore", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mama-bindings-test-${Date.now()}-${Math.random()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("upsert creates vaults directory and bindings.json when missing", () => {
+    const store = new FileUserBindingStore(tmpDir);
+
+    store.upsert({
+      platform: "telegram",
+      platformUserId: "123456",
+      internalUserId: "alice",
+      vaultId: "alice",
+      status: "active",
+      createdAt: "2026-04-09T00:00:00Z",
+      updatedAt: "2026-04-09T00:00:00Z",
+    });
+
+    const configPath = join(tmpDir, "vaults", "bindings.json");
+    expect(existsSync(configPath)).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as {
+      bindings: Array<{ platformUserId: string; vaultId: string }>;
+    };
+    expect(parsed.bindings).toHaveLength(1);
+    expect(parsed.bindings[0]).toMatchObject({
+      platformUserId: "123456",
+      vaultId: "alice",
+    });
+  });
+
+  test("resolve only returns active bindings", () => {
+    const store = new FileUserBindingStore(tmpDir);
+    store.upsert({
+      platform: "slack",
+      platformUserId: "U123",
+      internalUserId: "alice",
+      vaultId: "alice",
+      status: "active",
+      createdAt: "2026-04-09T00:00:00Z",
+      updatedAt: "2026-04-09T00:00:00Z",
+    });
+
+    expect(store.resolve("slack", "U123")?.vaultId).toBe("alice");
+    store.revoke("slack", "U123");
+    expect(store.resolve("slack", "U123")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Next split from #25. This wires the vault storage layer into tool execution, without exposing the chat `/login` command yet.

- add file-backed platform user → vault bindings
- add actor vault key resolution
- route each agent run through the current message actor before executing tools
- inject vault env into container and firecracker executors only
- keep credential state under `--state-dir` (default `~/.mama`) instead of the workspace
- add secure `--state-dir` checks and binding-store tests

## Runtime routing semantics

- `host`: no vault env injection.
- `container:<name>`: the container has one vault key, `container-<name>`. If multiple users share that same container, they therefore share that one container vault.
- `firecracker`: resolve the platform user to a vault via `bindings.json` first, then direct `userId` vault if present.

## Notes

This PR deliberately does **not** add the user-facing `/login` handler. It only makes execution capable of using vault credentials once a vault/binding exists. The `/login` runtime wiring will follow separately.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.