### PR TITLE
refactor(log): use conversation context naming

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -604,9 +604,9 @@ export async function createRunner(
   const runState = {
     responseCtx: null as ChatResponseContext | null,
     logCtx: null as {
-      channelId: string;
+      conversationId: string;
       userName?: string;
-      channelName?: string;
+      conversationName?: string;
       sessionId?: string;
     } | null,
     queue: null as {
@@ -637,7 +637,7 @@ export async function createRunner(
     if (!runState.responseCtx || !runState.logCtx || !runState.queue) return;
 
     const { responseCtx, logCtx, queue, pendingTools } = runState;
-    const baseAttrs = { channel_id: logCtx.channelId, session_id: logCtx.sessionId };
+    const baseAttrs = { channel_id: logCtx.conversationId, session_id: logCtx.sessionId };
 
     if (event.type === "tool_execution_start") {
       const agentEvent = event as AgentEvent & { type: "tool_execution_start" };
@@ -944,9 +944,9 @@ export async function createRunner(
       // Reset per-run state
       runState.responseCtx = responseCtx;
       runState.logCtx = {
-        channelId: sessionChannel,
+        conversationId: sessionChannel,
         userName: message.userName,
-        channelName: undefined,
+        conversationName: undefined,
         sessionId: sessionUuid,
       };
       runState.pendingTools.clear();

--- a/src/log.ts
+++ b/src/log.ts
@@ -35,9 +35,9 @@ function createGcpStream(): Writable {
 }
 
 export interface LogContext {
-  channelId: string;
+  conversationId: string;
   userName?: string;
-  channelName?: string; // For display like #dev-team vs C16HET4EQ
+  conversationName?: string; // For display like #dev-team vs C16HET4EQ
   sessionId?: string;
 }
 
@@ -70,9 +70,9 @@ export function __resetLoggerForTest(): void {
 }
 
 function ctxFields(ctx: LogContext): Record<string, string> {
-  const out: Record<string, string> = { channel: ctx.channelId };
+  const out: Record<string, string> = { channel: ctx.conversationId };
   if (ctx.userName) out.user = ctx.userName;
-  if (ctx.channelName) out.channelName = ctx.channelName;
+  if (ctx.conversationName) out.channelName = ctx.conversationName;
   if (ctx.sessionId) out.sessionId = ctx.sessionId;
   return out;
 }
@@ -87,12 +87,12 @@ function timestamp(): string {
 
 function formatContext(ctx: LogContext): string {
   const session = ctx.sessionId ? `:${ctx.sessionId}` : "";
-  if (ctx.channelId.startsWith("D")) {
-    return `[DM:${ctx.userName || ctx.channelId}${session}]`;
+  if (ctx.conversationId.startsWith("D")) {
+    return `[DM:${ctx.userName || ctx.conversationId}${session}]`;
   }
-  const channel = ctx.channelName || ctx.channelId;
+  const conversation = ctx.conversationName || ctx.conversationId;
   const user = ctx.userName || "unknown";
-  return `[${channel.startsWith("#") ? channel : `#${channel}`}:${user}${session}]`;
+  return `[${conversation.startsWith("#") ? conversation : `#${conversation}`}:${user}${session}]`;
 }
 
 function truncate(text: string, maxLen: number): string {


### PR DESCRIPTION
## Summary

Next small split from #25. This keeps the earlier conversation naming cleanup moving through the runtime log layer without changing platform-facing APIs.

- rename internal `LogContext.channelId` to `conversationId`
- rename internal `LogContext.channelName` to `conversationName`
- update the runner's per-run log context to match
- keep emitted log/metric fields unchanged (`channel`, `channelName`) to avoid external noise

## Why

Earlier cleanup standardized cross-platform contracts on `conversationId`. This PR applies the same naming to the internal runtime log context while keeping external behavior stable.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.
