### PR TITLE
docs(vault): document sandbox login semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ bin/
 *.env
 .env*
 
+# Local mama state / credential vaults
+.mama/
+vaults/vault.json
+vaults/bindings.json
+vaults/*/
+

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ We actively track the upstream `pi-mom` and plan to:
 - **Multi-platform** — Slack, Telegram, and Discord adapters out of the box
 - **Persistent sessions** — session behavior is adapted per platform instead of forcing one thread model everywhere
 - **Concurrent conversations** — Slack threads, Discord replies/threads, and Telegram reply chains can run independently
-- **Sandbox execution** — run agent commands on host or inside a container
+- **Sandbox execution** — run agent commands on host, in a container, or in a Firecracker VM
+- **Credential vaults** — `/login` stores credentials under `--state-dir` and injects env only into container/Firecracker runs
 - **Persistent memory** — workspace-level and channel-level `MEMORY.md` files
 - **Skills** — drop custom CLI tools into `skills/` directories
 - **Event system** — schedule one-shot or recurring tasks via JSON files
@@ -169,7 +170,7 @@ Or import this **App Manifest** directly (Settings → App Manifest → paste JS
 export MOM_SLACK_APP_TOKEN=xapp-...
 export MOM_SLACK_BOT_TOKEN=xoxb-...
 
-mama [--sandbox=host|container:<container>] <working-directory>
+mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|firecracker:<vm-id>:<path>] <working-directory>
 ```
 
 The bot responds when `@mentioned` in any channel or via DM.
@@ -188,7 +189,7 @@ The bot responds when `@mentioned` in any channel or via DM.
 ```bash
 export MOM_TELEGRAM_BOT_TOKEN=123456:ABC-...
 
-mama [--sandbox=host|container:<container>] <working-directory>
+mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|firecracker:<vm-id>:<path>] <working-directory>
 ```
 
 - **Private chats** — every message is forwarded to the bot automatically.
@@ -208,7 +209,7 @@ mama [--sandbox=host|container:<container>] <working-directory>
 ```bash
 export MOM_DISCORD_BOT_TOKEN=MTI...
 
-mama [--sandbox=host|container:<container>] <working-directory>
+mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|firecracker:<vm-id>:<path>] <working-directory>
 ```
 
 - **Server channels** — the bot responds when `@mentioned`.
@@ -221,23 +222,47 @@ mama [--sandbox=host|container:<container>] <working-directory>
 
 ## Options
 
-| Option                                 | Default | Description                                                         |
-| -------------------------------------- | ------- | ------------------------------------------------------------------- |
-| `--sandbox=host`                       | ✓       | Run commands directly on host                                       |
-| `--sandbox=container:<name>`           |         | Run commands in a shared container (mama does not manage lifecycle) |
-| `--sandbox=firecracker:<vm-id>:<path>` |         | Run commands inside a Firecracker microVM                           |
-| `--download <channel-id>`              |         | Download channel history to stdout and exit (Slack only)            |
+| Option                                 | Default   | Description                                              |
+| -------------------------------------- | --------- | -------------------------------------------------------- |
+| `--state-dir=<dir>`                    | `~/.mama` | Store credential vaults and bindings outside workspace   |
+| `--sandbox=host`                       | ✓         | Run commands directly on host; vault env is not injected |
+| `--sandbox=container:<name>`           |           | Run commands in an existing container                    |
+| `--sandbox=firecracker:<vm-id>:<path>` |           | Run commands inside a Firecracker microVM                |
+| `--download <channel-id>`              |           | Download channel history to stdout and exit (Slack only) |
 
-### Container Mode Semantics
+### Sandbox and Vault Semantics
 
-- `container:*` uses one shared container for all sessions/users. mama does not create/start/stop/delete this container.
-- `docker:*` and `image:*` are reserved for future modes where each session gets an isolated container and mama manages container lifecycle.
+- `host`: no vault env injection.
+- `container:<name>`: one container maps to one vault key: `container-<name>`.
+- `firecracker:*`: per-user vault routing via `bindings.json` first, then direct userId vault.
+- `docker:*` and `image:*` are reserved for future managed-container modes.
+
+See [docs/sandbox.md](docs/sandbox.md) for the full sandbox/vault behavior matrix.
 
 ### Download channel history (Slack)
 
 ```bash
 mama --download C0123456789
 ```
+
+## `/login` Credential Onboarding
+
+Set `MOM_LINK_URL` to enable the web credential onboarding flow:
+
+```bash
+export MOM_LINK_URL="https://mama.example.com"
+# optional; defaults to 8181 when MOM_LINK_URL is set
+export MOM_LINK_PORT=8181
+```
+
+Users can then run `/login` in a private conversation with the bot. mama returns a 15-minute link for storing API keys or using built-in OAuth providers.
+
+Built-in OAuth guides:
+
+- [GitHub OAuth](docs/oauth/github.md)
+- [Google Workspace CLI OAuth](docs/oauth/google-workspace.md)
+
+Credentials are stored under `<state-dir>/vaults` (default `~/.mama/vaults`). Runtime env injection only happens in `container` and `firecracker` modes.
 
 ## Configuration
 
@@ -316,13 +341,15 @@ Logs appear in Cloud Logging under **Log name: `mama`**. Console output (stdout)
 
 ```bash
 # Create a container (mount your working directory to /workspace)
-docker run -d --name mama-sandbox \
+docker run -d --name mama-tools \
   -v /path/to/workspace:/workspace \
   alpine:latest sleep infinity
 
 # Start mama with container sandbox
-mama --sandbox=container:mama-sandbox /path/to/workspace
+mama --sandbox=container:mama-tools /path/to/workspace
 ```
+
+`container:mama-tools` uses vault key `container-mama-tools`. If multiple users share the same container, they share that container vault.
 
 ## Firecracker Sandbox
 
@@ -438,12 +465,12 @@ npm run build   # production build
 
 ## 📦 Dependencies & Versions
 
-| Package                         | mama Version | pi-mom Synced Version         |
-| ------------------------------- | ------------ | ----------------------------- |
-| `@mariozechner/pi-agent-core`   | `^0.57.1`    | ✅ Synchronized               |
-| `@mariozechner/pi-ai`           | `^0.57.1`    | ✅ Synchronized               |
-| `@mariozechner/pi-coding-agent` | `^0.57.1`    | ✅ Synchronized               |
-| `@anthropic-ai/sandbox-runtime` | `^0.0.40`    | ⚠️ Newer (pi-mom uses 0.0.16) |
+| Package                         | mama Version | pi-mom Synced Version            |
+| ------------------------------- | ------------ | -------------------------------- |
+| `@mariozechner/pi-agent-core`   | `^0.69.0`    | ✅ Synchronized                  |
+| `@mariozechner/pi-ai`           | `^0.69.0`    | ✅ Synchronized                  |
+| `@mariozechner/pi-coding-agent` | `^0.69.0`    | ✅ Synchronized                  |
+| `@anthropic-ai/sandbox-runtime` | `^0.0.49`    | ⚠️ Newer than original fork base |
 
 ## License
 

--- a/docs/oauth/github.md
+++ b/docs/oauth/github.md
@@ -1,0 +1,81 @@
+# GitHub OAuth Setup
+
+這份文件說明如何設定 mama `/login` 內建的 GitHub OAuth。
+
+## 1. 建立 GitHub OAuth App
+
+到 GitHub：
+
+```text
+Settings → Developer settings → OAuth Apps → New OAuth App
+```
+
+填入：
+
+- Application name：例如 `mama`
+- Homepage URL：你的 `MOM_LINK_URL`
+- Authorization callback URL：`<MOM_LINK_URL>/oauth/callback`
+
+範例：
+
+```text
+MOM_LINK_URL=https://mama.example.com
+Callback URL=https://mama.example.com/oauth/callback
+```
+
+## 2. 設定環境變數
+
+```bash
+export MOM_LINK_URL="https://mama.example.com"
+export GITHUB_OAUTH_CLIENT_ID="<client-id>"
+export GITHUB_OAUTH_CLIENT_SECRET="<client-secret>"
+```
+
+如果沒有設定 `MOM_LINK_PORT`，mama 會在 `MOM_LINK_URL` 存在時預設監聽 `8181`。
+
+## 3. 啟動 mama
+
+```bash
+mama --sandbox=container:mama-tools /path/to/workspace
+```
+
+或：
+
+```bash
+mama --sandbox=firecracker:192.168.1.100:/path/to/workspace /path/to/workspace
+```
+
+## 4. 使用 `/login`
+
+在與 bot 的私訊中輸入：
+
+```text
+/login
+```
+
+打開 mama 回傳的 link，選擇 GitHub OAuth。
+
+成功後，mama 會把 token 寫入對應 vault 的 `env`，包含：
+
+```text
+GITHUB_OAUTH_ACCESS_TOKEN
+GH_TOKEN
+```
+
+在 `container` / `firecracker` sandbox 中，後續工具執行會注入這些 env。
+
+## Scopes
+
+預設 GitHub OAuth scopes：
+
+```text
+repo read:user user:email read:org gist
+```
+
+可用環境變數覆蓋：
+
+```bash
+export MOM_GITHUB_OAUTH_SCOPES="repo read:user user:email read:org gist workflow"
+```
+
+請只加入你真的需要的 scopes。較高權限 scopes 會增加 credential 外洩時的風險。

--- a/docs/oauth/google-workspace.md
+++ b/docs/oauth/google-workspace.md
@@ -1,0 +1,78 @@
+# Google Workspace CLI OAuth Setup
+
+這份文件說明如何設定 mama `/login` 內建的 Google Workspace CLI OAuth。
+
+> 注意：目前 mama 會把 Google authorized_user JSON 存進 vault，並保存 target path metadata；但現有 `container` / `firecracker` runtime 尚未自動把 vault file 投影到 sandbox 內的 target path。env token 類 credential 會自動注入，file credential 的自動投影會在後續 PR 處理。
+
+## 1. 建立 Google OAuth Client
+
+到 Google Cloud Console：
+
+```text
+APIs & Services → Credentials → Create Credentials → OAuth client ID
+```
+
+設定：
+
+- Application type：`Web application`
+- Authorized redirect URI：`<MOM_LINK_URL>/oauth/callback`
+
+範例：
+
+```text
+MOM_LINK_URL=https://mama.example.com
+Redirect URI=https://mama.example.com/oauth/callback
+```
+
+如果 OAuth app 還在 testing mode，請把使用者加入：
+
+```text
+OAuth consent screen → Test users
+```
+
+## 2. 設定環境變數
+
+```bash
+export MOM_LINK_URL="https://mama.example.com"
+export GOOGLE_WORKSPACE_CLI_CLIENT_ID="<client-id>"
+export GOOGLE_WORKSPACE_CLI_CLIENT_SECRET="<client-secret>"
+```
+
+可選：覆蓋預設 scopes：
+
+```bash
+export MOM_GOOGLE_WORKSPACE_CLI_OAUTH_SCOPES="https://www.googleapis.com/auth/drive https://mail.google.com/ https://www.googleapis.com/auth/calendar"
+```
+
+## 3. 使用 `/login`
+
+在與 bot 的私訊中輸入：
+
+```text
+/login
+```
+
+打開 mama 回傳的 link，選擇 Google Workspace CLI OAuth。
+
+成功後，mama 會把 authorized user credential 存成 vault file，例如：
+
+```json
+{
+  "client_id": "...",
+  "client_secret": "...",
+  "refresh_token": "...",
+  "type": "authorized_user"
+}
+```
+
+預設 metadata target path 是：
+
+```text
+/root/.config/gws/credentials.json
+```
+
+## Notes
+
+- mama 使用 web OAuth callback，因此 Google OAuth client 必須是 `Web application`，不是 desktop app。
+- 如果 Google 沒有回傳 `refresh_token`，請撤銷既有 consent 後重新 `/login`。mama 會要求 `access_type=offline` 與 `prompt=consent`，但 Google 仍可能因既有授權而省略 refresh token。
+- file credential 自動投影尚未完成；目前請把這份文件視為 OAuth provisioning 設定，而不是完整 gws runtime 使用教學。

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,0 +1,229 @@
+# Sandbox 與 Vault
+
+這份文件說明 mama 目前支援的 sandbox 模式，以及 credential vault 在各模式下的行為。
+
+## 支援模式
+
+| 模式                                                        | 執行位置              | Vault env injection | Vault key 語意                            | 備註                                                           |
+| ----------------------------------------------------------- | --------------------- | ------------------- | ----------------------------------------- | -------------------------------------------------------------- |
+| `host`                                                      | 宿主機                | 不注入              | 可存，但執行時不用                        | 最適合本機開發；不把 vault env 放進 host process               |
+| `container:<name>`                                          | 既有 Docker container | 注入                | `container-<name>`                        | one container one vault；多人共用同一 container 就共用該 vault |
+| `firecracker:<vm-id>:<host-path>[:<ssh-user>[:<ssh-port>]]` | Firecracker VM        | 注入                | binding 優先，再 fallback 到 userId vault | VM 需自行啟動，workspace 需在 VM 內掛到 `/workspace`           |
+
+目前 `docker:*` / `image:*` 不是可用模式；`image:*` 保留給未來由 mama 管理 per-user container lifecycle 的設計。
+
+---
+
+## State directory 與 vault 位置
+
+credential state 預設放在：
+
+```text
+~/.mama/vaults/
+```
+
+也可以用 `--state-dir` 指定：
+
+```bash
+mama --state-dir=/secure/mama-state --sandbox=container:mama-tools /path/to/workspace
+```
+
+此時 credential 會在：
+
+```text
+/secure/mama-state/vaults/
+```
+
+啟動時 mama 會拒絕使用 world-writable 或非目前使用者擁有的 `--state-dir`，避免本機其他使用者竄改 vault 或 binding。
+
+---
+
+## Vault 內容
+
+每個 vault entry 可包含：
+
+- `env` file：`KEY=value` 形式的環境變數
+- file credentials：例如 `gws.json`、`.ssh/config`
+- mount metadata：記錄 file credential 理想上應該投影到 sandbox 內哪個 target path
+
+範例：
+
+```text
+~/.mama/vaults/
+├── vault.json
+├── bindings.json
+└── container-mama-tools/
+    ├── env
+    └── gws.json
+```
+
+`env` 範例：
+
+```env
+GH_TOKEN=ghp_xxx
+GITHUB_OAUTH_ACCESS_TOKEN=gho_xxx
+```
+
+---
+
+## `host`
+
+```bash
+mama --sandbox=host /path/to/workspace
+```
+
+特性：
+
+- commands 直接在宿主機執行
+- 不注入 vault env
+- `/login` 仍可把 credential 存進 `state-dir/vaults`
+
+適合：
+
+- 本機開發
+- 不希望 mama 把 vault credential 放進 host command process
+
+---
+
+## `container:<name>`
+
+```bash
+docker run -d --name mama-tools \
+  -v /path/to/workspace:/workspace \
+  alpine:latest sleep infinity
+
+mama --sandbox=container:mama-tools /path/to/workspace
+```
+
+特性：
+
+- mama 使用 `docker exec` 在既有 container 中執行 command
+- container 內 workspace 預期是 `/workspace`
+- vault key 是：
+
+```text
+container-<name>
+```
+
+例如：
+
+```bash
+--sandbox=container:mama-tools
+```
+
+會使用：
+
+```text
+~/.mama/vaults/container-mama-tools/
+```
+
+這是 **one container one vault**：
+
+- 不同 container 有不同 vault
+- 多個使用者如果共用同一個 container，就共用同一個 container vault
+
+限制：
+
+- mama 只在 `docker exec` 時注入 env
+- `docker exec` 不能新增 bind mount
+- vault file credential 會被保存，但目前不會自動投影到 container 內的 target path
+
+---
+
+## `firecracker:<vm-id>:<host-path>`
+
+```bash
+mama --sandbox=firecracker:192.168.1.100:/home/mama/workspace /home/mama/workspace
+```
+
+完整格式：
+
+```text
+firecracker:<vm-id>:<host-path>[:<ssh-user>[:<ssh-port>]]
+```
+
+範例：
+
+```bash
+mama --sandbox=firecracker:192.168.1.100:/home/mama/workspace:root:22 /home/mama/workspace
+```
+
+特性：
+
+- mama 透過 SSH 進 VM 執行 command
+- VM 內 workspace 預期是 `/workspace`
+- vault env 會透過 SSH stdin 注入，避免 secret 出現在宿主機 command line
+- vault 選擇邏輯：
+  1. 先看 `bindings.json` 是否把 platform user 綁到 vault
+  2. 若沒有 binding，使用同名 `userId` vault（如果存在）
+  3. 找不到 vault 時不注入 env
+
+限制：
+
+- VM lifecycle 由你管理
+- workspace mount 由你管理
+- vault file credential 會被保存，但目前不會自動投影到 VM 內的 target path
+
+---
+
+## `/login` 與 vault
+
+使用者在私訊中執行：
+
+```text
+/login
+```
+
+mama 會產生一個 15 分鐘有效的 onboarding link。使用者可在網頁中：
+
+- 儲存任意 API key / env var
+- 走 GitHub OAuth
+- 走 Google Workspace CLI OAuth
+
+`/login` 只能在 DM / 私訊使用，避免共享頻道中的其他人取得 credential onboarding link。
+
+### 啟用 link server
+
+設定公開 URL：
+
+```bash
+export MOM_LINK_URL="https://mama.example.com"
+```
+
+若沒有設定 `MOM_LINK_PORT`，mama 會在 `MOM_LINK_URL` 存在時預設使用 port `8181`。
+
+也可以明確指定：
+
+```bash
+export MOM_LINK_PORT=8181
+```
+
+OAuth callback URL 是：
+
+```text
+<MOM_LINK_URL>/oauth/callback
+```
+
+---
+
+## Binding store
+
+`bindings.json` 可把 platform user 對應到指定 vault：
+
+```json
+{
+  "bindings": [
+    {
+      "platform": "slack",
+      "platformUserId": "U123456",
+      "internalUserId": "alice",
+      "vaultId": "alice",
+      "status": "active",
+      "createdAt": "2026-04-26T00:00:00Z",
+      "updatedAt": "2026-04-26T00:00:00Z"
+    }
+  ]
+}
+```
+
+目前 binding 主要影響 `firecracker` 這類 per-user routing 模式。`container:<name>` 會固定使用 container vault，因此不看 per-user binding。

--- a/vaults/vault.example.json
+++ b/vaults/vault.example.json
@@ -1,24 +1,30 @@
 {
-  "$comment": "Copy this file to vault.json. Entries are auto-created when a user's first tool call runs — this example is just a reference for hand-authored entries.",
+  "$comment": "Example only. Runtime credentials live under --state-dir/vaults (default ~/.mama/vaults), not the project workspace.",
   "vaults": {
+    "container-mama-tools": {
+      "displayName": "container:mama-tools",
+      "envFile": true
+    },
     "U12345": {
       "displayName": "Alice",
       "platform": "slack",
-      "mounts": [".gcloud", ".ssh", ".kube", ".gitconfig"],
       "envFile": true,
-      "sandbox": {
-        "type": "image",
-        "container": "mama-sandbox-alice"
-      }
+      "mounts": [
+        {
+          "source": "gws.json",
+          "target": "/root/.config/gws/credentials.json"
+        }
+      ]
     },
-    "U67890": {
-      "displayName": "Bob",
+    "alice": {
+      "displayName": "Alice shared identity",
       "platform": "slack",
-      "mounts": [".gcloud", ".ssh"],
       "envFile": true,
       "sandbox": {
-        "type": "image",
-        "container": "mama-sandbox-bob"
+        "type": "firecracker",
+        "vmId": "192.168.1.100",
+        "sshUser": "root",
+        "sshPort": 22
       }
     }
   }


### PR DESCRIPTION
## Summary

Next split from #25. This documents the sandbox/vault/login behavior that is now in `main` after #30-#34.

- add `docs/sandbox.md` with the current host/container/firecracker behavior matrix
- document `/login`, `MOM_LINK_URL`, and credential vault location
- add GitHub OAuth setup guide
- add Google Workspace CLI OAuth setup guide with current file-projection limitation called out
- update README quick start, options, dependency versions, and container vault semantics
- update `vaults/vault.example.json` to avoid the not-yet-supported `image:*` mode
- ignore local state/vault secret files

## Important semantics captured here

- `--state-dir` defaults to `~/.mama`
- credentials live under `<state-dir>/vaults`
- `host` does not inject vault env
- `container:<name>` uses one vault per container: `container-<name>`
- `firecracker` uses per-user routing via bindings/direct user vault
- vault file credential target projection is documented as not implemented yet

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.
