### PR TITLE
feat(events): add actor-aware scheduling tool

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -145,6 +145,7 @@ function loadMamaSkills(channelDir: string, workspacePath: string): Skill[] {
 function buildSystemPrompt(
   workspacePath: string,
   channelId: string,
+  currentUserId: string | undefined,
   memory: string,
   sandboxConfig: SandboxConfig,
   platform: PlatformInfo,
@@ -242,17 +243,17 @@ You can schedule events that wake you up at specific times or when external thin
 
 **Immediate** - Triggers as soon as harness sees the file. Use in scripts/webhooks to signal external events.
 \`\`\`json
-{"type": "immediate", "platform": "${platform.name}", "channelId": "${channelId}", "text": "New GitHub issue opened"}
+{"type": "immediate", "platform": "${platform.name}", "channelId": "${channelId}", "userId": "${currentUserId ?? "<requester userId>"}", "text": "New GitHub issue opened"}
 \`\`\`
 
 **One-shot** - Triggers once at a specific time. Use for reminders.
 \`\`\`json
-{"type": "one-shot", "platform": "${platform.name}", "channelId": "${channelId}", "text": "Remind Mario about dentist", "at": "2025-12-15T09:00:00+01:00"}
+{"type": "one-shot", "platform": "${platform.name}", "channelId": "${channelId}", "userId": "${currentUserId ?? "<requester userId>"}", "text": "Remind Mario about dentist", "at": "2025-12-15T09:00:00+01:00"}
 \`\`\`
 
 **Periodic** - Triggers on a cron schedule. Use for recurring tasks.
 \`\`\`json
-{"type": "periodic", "platform": "${platform.name}", "channelId": "${channelId}", "text": "Check inbox and summarize", "schedule": "0 9 * * 1-5", "timezone": "${Intl.DateTimeFormat().resolvedOptions().timeZone}"}
+{"type": "periodic", "platform": "${platform.name}", "channelId": "${channelId}", "userId": "${currentUserId ?? "<requester userId>"}", "text": "Check inbox and summarize", "schedule": "0 9 * * 1-5", "timezone": "${Intl.DateTimeFormat().resolvedOptions().timeZone}"}
 \`\`\`
 
 ### Cron Format
@@ -265,14 +266,18 @@ You can schedule events that wake you up at specific times or when external thin
 ### Timezones
 All \`at\` timestamps must include offset (e.g., \`+01:00\`). Periodic events use IANA timezone names. The harness runs in ${Intl.DateTimeFormat().resolvedOptions().timeZone}. When users mention times without timezone, assume ${Intl.DateTimeFormat().resolvedOptions().timeZone}.
 
-### Platform Routing
+### Platform and Credential Routing
 Set \`platform\` to the target bot platform (\`${platform.name}\` for this conversation). When only one platform is running, omitting \`platform\` is allowed for backward compatibility, but include it by default to avoid ambiguity.
+
+Set \`userId\` to the platform userId of whoever asked for the event. When the event fires, tool execution routes using that user's vault selection in per-user modes. In \`container:<name>\`, events use the container's single vault.
+
+Prefer the \`event\` tool over manually writing JSON files; it fills \`platform\`, \`channelId\`, and \`userId\` for the current conversation automatically.
 
 ### Creating Events
 Use unique filenames to avoid overwriting existing events. Include a timestamp or random suffix:
 \`\`\`bash
 cat > ${workspacePath}/events/dentist-reminder-$(date +%s).json << 'EOF'
-{"type": "one-shot", "platform": "${platform.name}", "channelId": "${channelId}", "text": "Dentist tomorrow", "at": "2025-12-14T09:00:00+01:00"}
+{"type": "one-shot", "platform": "${platform.name}", "channelId": "${channelId}", "userId": "${currentUserId ?? "<requester userId>"}", "text": "Dentist tomorrow", "at": "2025-12-14T09:00:00+01:00"}
 EOF
 \`\`\`
 Or check if file exists first before creating.
@@ -458,7 +463,7 @@ export async function createRunner(
   let workspacePath = getWorkspacePath();
 
   // Create tools (per-runner, with per-runner upload function setter)
-  const { tools, setUploadFunction } = createMamaTools(executor);
+  const { tools, setUploadFunction, setEventContext } = createMamaTools(executor, workspaceDir);
 
   // Resolve model from config
   // Use 'as any' cast because agentConfig.provider/model are plain strings,
@@ -478,6 +483,7 @@ export async function createRunner(
   const systemPrompt = buildSystemPrompt(
     workspacePath,
     channelId,
+    undefined,
     memory,
     sandboxConfig,
     emptyPlatform,
@@ -915,12 +921,19 @@ export async function createRunner(
       const systemPrompt = buildSystemPrompt(
         workspacePath,
         channelId,
+        message.userId,
         memory,
         executor.getSandboxConfig(),
         platform,
         skills,
       );
       session.agent.state.systemPrompt = systemPrompt;
+
+      setEventContext({
+        platform: platform.name,
+        channelId,
+        userId: message.userId,
+      });
 
       // Set up file upload function
       setUploadFunction(async (filePath: string, title?: string) => {

--- a/src/events.ts
+++ b/src/events.ts
@@ -22,6 +22,8 @@ export interface ImmediateEvent {
   type: "immediate";
   platform: string;
   channelId: string;
+  /** Creator userId — routes tool execution to that user's vault selection when fired. */
+  userId?: string;
   text: string;
 }
 
@@ -29,6 +31,7 @@ export interface OneShotEvent {
   type: "one-shot";
   platform: string;
   channelId: string;
+  userId?: string;
   text: string;
   at: string; // ISO 8601 with timezone offset
 }
@@ -37,6 +40,7 @@ export interface PeriodicEvent {
   type: "periodic";
   platform: string;
   channelId: string;
+  userId?: string;
   text: string;
   schedule: string; // cron syntax
   timezone: string; // IANA timezone
@@ -281,10 +285,11 @@ export class EventsWatcher {
     }
 
     const platform = this.resolvePlatform(data.platform, filename);
+    const userId = typeof data.userId === "string" ? data.userId : undefined;
 
     switch (data.type) {
       case "immediate":
-        return { type: "immediate", platform, channelId: data.channelId, text: data.text };
+        return { type: "immediate", platform, channelId: data.channelId, userId, text: data.text };
 
       case "one-shot":
         if (!data.at) {
@@ -294,6 +299,7 @@ export class EventsWatcher {
           type: "one-shot",
           platform,
           channelId: data.channelId,
+          userId,
           text: data.text,
           at: data.at,
         };
@@ -309,6 +315,7 @@ export class EventsWatcher {
           type: "periodic",
           platform,
           channelId: data.channelId,
+          userId,
           text: data.text,
           schedule: data.schedule,
           timezone: data.timezone,
@@ -429,13 +436,16 @@ export class EventsWatcher {
       return;
     }
 
-    // Create synthetic BotEvent - use channelId as ts for stable session key
+    // Create synthetic BotEvent. Keep a stable channel session key so recurring
+    // reminders share context, but use a unique synthetic message id because
+    // some adapters treat ts/message id as a reply target.
     const syntheticEvent: BotEvent = {
       type: "mention",
       channel: event.channelId,
-      user: "EVENT",
+      user: event.userId ?? "EVENT",
       text: message,
-      ts: event.channelId, // Stable key: same channel uses same ts for all events
+      ts: `event:${filename}`,
+      sessionKey: event.channelId,
     };
 
     // Enqueue for processing

--- a/src/tools/event.ts
+++ b/src/tools/event.ts
@@ -1,0 +1,171 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+
+const eventSchema = Type.Object({
+  label: Type.String({
+    description: "Brief description of the event you're scheduling (shown to user)",
+  }),
+  type: Type.Union([Type.Literal("immediate"), Type.Literal("one-shot"), Type.Literal("periodic")]),
+  text: Type.String({ description: "The reminder or event text to send when it fires" }),
+  at: Type.Optional(
+    Type.String({
+      description: "ISO 8601 timestamp with offset, required for one-shot events",
+    }),
+  ),
+  schedule: Type.Optional(
+    Type.String({
+      description: "Cron schedule, required for periodic events",
+    }),
+  ),
+  timezone: Type.Optional(
+    Type.String({
+      description: "IANA timezone, required for periodic events",
+    }),
+  ),
+  filenamePrefix: Type.Optional(
+    Type.String({
+      description: "Optional filename prefix for the event file",
+    }),
+  ),
+});
+
+interface EventToolContext {
+  platform: string;
+  channelId: string;
+  userId: string;
+}
+
+type EventToolParams = {
+  label: string;
+  type: "immediate" | "one-shot" | "periodic";
+  text: string;
+  at?: string;
+  schedule?: string;
+  timezone?: string;
+  filenamePrefix?: string;
+};
+
+type EventPayload =
+  | {
+      type: "immediate";
+      platform: string;
+      channelId: string;
+      userId: string;
+      text: string;
+    }
+  | {
+      type: "one-shot";
+      platform: string;
+      channelId: string;
+      userId: string;
+      text: string;
+      at: string;
+    }
+  | {
+      type: "periodic";
+      platform: string;
+      channelId: string;
+      userId: string;
+      text: string;
+      schedule: string;
+      timezone: string;
+    };
+
+export function createEventTool(workspaceDir: string): {
+  tool: AgentTool<typeof eventSchema>;
+  setEventContext: (context: EventToolContext) => void;
+} {
+  let eventContext: EventToolContext | null = null;
+
+  const tool: AgentTool<typeof eventSchema> = {
+    name: "event",
+    label: "event",
+    description:
+      "Schedule an immediate, one-shot, or periodic event for the current conversation. This automatically writes to the correct events directory and fills the current platform, channel, and requester userId.",
+    parameters: eventSchema,
+    execute: async (_toolCallId: string, params: EventToolParams, signal?: AbortSignal) => {
+      if (signal?.aborted) {
+        throw new Error("Operation aborted");
+      }
+
+      if (!eventContext) {
+        throw new Error("Event context not configured");
+      }
+
+      const payload = buildEventPayload(params, eventContext);
+      const eventsDir = join(workspaceDir, "events");
+      await mkdir(eventsDir, { recursive: true });
+
+      const prefix = sanitizeFileSegment(params.filenamePrefix || payload.type || "event");
+      const filename = `${prefix}-${Date.now()}.json`;
+      const filePath = join(eventsDir, filename);
+      await writeFile(filePath, JSON.stringify(payload) + "\n", "utf-8");
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              payload.type === "periodic"
+                ? `Scheduled periodic event ${filename} for ${payload.platform}/${payload.channelId} (${payload.schedule} ${payload.timezone})`
+                : payload.type === "one-shot"
+                  ? `Scheduled one-shot event ${filename} for ${payload.platform}/${payload.channelId} at ${payload.at}`
+                  : `Queued immediate event ${filename} for ${payload.platform}/${payload.channelId}`,
+          },
+        ],
+        details: undefined,
+      };
+    },
+  };
+
+  return {
+    tool,
+    setEventContext: (context: EventToolContext) => {
+      eventContext = context;
+    },
+  };
+}
+
+function buildEventPayload(params: EventToolParams, context: EventToolContext): EventPayload {
+  const base = {
+    platform: context.platform,
+    channelId: context.channelId,
+    userId: context.userId,
+    text: params.text,
+  };
+
+  if (params.type === "immediate") {
+    return { ...base, type: "immediate" };
+  }
+
+  if (params.type === "one-shot") {
+    if (!params.at) {
+      throw new Error("`at` is required for one-shot events");
+    }
+    return { ...base, type: "one-shot", at: params.at };
+  }
+
+  if (!params.schedule) {
+    throw new Error("`schedule` is required for periodic events");
+  }
+  if (!params.timezone) {
+    throw new Error("`timezone` is required for periodic events");
+  }
+  return {
+    ...base,
+    type: "periodic",
+    schedule: params.schedule,
+    timezone: params.timezone,
+  };
+}
+
+function sanitizeFileSegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || "event";
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,22 +3,30 @@ import { createAttachTool } from "../adapters/slack/tools/attach.js";
 import type { Executor } from "../sandbox.js";
 import { createBashTool } from "./bash.js";
 import { createEditTool } from "./edit.js";
+import { createEventTool } from "./event.js";
 import { createReadTool } from "./read.js";
 import { createWriteTool } from "./write.js";
 
-export function createMamaTools(executor: Executor): {
+export function createMamaTools(
+  executor: Executor,
+  workspaceDir: string,
+): {
   tools: AgentTool<any>[];
   setUploadFunction: (fn: (filePath: string, title?: string) => Promise<void>) => void;
+  setEventContext: (context: { platform: string; channelId: string; userId: string }) => void;
 } {
   const { tool: attachTool, setUploadFunction } = createAttachTool();
+  const { tool: eventTool, setEventContext } = createEventTool(workspaceDir);
   return {
     tools: [
       createReadTool(executor),
       createBashTool(executor),
       createEditTool(executor),
       createWriteTool(executor),
+      eventTool,
       attachTool,
     ],
     setUploadFunction,
+    setEventContext,
   };
 }

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -55,6 +55,7 @@ describe("EventsWatcher platform routing", () => {
       type: "immediate",
       platform: "telegram",
       channelId: "123",
+      userId: undefined,
       text: "Check inbox",
     });
   });
@@ -92,6 +93,7 @@ describe("EventsWatcher platform routing", () => {
       platform: "discord",
       channelId: "CH-42",
       text: "Deploy in 10 minutes",
+      userId: "U123",
     });
 
     expect(enqueueSlack).not.toHaveBeenCalled();
@@ -99,9 +101,10 @@ describe("EventsWatcher platform routing", () => {
     expect(enqueueDiscord).toHaveBeenCalledWith({
       type: "mention",
       channel: "CH-42",
-      user: "EVENT",
+      user: "U123",
       text: "[EVENT:deploy-reminder.json:immediate:immediate] Deploy in 10 minutes",
-      ts: "CH-42",
+      ts: "event:deploy-reminder.json",
+      sessionKey: "CH-42",
     });
   });
 });


### PR DESCRIPTION
## Summary

Next split from #25. This adds actor-aware event scheduling now that vault routing is in place.

- add an `event` agent tool for scheduling immediate, one-shot, and periodic events
- automatically fills current platform, channelId, and requester userId
- preserve event `userId` when parsing JSON event files
- enqueue synthetic event runs as the creator userId, falling back to `EVENT` for legacy files
- keep recurring events in a stable channel session via `sessionKey = channelId`
- update event prompt examples to include `userId` and prefer the event tool
- update events tests for the new synthetic event shape

## Why

Scheduled events may execute tools later. Carrying `userId` lets container/firecracker vault routing choose the same credential context as the user who scheduled the event.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.
