### PR TITLE
refactor(ui): centralize status copy

### DIFF
--- a/src/adapters/discord/bot.ts
+++ b/src/adapters/discord/bot.ts
@@ -16,6 +16,7 @@ import { basename, join } from "path";
 
 import type { Bot, BotEvent, BotHandler, PlatformInfo } from "../../adapter.js";
 import * as log from "../../log.js";
+import { formatAlreadyWorking, formatNothingRunning } from "../../ui-copy.js";
 import { createDiscordAdapters } from "./context.js";
 
 // ============================================================================
@@ -387,13 +388,13 @@ export class DiscordBot implements Bot {
         if (this.handler.isRunning(sessionKey)) {
           this.handler.handleStop(sessionKey, channelId, this);
         } else {
-          await this.postMessage(channelId, "_Nothing running_");
+          await this.postMessage(channelId, formatNothingRunning("discord"));
         }
         return;
       }
 
       if (this.handler.isRunning(sessionKey)) {
-        await this.postMessage(channelId, "_Already working. Say `stop` to cancel._");
+        await this.postMessage(channelId, formatAlreadyWorking("discord", "stop"));
       } else {
         this.getQueue(sessionKey).enqueue(() => {
           const adapters = createDiscordAdapters(event, this, false);

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -7,6 +7,12 @@ import type { Bot, BotEvent, BotHandler, PlatformInfo } from "../../adapter.js";
 import type { EventsWatcher } from "../../events.js";
 import * as log from "../../log.js";
 import type { Attachment, ChannelStore } from "../../store.js";
+import {
+  PRODUCT_NAME,
+  formatAlreadyWorking,
+  formatForceStopped,
+  formatNothingRunning,
+} from "../../ui-copy.js";
 import { createSlackAdapters } from "./context.js";
 
 // ============================================================================
@@ -407,12 +413,12 @@ export class SlackBot implements Bot {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Pi Agent*\nWelcome back! Start a new task or check on running work.",
+          text: `*${PRODUCT_NAME}*\nStart a new task or check on running work.`,
         },
         accessory: {
           type: "image",
           image_url: "https://media1.tenor.com/m/lfDATg4Bhc0AAAAC/happy-cat.gif",
-          alt_text: "Pi Agent",
+          alt_text: PRODUCT_NAME,
         },
       },
     ];
@@ -626,7 +632,7 @@ export class SlackBot implements Bot {
         if (stopTarget) {
           this.handler.handleStop(stopTarget, e.channel, this);
         } else {
-          this.postMessage(e.channel, "_Nothing running_");
+          this.postMessage(e.channel, formatNothingRunning("slack"));
         }
         ack();
         return;
@@ -636,7 +642,7 @@ export class SlackBot implements Bot {
       if (this.handler.isRunning(sessionKey)) {
         this.postMessage(
           e.channel,
-          "_Already working in this thread. Say `@mama stop` to cancel._",
+          formatAlreadyWorking("slack", "@mama stop", { scope: "thread" }),
         );
       } else {
         this.getQueue(sessionKey).enqueue(() => {
@@ -721,7 +727,7 @@ export class SlackBot implements Bot {
         if (stopTarget) {
           this.handler.handleStop(stopTarget, e.channel, this);
         } else {
-          this.postMessage(e.channel, "_Nothing running_");
+          this.postMessage(e.channel, formatNothingRunning("slack"));
         }
         ack();
         return;
@@ -735,14 +741,14 @@ export class SlackBot implements Bot {
           if (this.handler.isRunning(dmSessionKey)) {
             this.handler.handleStop(dmSessionKey, e.channel, this); // Don't await, don't queue
           } else {
-            this.postMessage(e.channel, "_Nothing running_");
+            this.postMessage(e.channel, formatNothingRunning("slack"));
           }
           ack();
           return;
         }
 
         if (this.handler.isRunning(dmSessionKey)) {
-          this.postMessage(e.channel, "_Already working. Say `stop` to cancel._");
+          this.postMessage(e.channel, formatAlreadyWorking("slack", "stop"));
         } else {
           this.getQueue(dmSessionKey).enqueue(() => {
             const adapters = createSlackAdapters(slackEvent, this, false);
@@ -794,7 +800,7 @@ export class SlackBot implements Bot {
       this.handler.forceStop(sessionKey);
 
       // Notify in channel
-      await this.postMessage(channelId, `_🔴 Force stopped by ${userId}_`);
+      await this.postMessage(channelId, formatForceStopped("slack", userId ?? "unknown"));
 
       // Refresh home tab
       if (userId) {

--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -3,6 +3,7 @@ import { basename, join } from "path";
 import { Bot as GrammyBot, InputFile } from "grammy";
 import type { Bot, BotEvent, BotHandler, PlatformInfo } from "../../adapter.js";
 import * as log from "../../log.js";
+import { formatAlreadyWorking, formatNothingRunning } from "../../ui-copy.js";
 import { createTelegramAdapters } from "./context.js";
 
 // ============================================================================
@@ -380,7 +381,7 @@ export class TelegramBot implements Bot {
       if (this.handler.isRunning(mc.sessionKey)) {
         await this.handler.handleStop(mc.sessionKey, mc.chatId, this);
       } else {
-        await this.postMessage(mc.chatId, "Nothing running.");
+        await this.postMessage(mc.chatId, formatNothingRunning("telegram"));
       }
     });
 
@@ -432,13 +433,13 @@ export class TelegramBot implements Bot {
         if (this.handler.isRunning(mc.sessionKey)) {
           await this.handler.handleStop(mc.sessionKey, mc.chatId, this);
         } else {
-          await this.postMessage(mc.chatId, "Nothing running.");
+          await this.postMessage(mc.chatId, formatNothingRunning("telegram"));
         }
         return;
       }
 
       if (this.handler.isRunning(mc.sessionKey)) {
-        await this.postMessage(mc.chatId, "Already working. Say <code>/stop</code> to cancel.");
+        await this.postMessage(mc.chatId, formatAlreadyWorking("telegram", "/stop"));
       } else {
         this.getQueue(mc.sessionKey).enqueue(() => {
           const adapters = createTelegramAdapters(event, this, false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import {
 } from "./vault-routing.js";
 import { addLifecycleBreadcrumb, applyRunScope } from "./sentry.js";
 import { ChannelStore } from "./store.js";
+import { formatNothingRunning, formatStopped, formatStopping } from "./ui-copy.js";
 import * as Sentry from "@sentry/node";
 
 // ============================================================================
@@ -453,10 +454,10 @@ const handler: BotHandler = {
     if (state?.running) {
       state.stopRequested = true;
       state.runner.abort();
-      const ts = await bot.postMessage(channelId, "_Stopping..._");
+      const ts = await bot.postMessage(channelId, formatStopping(bot));
       state.stopMessageTs = ts;
     } else {
-      await bot.postMessage(channelId, "_Nothing running_");
+      await bot.postMessage(channelId, formatNothingRunning(bot));
     }
   },
 
@@ -585,10 +586,10 @@ const handler: BotHandler = {
 
             if (result.stopReason === "aborted" && state.stopRequested) {
               if (state.stopMessageTs) {
-                await bot.updateMessage(event.channel, state.stopMessageTs, "_Stopped_");
+                await bot.updateMessage(event.channel, state.stopMessageTs, formatStopped(bot));
                 state.stopMessageTs = undefined;
               } else {
-                await bot.postMessage(event.channel, "_Stopped_");
+                await bot.postMessage(event.channel, formatStopped(bot));
               }
             }
           } catch (err) {

--- a/src/ui-copy.ts
+++ b/src/ui-copy.ts
@@ -1,1 +1,51 @@
+import type { Bot, PlatformInfo } from "./adapter.js";
+
 export const PRODUCT_NAME = "mama";
+
+type PlatformSource = Bot | PlatformInfo | string;
+
+function resolvePlatformName(source: PlatformSource): string {
+  if (typeof source === "string") return source;
+  if ("getPlatformInfo" in source) return source.getPlatformInfo().name;
+  return source.name;
+}
+
+function supportsHtmlFormatting(platformName: string): boolean {
+  return platformName === "telegram";
+}
+
+function formatItalic(platformName: string, text: string): string {
+  return supportsHtmlFormatting(platformName) ? text : `_${text}_`;
+}
+
+function formatCode(platformName: string, text: string): string {
+  return supportsHtmlFormatting(platformName) ? `<code>${text}</code>` : `\`${text}\``;
+}
+
+export function formatNothingRunning(source: PlatformSource): string {
+  return formatItalic(resolvePlatformName(source), "Nothing running.");
+}
+
+export function formatStopping(source: PlatformSource): string {
+  return formatItalic(resolvePlatformName(source), "Stopping…");
+}
+
+export function formatStopped(source: PlatformSource): string {
+  return formatItalic(resolvePlatformName(source), "Stopped.");
+}
+
+export function formatAlreadyWorking(
+  source: PlatformSource,
+  stopCommand: string,
+  options?: { scope?: "thread" },
+): string {
+  const platformName = resolvePlatformName(source);
+  const command = formatCode(platformName, stopCommand);
+  const prefix =
+    options?.scope === "thread" ? "Already working in this thread." : "Already working.";
+  return formatItalic(platformName, `${prefix} Send ${command} to cancel.`);
+}
+
+export function formatForceStopped(source: PlatformSource, actorLabel: string): string {
+  return formatItalic(resolvePlatformName(source), `Force stopped by ${actorLabel}.`);
+}


### PR DESCRIPTION
## Summary

Next split from #25. This is a small user-facing copy cleanup before the larger adapter/context naming work.

- centralize common status messages in `src/ui-copy.ts`
- format status copy correctly for Telegram HTML vs Slack/Discord markdown
- replace duplicated `Nothing running`, `Stopping`, `Stopped`, and `Already working` strings
- use `mama` product name in Slack App Home instead of `Pi Agent`
- normalize force-stop notification copy

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.
