### PR TITLE
refactor(adapter): use conversation naming

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -40,8 +40,8 @@ export interface ChatAdapter {
  */
 export interface BotEvent {
   type: string;
-  /** Platform-specific channel/chat identifier */
-  channel: string;
+  /** Platform-specific conversation/channel/chat identifier */
+  conversationId: string;
   /** Message timestamp or ID as string */
   ts: string;
   /** Parent message ID for threaded replies (optional) */
@@ -52,7 +52,7 @@ export interface BotEvent {
   text: string;
   /** Downloaded attachments */
   attachments?: { name: string; localPath: string }[];
-  /** Platform-computed session key; overrides default channel:thread_ts computation */
+  /** Platform-computed session key; overrides default conversationId:thread_ts computation */
   sessionKey?: string;
 }
 
@@ -92,11 +92,11 @@ export interface BotHandler {
   isRunning(sessionKey: string): boolean;
   getRunningSessions(): RunningSession[];
   handleEvent(event: BotEvent, bot: Bot, adapters: BotAdapters, isEvent?: boolean): Promise<void>;
-  handleStop(sessionKey: string, channelId: string, bot: Bot): Promise<void>;
+  handleStop(sessionKey: string, conversationId: string, bot: Bot): Promise<void>;
   /** Force stop a running session (bypass normal stop mechanism) */
   forceStop(sessionKey: string): void;
   /** Reset a session: abort if running, delete history, remove from cache */
-  handleNew(sessionKey: string, channelId: string, bot: Bot): Promise<void>;
+  handleNew(sessionKey: string, conversationId: string, bot: Bot): Promise<void>;
 }
 
 /** @deprecated Use BotHandler */

--- a/src/adapters/discord/bot.ts
+++ b/src/adapters/discord/bot.ts
@@ -120,14 +120,15 @@ export class DiscordBot implements Bot {
   }
 
   enqueueEvent(event: BotEvent): boolean {
-    const queue = this.getQueue(event.channel);
+    const conversationId = event.conversationId;
+    const queue = this.getQueue(conversationId);
     if (queue.size() >= 5) {
       log.logWarning(
-        `Event queue full for ${event.channel}, discarding: ${event.text.substring(0, 50)}`,
+        `Event queue full for ${conversationId}, discarding: ${event.text.substring(0, 50)}`,
       );
       return false;
     }
-    log.logInfo(`Enqueueing event for ${event.channel}: ${event.text.substring(0, 50)}`);
+    log.logInfo(`Enqueueing event for ${conversationId}: ${event.text.substring(0, 50)}`);
     queue.enqueue(() => {
       const adapters = createDiscordAdapters(event as DiscordEvent, this, true);
       return this.handler.handleEvent(event, this, adapters, true);
@@ -363,7 +364,7 @@ export class DiscordBot implements Bot {
 
       const event: DiscordEvent = {
         type: isDM ? "dm" : "mention",
-        channel: channelId,
+        conversationId: channelId,
         ts: msgId,
         thread_ts: threadTs,
         user: userId,

--- a/src/adapters/discord/context.ts
+++ b/src/adapters/discord/context.ts
@@ -30,12 +30,14 @@ export function createDiscordAdapters(
     }
   }
 
+  const conversationId = event.conversationId;
+  const channelId = conversationId;
   const _eventFilename = isEvent ? event.text.match(/^\[EVENT:([^:]+):/)?.[1] : undefined;
   const isThreaded = !!event.thread_ts;
 
   const message: ChatMessage = {
     id: event.ts,
-    sessionKey: `${event.channel}:${event.thread_ts ?? event.ts}`,
+    sessionKey: `${conversationId}:${event.thread_ts ?? event.ts}`,
     userId: event.user,
     userName: event.userName,
     text: event.text,
@@ -73,18 +75,18 @@ export function createDiscordAdapters(
           );
 
           if (messageId !== null) {
-            await bot.updateMessageRaw(event.channel, messageId, displayText);
+            await bot.updateMessageRaw(channelId, messageId, displayText);
           } else {
             stopTyping();
             if (isThreaded && event.thread_ts) {
-              messageId = await bot.postInThread(event.channel, event.thread_ts, displayText);
+              messageId = await bot.postInThread(channelId, event.thread_ts, displayText);
             } else {
-              messageId = await bot.postReply(event.channel, event.ts, displayText);
+              messageId = await bot.postReply(channelId, event.ts, displayText);
             }
           }
 
           if (messageId !== null) {
-            bot.logBotResponse(event.channel, text, messageId);
+            bot.logBotResponse(channelId, text, messageId);
           }
         } catch (err) {
           log.logWarning("Discord respond error", err instanceof Error ? err.message : String(err));
@@ -100,13 +102,13 @@ export function createDiscordAdapters(
           const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
 
           if (messageId !== null) {
-            await bot.updateMessageRaw(event.channel, messageId, displayText);
+            await bot.updateMessageRaw(channelId, messageId, displayText);
           } else {
             stopTyping();
             if (isThreaded && event.thread_ts) {
-              messageId = await bot.postInThread(event.channel, event.thread_ts, displayText);
+              messageId = await bot.postInThread(channelId, event.thread_ts, displayText);
             } else {
-              messageId = await bot.postReply(event.channel, event.ts, displayText);
+              messageId = await bot.postReply(channelId, event.ts, displayText);
             }
           }
         } catch (err) {
@@ -125,9 +127,9 @@ export function createDiscordAdapters(
     setTyping: async (isTyping: boolean) => {
       if (isTyping && typingInterval === null) {
         // Send immediately and repeat every 8s (Discord clears indicator after ~10s)
-        bot.sendTyping(event.channel).catch(() => {});
+        bot.sendTyping(channelId).catch(() => {});
         typingInterval = setInterval(() => {
-          bot.sendTyping(event.channel).catch(() => {});
+          bot.sendTyping(channelId).catch(() => {});
         }, 8000);
       } else if (!isTyping) {
         stopTyping();
@@ -141,7 +143,7 @@ export function createDiscordAdapters(
           if (!working) stopTyping();
           if (messageId !== null) {
             const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
-            await bot.updateMessageRaw(event.channel, messageId, displayText);
+            await bot.updateMessageRaw(channelId, messageId, displayText);
           }
         } catch (err) {
           log.logWarning(
@@ -154,7 +156,7 @@ export function createDiscordAdapters(
     },
 
     uploadFile: async (filePath: string, title?: string) => {
-      await bot.uploadFile(event.channel, filePath, title);
+      await bot.uploadFile(channelId, filePath, title);
     },
 
     deleteResponse: async () => {
@@ -162,7 +164,7 @@ export function createDiscordAdapters(
         stopTyping();
         if (messageId !== null) {
           try {
-            await bot.deleteMessageRaw(event.channel, messageId);
+            await bot.deleteMessageRaw(channelId, messageId);
           } catch {
             // Ignore errors
           }

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -73,6 +73,7 @@ async function withRetry<T>(
 
 export interface SlackEvent {
   type: "mention" | "dm";
+  conversationId: string;
   channel: string;
   ts: string;
   thread_ts?: string;
@@ -377,16 +378,31 @@ export class SlackBot implements Bot {
    * Returns true if enqueued, false if queue is full (max 5).
    */
   enqueueEvent(event: BotEvent): boolean {
-    const queue = this.getQueue(event.channel);
+    const conversationId = event.conversationId;
+    const queue = this.getQueue(conversationId);
     if (queue.size() >= 5) {
       log.logWarning(
-        `Event queue full for ${event.channel}, discarding: ${event.text.substring(0, 50)}`,
+        `Event queue full for ${conversationId}, discarding: ${event.text.substring(0, 50)}`,
       );
       return false;
     }
-    log.logInfo(`Enqueueing event for ${event.channel}: ${event.text.substring(0, 50)}`);
+    log.logInfo(`Enqueueing event for ${conversationId}: ${event.text.substring(0, 50)}`);
     queue.enqueue(() => {
-      const adapters = createSlackAdapters(event as unknown as SlackEvent, this, true);
+      const slackEvent: SlackEvent = {
+        type: event.type as SlackEvent["type"],
+        conversationId,
+        channel: conversationId,
+        ts: event.ts,
+        thread_ts: event.thread_ts,
+        user: event.user,
+        text: event.text,
+        attachments: event.attachments?.map((attachment) => ({
+          original: attachment.name,
+          local: attachment.localPath,
+        })),
+        sessionKey: event.sessionKey,
+      };
+      const adapters = createSlackAdapters(slackEvent, this, true);
       return this.handler.handleEvent(event, this, adapters, true);
     });
     return true;
@@ -604,6 +620,7 @@ export class SlackBot implements Bot {
 
       const slackEvent: SlackEvent = {
         type: "mention",
+        conversationId: e.channel,
         channel: e.channel,
         ts: e.ts,
         thread_ts: e.thread_ts,
@@ -698,6 +715,7 @@ export class SlackBot implements Bot {
 
       const slackEvent: SlackEvent = {
         type: isDM ? "dm" : "mention",
+        conversationId: e.channel,
         channel: e.channel,
         ts: e.ts,
         thread_ts: e.thread_ts,

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -22,6 +22,8 @@ export function createSlackAdapters(
   const workingIndicator = " ...";
   let updatePromise = Promise.resolve();
 
+  const channelId = event.channel;
+  const conversationId = event.conversationId;
   const user = slack.getUser(event.user);
 
   // Extract event filename for status message
@@ -32,13 +34,14 @@ export function createSlackAdapters(
 
   /** Post first reply in-thread under the user's message, creating a thread if none exists */
   const postFirstMessage = async (text: string): Promise<string> => {
-    return slack.postInThread(event.channel, event.ts, text);
+    return slack.postInThread(channelId, event.ts, text);
   };
 
   const message: ChatMessage = {
     id: event.ts,
     sessionKey:
-      event.sessionKey ?? (event.thread_ts ? `${event.channel}:${event.thread_ts}` : event.channel),
+      event.sessionKey ??
+      (event.thread_ts ? `${conversationId}:${event.thread_ts}` : conversationId),
     userId: event.user,
     userName: user?.userName,
     text: event.text,
@@ -73,16 +76,16 @@ export function createSlackAdapters(
           const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
 
           if (messageTs) {
-            await slack.updateMessage(event.channel, messageTs, displayText);
+            await slack.updateMessage(channelId, messageTs, displayText);
           } else if (isThreaded) {
             // Reply within the user's thread
-            messageTs = await slack.postInThread(event.channel, rootTs, displayText);
+            messageTs = await slack.postInThread(channelId, rootTs, displayText);
           } else {
             messageTs = await postFirstMessage(displayText);
           }
 
           if (messageTs) {
-            slack.logBotResponse(event.channel, text, messageTs, isThreaded ? rootTs : undefined);
+            slack.logBotResponse(channelId, text, messageTs, isThreaded ? rootTs : undefined);
           }
         } catch (err) {
           log.logWarning("Slack respond error", err instanceof Error ? err.message : String(err));
@@ -107,9 +110,9 @@ export function createSlackAdapters(
           const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
 
           if (messageTs) {
-            await slack.updateMessage(event.channel, messageTs, displayText);
+            await slack.updateMessage(channelId, messageTs, displayText);
           } else if (isThreaded) {
-            messageTs = await slack.postInThread(event.channel, rootTs, displayText);
+            messageTs = await slack.postInThread(channelId, rootTs, displayText);
           } else {
             messageTs = await postFirstMessage(displayText);
           }
@@ -143,12 +146,12 @@ export function createSlackAdapters(
                 threadText.length > CONTEXT_TEXT_LIMIT
                   ? threadText.substring(0, CONTEXT_TEXT_LIMIT - 20) + "\n_(truncated)_"
                   : threadText;
-              const ts = await slack.postInThreadBlocks(event.channel, threadAnchor, threadText, [
+              const ts = await slack.postInThreadBlocks(channelId, threadAnchor, threadText, [
                 { type: "context", elements: [{ type: "mrkdwn", text: blockText }] },
               ]);
               threadMessageTs.push(ts);
             } else {
-              const ts = await slack.postInThread(event.channel, threadAnchor, threadText);
+              const ts = await slack.postInThread(channelId, threadAnchor, threadText);
               threadMessageTs.push(ts);
             }
           }
@@ -166,7 +169,7 @@ export function createSlackAdapters(
       if (isTyping && !messageTs) {
         try {
           const statusText = eventFilename ? `Starting event: ${eventFilename}` : "Thinking";
-          await slack.setAssistantStatus(event.channel, rootTs, statusText);
+          await slack.setAssistantStatus(channelId, rootTs, statusText);
         } catch {
           // Assistant API not available — first respond() call will create the message
         }
@@ -174,7 +177,7 @@ export function createSlackAdapters(
     },
 
     uploadFile: async (filePath: string, title?: string) => {
-      await slack.uploadFile(event.channel, filePath, title, rootTs);
+      await slack.uploadFile(channelId, filePath, title, rootTs);
     },
 
     setWorking: async (working: boolean) => {
@@ -184,10 +187,10 @@ export function createSlackAdapters(
           if (messageTs) {
             const displayText = isWorking ? accumulatedText + workingIndicator : accumulatedText;
             const updates: Promise<void>[] = [
-              slack.updateMessage(event.channel, messageTs, displayText),
+              slack.updateMessage(channelId, messageTs, displayText),
             ];
             if (!working) {
-              updates.push(slack.setAssistantStatus(event.channel, rootTs, "").catch(() => {}));
+              updates.push(slack.setAssistantStatus(channelId, rootTs, "").catch(() => {}));
             }
             await Promise.all(updates);
           }
@@ -205,7 +208,7 @@ export function createSlackAdapters(
       updatePromise = updatePromise.then(async () => {
         // Clear assistant status first
         try {
-          await slack.setAssistantStatus(event.channel, rootTs, "");
+          await slack.setAssistantStatus(channelId, rootTs, "");
         } catch {
           // Ignore errors clearing status
         }
@@ -213,7 +216,7 @@ export function createSlackAdapters(
         // Delete thread messages first (in reverse order)
         for (let i = threadMessageTs.length - 1; i >= 0; i--) {
           try {
-            await slack.deleteMessage(event.channel, threadMessageTs[i]);
+            await slack.deleteMessage(channelId, threadMessageTs[i]);
           } catch {
             // Ignore errors deleting thread messages
           }
@@ -221,7 +224,7 @@ export function createSlackAdapters(
         threadMessageTs.length = 0;
         // Then delete main message
         if (messageTs) {
-          await slack.deleteMessage(event.channel, messageTs);
+          await slack.deleteMessage(channelId, messageTs);
           messageTs = null;
         }
       });

--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -131,14 +131,15 @@ export class TelegramBot implements Bot {
   }
 
   enqueueEvent(event: BotEvent): boolean {
-    const queue = this.getQueue(event.channel);
+    const conversationId = event.conversationId;
+    const queue = this.getQueue(conversationId);
     if (queue.size() >= 5) {
       log.logWarning(
-        `Event queue full for ${event.channel}, discarding: ${event.text.substring(0, 50)}`,
+        `Event queue full for ${conversationId}, discarding: ${event.text.substring(0, 50)}`,
       );
       return false;
     }
-    log.logInfo(`Enqueueing event for ${event.channel}: ${event.text.substring(0, 50)}`);
+    log.logInfo(`Enqueueing event for ${conversationId}: ${event.text.substring(0, 50)}`);
     queue.enqueue(() => {
       const adapters = createTelegramAdapters(event as TelegramEvent, this, true);
       return this.handler.handleEvent(event, this, adapters, true);
@@ -407,7 +408,7 @@ export class TelegramBot implements Bot {
 
       const event: TelegramEvent = {
         type: "message",
-        channel: mc.chatId,
+        conversationId: mc.chatId,
         ts: mc.msgId,
         thread_ts: mc.threadTs,
         sessionKey: mc.sessionKey,

--- a/src/adapters/telegram/context.ts
+++ b/src/adapters/telegram/context.ts
@@ -83,12 +83,13 @@ export function createTelegramAdapters(
     }
   }
 
-  const chatId = parseInt(event.channel);
+  const conversationId = event.conversationId;
+  const chatId = parseInt(conversationId);
   const replyToId = event.thread_ts ? parseInt(event.thread_ts) : null;
 
   const message: ChatMessage = {
     id: event.ts,
-    sessionKey: event.sessionKey ?? `${event.channel}:${event.thread_ts ?? event.ts}`,
+    sessionKey: event.sessionKey ?? `${conversationId}:${event.thread_ts ?? event.ts}`,
     userId: event.user,
     userName: event.userName,
     text: event.text,
@@ -116,7 +117,7 @@ export function createTelegramAdapters(
 
   async function sendOrUpdate(displayText: string): Promise<void> {
     if (messageId !== null) {
-      await bot.updateMessage(event.channel, String(messageId), displayText);
+      await bot.updateMessage(conversationId, String(messageId), displayText);
     } else if (replyToId !== null) {
       messageId = await bot.postReply(chatId, replyToId, displayText);
     } else {
@@ -133,7 +134,7 @@ export function createTelegramAdapters(
           const displayText = truncate(accumulatedText, MAX_LENGTH, truncationNote);
           await sendOrUpdate(displayText);
           if (messageId !== null) {
-            bot.logBotResponse(event.channel, text, String(messageId));
+            bot.logBotResponse(conversationId, text, String(messageId));
           }
         } catch (err) {
           await notifyError(bot, chatId, "respond", err);
@@ -174,7 +175,7 @@ export function createTelegramAdapters(
     },
 
     uploadFile: async (filePath: string, title?: string) => {
-      await bot.uploadFile(event.channel, filePath, title);
+      await bot.uploadFile(conversationId, filePath, title);
     },
 
     deleteResponse: async () => {

--- a/src/events.ts
+++ b/src/events.ts
@@ -436,12 +436,12 @@ export class EventsWatcher {
       return;
     }
 
-    // Create synthetic BotEvent. Keep a stable channel session key so recurring
+    // Create synthetic BotEvent. Keep a stable conversation session key so recurring
     // reminders share context, but use a unique synthetic message id because
     // some adapters treat ts/message id as a reply target.
     const syntheticEvent: BotEvent = {
       type: "mention",
-      channel: event.channelId,
+      conversationId: event.channelId,
       user: event.userId ?? "EVENT",
       text: message,
       ts: `event:${filename}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -261,7 +261,7 @@ function normalizeLoginBaseUrl(): string | undefined {
 }
 
 function isPrivateConversation(event: BotEvent): boolean {
-  return event.type === "dm" || event.sessionKey === event.channel;
+  return event.type === "dm" || event.sessionKey === event.conversationId;
 }
 
 function ensureLoginVault(platform: string, platformUserId: string): string {
@@ -449,15 +449,15 @@ const handler: BotHandler = {
     return sessions;
   },
 
-  async handleStop(sessionKey: string, channelId: string, bot: Bot): Promise<void> {
+  async handleStop(sessionKey: string, conversationId: string, bot: Bot): Promise<void> {
     const state = channelStates.get(sessionKey);
     if (state?.running) {
       state.stopRequested = true;
       state.runner.abort();
-      const ts = await bot.postMessage(channelId, formatStopping(bot));
+      const ts = await bot.postMessage(conversationId, formatStopping(bot));
       state.stopMessageTs = ts;
     } else {
-      await bot.postMessage(channelId, formatNothingRunning(bot));
+      await bot.postMessage(conversationId, formatNothingRunning(bot));
     }
   },
 
@@ -471,7 +471,7 @@ const handler: BotHandler = {
     }
   },
 
-  async handleNew(sessionKey: string, channelId: string, bot: Bot): Promise<void> {
+  async handleNew(sessionKey: string, conversationId: string, bot: Bot): Promise<void> {
     const state = channelStates.get(sessionKey);
     if (state?.running) {
       state.stopRequested = true;
@@ -479,7 +479,7 @@ const handler: BotHandler = {
     }
 
     // Channel sessions rotate via current pointer. Thread sessions reset in place.
-    const channelDir = join(workingDir, channelId);
+    const channelDir = join(workingDir, conversationId);
     if (sessionKey.includes(":")) {
       createManagedSessionFileAtPath(getThreadSessionFile(channelDir, sessionKey), channelDir);
     } else {
@@ -489,8 +489,8 @@ const handler: BotHandler = {
     // Remove from in-memory cache
     channelStates.delete(sessionKey);
 
-    log.logInfo(`[${channelId}] Session reset: ${sessionKey}`);
-    await bot.postMessage(channelId, "Conversation reset. Send a new message to start fresh.");
+    log.logInfo(`[${conversationId}] Session reset: ${sessionKey}`);
+    await bot.postMessage(conversationId, "Conversation reset. Send a new message to start fresh.");
   },
 
   async handleEvent(
@@ -499,26 +499,28 @@ const handler: BotHandler = {
     adapters: BotAdapters,
     _isEvent?: boolean,
   ): Promise<void> {
+    const conversationId = event.conversationId;
+
     // Don't accept new events during shutdown
     if (isShuttingDown) {
       log.logInfo(
-        `[${event.channel}] Rejected event during shutdown: ${event.text.substring(0, 50)}`,
+        `[${conversationId}] Rejected event during shutdown: ${event.text.substring(0, 50)}`,
       );
       return;
     }
 
-    const sessionKey = event.sessionKey ?? `${event.channel}:${event.thread_ts ?? event.ts}`;
+    const sessionKey = event.sessionKey ?? `${conversationId}:${event.thread_ts ?? event.ts}`;
     const handledLogin = await handleLoginCommand(
       adapters.platform.name,
       event.user,
-      event.channel,
+      conversationId,
       bot,
       event.text,
       isPrivateConversation(event),
     );
     if (handledLogin) return;
 
-    const state = await getState(event.channel, sessionKey);
+    const state = await getState(conversationId, sessionKey);
 
     // Start run
     state.running = true;
@@ -526,21 +528,21 @@ const handler: BotHandler = {
     state.startedAt = Date.now();
     state.lastActivityAt = Date.now();
 
-    log.logInfo(`[${event.channel}] Starting run: ${event.text.substring(0, 50)}`);
+    log.logInfo(`[${conversationId}] Starting run: ${event.text.substring(0, 50)}`);
 
     // Wrap in-flight run tracking
     Sentry.metrics.count("agent.run.started", 1, {
-      attributes: { channel: event.channel },
+      attributes: { channel: conversationId },
     });
     Sentry.metrics.gauge("agent.sessions.active", inFlightRuns.size + 1);
 
     const runPromise = Sentry.startSpan(
-      { name: "agent.run", op: "agent", attributes: { channelId: event.channel, sessionKey } },
+      { name: "agent.run", op: "agent", attributes: { channelId: conversationId, sessionKey } },
       async () => {
         return Sentry.withScope(async (scope) => {
           const { message, responseCtx, platform } = adapters;
           applyRunScope(scope, {
-            channelId: event.channel,
+            channelId: conversationId,
             sessionKey,
             messageId: message.id,
             platform: platform.name,
@@ -550,7 +552,7 @@ const handler: BotHandler = {
             isEvent: _isEvent,
           });
           addLifecycleBreadcrumb("agent.run.started", {
-            channel_id: event.channel,
+            channel_id: conversationId,
             platform: platform.name,
             has_attachments: (message.attachments?.length ?? 0) > 0,
           });
@@ -565,20 +567,20 @@ const handler: BotHandler = {
             Sentry.metrics.distribution("agent.run.duration", durationMs, {
               unit: "millisecond",
               attributes: {
-                channel: event.channel,
+                channel: conversationId,
                 platform: platform.name,
                 stop_reason: result.stopReason,
               },
             });
             Sentry.metrics.count("agent.run.completed", 1, {
               attributes: {
-                channel: event.channel,
+                channel: conversationId,
                 platform: platform.name,
                 stop_reason: result.stopReason,
               },
             });
             addLifecycleBreadcrumb("agent.run.completed", {
-              channel_id: event.channel,
+              channel_id: conversationId,
               platform: platform.name,
               stop_reason: result.stopReason,
               duration_ms: durationMs,
@@ -586,15 +588,15 @@ const handler: BotHandler = {
 
             if (result.stopReason === "aborted" && state.stopRequested) {
               if (state.stopMessageTs) {
-                await bot.updateMessage(event.channel, state.stopMessageTs, formatStopped(bot));
+                await bot.updateMessage(conversationId, state.stopMessageTs, formatStopped(bot));
                 state.stopMessageTs = undefined;
               } else {
-                await bot.postMessage(event.channel, formatStopped(bot));
+                await bot.postMessage(conversationId, formatStopped(bot));
               }
             }
           } catch (err) {
             scope.setContext("agent_run_error", {
-              channelId: event.channel,
+              channelId: conversationId,
               sessionKey,
               platform: adapters.platform.name,
               messageId: adapters.message.id,
@@ -602,10 +604,10 @@ const handler: BotHandler = {
             });
             Sentry.captureException(err);
             Sentry.metrics.count("agent.run.errors", 1, {
-              attributes: { channel: event.channel, platform: adapters.platform.name },
+              attributes: { channel: conversationId, platform: adapters.platform.name },
             });
             log.logWarning(
-              `[${event.channel}] Run error`,
+              `[${conversationId}] Run error`,
               err instanceof Error ? err.message : String(err),
             );
           } finally {

--- a/test/discord-context.test.ts
+++ b/test/discord-context.test.ts
@@ -32,7 +32,7 @@ function makeDiscordBot(overrides: Partial<DiscordBot> = {}): DiscordBot {
 function makeEvent(overrides: Partial<DiscordEvent> = {}): DiscordEvent {
   return {
     type: "mention",
-    channel: "CH001",
+    conversationId: "CH001",
     ts: "MSG001",
     user: "U001",
     text: "hello",

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -100,7 +100,7 @@ describe("EventsWatcher platform routing", () => {
     expect(enqueueDiscord).toHaveBeenCalledTimes(1);
     expect(enqueueDiscord).toHaveBeenCalledWith({
       type: "mention",
-      channel: "CH-42",
+      conversationId: "CH-42",
       user: "U123",
       text: "[EVENT:deploy-reminder.json:immediate:immediate] Deploy in 10 minutes",
       ts: "event:deploy-reminder.json",

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -26,13 +26,16 @@ function makeSlackBot(overrides: Partial<SlackBot> = {}): SlackBot {
 }
 
 function makeEvent(overrides: Partial<SlackEvent> = {}): SlackEvent {
+  const { channel: overrideChannel, conversationId: overrideConversationId, ...rest } = overrides;
+  const channel = overrideChannel ?? "C001";
   return {
     type: "mention",
-    channel: "C001",
+    channel,
+    conversationId: overrideConversationId ?? channel,
     ts: "1000.0001",
     user: "U001",
     text: "hello",
-    ...overrides,
+    ...rest,
   };
 }
 

--- a/test/telegram-context.test.ts
+++ b/test/telegram-context.test.ts
@@ -29,7 +29,7 @@ function makeTelegramBot(overrides: Partial<TelegramBot> = {}): TelegramBot {
 function makeEvent(overrides: Partial<TelegramEvent> = {}): TelegramEvent {
   return {
     type: "message",
-    channel: "123456",
+    conversationId: "123456",
     ts: "1001",
     user: "U001",
     text: "hello",


### PR DESCRIPTION
## Summary

Next split from #25. Implemented via subagent delegation.

- rename the cross-platform `BotEvent.channel` contract to `conversationId`
- update `BotHandler` generic method parameter naming to `conversationId`
- keep platform-facing API names (`postMessage(channel, ...)`, Slack `channel`, Telegram `chatId`) where they still describe the platform API
- update Slack/Discord/Telegram adapter contexts to distinguish generic conversation IDs from platform channel/chat IDs
- update synthetic scheduled events to emit `conversationId`
- update context/event tests

## Scope

This is intended as a naming/contract cleanup only. It does not change vault, login, sandbox, or event behavior.

## Subagent workflow

A `worker` subagent implemented the branch changes. I reviewed the resulting diff and reran validation before committing.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.
