### PR TITLE
refactor(config): prefer state-dir settings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
+import { homedir } from "os";
+import { dirname, join, resolve } from "path";
 
 export interface AgentConfig {
   provider: string;
@@ -20,11 +21,9 @@ const DEFAULTS: AgentConfig = {
   logLevel: "info",
 };
 
-function loadRawAgentConfig(workspaceDir: string): Partial<AgentConfig> {
-  const settingsPath = join(workspaceDir, "settings.json");
-
+function loadConfigFile(settingsPath: string): Partial<AgentConfig> | undefined {
   if (!existsSync(settingsPath)) {
-    return {};
+    return undefined;
   }
 
   try {
@@ -34,7 +33,29 @@ function loadRawAgentConfig(workspaceDir: string): Partial<AgentConfig> {
       return parsed as Partial<AgentConfig>;
     }
   } catch {
-    // Ignore parse errors, fall through to env/defaults
+    // Ignore parse errors, fall through to next candidate
+  }
+
+  return undefined;
+}
+
+function getConfiguredStateDir(): string | undefined {
+  const raw = process.env.MAMA_STATE_DIR?.trim();
+  return raw ? resolve(raw) : undefined;
+}
+
+function loadRawAgentConfig(workspaceDir?: string): Partial<AgentConfig> {
+  const stateDir = getConfiguredStateDir();
+  const candidates = [
+    ...(stateDir ? [join(stateDir, "settings.json")] : []),
+    ...(workspaceDir ? [join(workspaceDir, "settings.json")] : []),
+  ];
+
+  for (const settingsPath of candidates) {
+    const config = loadConfigFile(settingsPath);
+    if (config) {
+      return config;
+    }
   }
 
   return {};
@@ -83,12 +104,24 @@ export function resolveWorkspaceDirFromArgv(args = process.argv.slice(2)): strin
   return undefined;
 }
 
-export function resolveSentryDsn(workspaceDir?: string): string | undefined {
-  if (workspaceDir) {
-    const fromFile = loadRawAgentConfig(workspaceDir);
-    if (fromFile.sentryDsn) {
-      return fromFile.sentryDsn;
+export function resolveStateDirFromArgv(args = process.argv.slice(2)): string {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith("--state-dir=")) {
+      return resolve(arg.slice("--state-dir=".length));
     }
+    if (arg === "--state-dir") {
+      return resolve(args[++i] || "");
+    }
+  }
+
+  return join(homedir(), ".mama");
+}
+
+export function resolveSentryDsn(workspaceDir?: string): string | undefined {
+  const fromFile = loadRawAgentConfig(workspaceDir);
+  if (fromFile.sentryDsn) {
+    return fromFile.sentryDsn;
   }
 
   return process.env.SENTRY_DSN;

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,7 +1,12 @@
 import * as Sentry from "@sentry/node";
-import { resolveSentryDsn, resolveWorkspaceDirFromArgv } from "./config.js";
+import {
+  resolveSentryDsn,
+  resolveStateDirFromArgv,
+  resolveWorkspaceDirFromArgv,
+} from "./config.js";
 import { createSentryInitOptions } from "./sentry.js";
 
+process.env.MAMA_STATE_DIR ??= resolveStateDirFromArgv();
 const workingDir = resolveWorkspaceDirFromArgv();
 const sentryDsn = resolveSentryDsn(workingDir);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -202,6 +202,7 @@ if (!parsedArgs.workingDir) {
 
 const { workingDir, sandbox } = { workingDir: parsedArgs.workingDir, sandbox: parsedArgs.sandbox };
 const stateDir = parsedArgs.stateDir ?? join(homedir(), ".mama");
+process.env.MAMA_STATE_DIR = stateDir;
 ensureSecureStateDir(stateDir);
 
 // Validate platform tokens

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   loadAgentConfig,
   resolveSentryDsn,
+  resolveStateDirFromArgv,
   resolveWorkspaceDirFromArgv,
   saveAgentConfig,
 } from "../src/config.js";
@@ -18,6 +19,9 @@ describe("loadAgentConfig", () => {
   });
 
   afterEach(() => {
+    delete process.env.MAMA_STATE_DIR;
+    delete process.env.MOM_AI_PROVIDER;
+    delete process.env.MOM_AI_MODEL;
     if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
   });
 
@@ -49,30 +53,37 @@ describe("loadAgentConfig", () => {
   });
 
   test("env vars override defaults but not settings.json", () => {
-    // With env var only (no settings.json)
     process.env.MOM_AI_PROVIDER = "google";
     process.env.MOM_AI_MODEL = "gemini-2.0-flash";
-    try {
-      const config = loadAgentConfig(tmpDir);
-      expect(config.provider).toBe("google");
-      expect(config.model).toBe("gemini-2.0-flash");
-    } finally {
-      delete process.env.MOM_AI_PROVIDER;
-      delete process.env.MOM_AI_MODEL;
-    }
+
+    const config = loadAgentConfig(tmpDir);
+    expect(config.provider).toBe("google");
+    expect(config.model).toBe("gemini-2.0-flash");
   });
 
   test("settings.json values override env vars", () => {
     saveAgentConfig(tmpDir, { provider: "openai", model: "gpt-4o" });
     process.env.MOM_AI_PROVIDER = "google";
     process.env.MOM_AI_MODEL = "gemini-2.0-flash";
+
+    const config = loadAgentConfig(tmpDir);
+    expect(config.provider).toBe("openai");
+    expect(config.model).toBe("gpt-4o");
+  });
+
+  test("prefers state-dir settings.json over workspace settings.json", () => {
+    const stateDir = join(tmpdir(), `mama-state-${Date.now()}`);
+    mkdirSync(stateDir, { recursive: true });
+    saveAgentConfig(tmpDir, { provider: "openai", model: "gpt-4o" });
+    saveAgentConfig(stateDir, { provider: "google", model: "gemini-2.0-flash" });
+    process.env.MAMA_STATE_DIR = stateDir;
+
     try {
       const config = loadAgentConfig(tmpDir);
-      expect(config.provider).toBe("openai");
-      expect(config.model).toBe("gpt-4o");
+      expect(config.provider).toBe("google");
+      expect(config.model).toBe("gemini-2.0-flash");
     } finally {
-      delete process.env.MOM_AI_PROVIDER;
-      delete process.env.MOM_AI_MODEL;
+      rmSync(stateDir, { recursive: true, force: true });
     }
   });
 
@@ -85,7 +96,7 @@ describe("loadAgentConfig", () => {
   });
 });
 
-describe("resolveWorkspaceDirFromArgv", () => {
+describe("argv config resolution", () => {
   test("returns the positional workspace dir", () => {
     expect(resolveWorkspaceDirFromArgv(["--sandbox=host", "/tmp/mama"])).toBe("/tmp/mama");
   });
@@ -96,6 +107,11 @@ describe("resolveWorkspaceDirFromArgv", () => {
 
   test("ignores download mode channel ids", () => {
     expect(resolveWorkspaceDirFromArgv(["--download", "C123"])).toBeUndefined();
+  });
+
+  test("resolves explicit state-dir from argv", () => {
+    expect(resolveStateDirFromArgv(["--state-dir", "/tmp/state", "/tmp/mama"])).toBe("/tmp/state");
+    expect(resolveStateDirFromArgv(["--state-dir=/tmp/state", "/tmp/mama"])).toBe("/tmp/state");
   });
 });
 
@@ -108,6 +124,7 @@ describe("resolveSentryDsn", () => {
   });
 
   afterEach(() => {
+    delete process.env.MAMA_STATE_DIR;
     delete process.env.SENTRY_DSN;
     if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
   });
@@ -121,6 +138,20 @@ describe("resolveSentryDsn", () => {
   test("falls back to env when settings.json has no sentryDsn", () => {
     process.env.SENTRY_DSN = "https://env.example/2";
     expect(resolveSentryDsn(tmpDir)).toBe("https://env.example/2");
+  });
+
+  test("prefers state-dir sentryDsn over workspace settings", () => {
+    const stateDir = join(tmpdir(), `mama-state-sentry-${Date.now()}`);
+    mkdirSync(stateDir, { recursive: true });
+    saveAgentConfig(tmpDir, { sentryDsn: "https://workspace.example/1" });
+    saveAgentConfig(stateDir, { sentryDsn: "https://state.example/1" });
+    process.env.MAMA_STATE_DIR = stateDir;
+
+    try {
+      expect(resolveSentryDsn(tmpDir)).toBe("https://state.example/1");
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -147,9 +178,9 @@ describe("saveAgentConfig", () => {
     saveAgentConfig(tmpDir, { provider: "openai", model: "gpt-4o", sessionScope: "channel" });
     saveAgentConfig(tmpDir, { model: "gpt-4o-mini" });
     const config = loadAgentConfig(tmpDir);
-    expect(config.provider).toBe("openai"); // preserved
-    expect(config.model).toBe("gpt-4o-mini"); // updated
-    expect(config.sessionScope).toBe("channel"); // preserved
+    expect(config.provider).toBe("openai");
+    expect(config.model).toBe("gpt-4o-mini");
+    expect(config.sessionScope).toBe("channel");
   });
 
   test("creates parent directories if they don't exist", () => {


### PR DESCRIPTION
## Summary

Next split from #25. This is a small config cleanup that makes runtime settings follow `--state-dir` / `MAMA_STATE_DIR` before falling back to legacy workspace settings.

- prefer `<state-dir>/settings.json` when `MAMA_STATE_DIR` is set
- keep workspace `settings.json` as a backwards-compatible fallback
- make `instrument.ts` resolve the state dir from argv before loading Sentry config
- export `resolveStateDirFromArgv()` for shared argv handling
- add config tests covering state-dir precedence and Sentry DSN lookup order

## Why

Credentials already live under `--state-dir`. This PR makes runtime settings lookup prefer the same state root without forcing an all-at-once migration.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.
