### PR TITLE
refactor(agent): remove stale attachment shape

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -40,13 +40,6 @@ import {
 import { createMamaTools } from "./tools/index.js";
 import * as Sentry from "@sentry/node";
 
-export interface PendingMessage {
-  userName: string;
-  text: string;
-  attachments: { local: string }[];
-  timestamp: number;
-}
-
 export interface AgentRunner {
   run(
     message: ChatMessage,
@@ -1022,7 +1015,7 @@ export async function createRunner(
       const nonImagePaths: string[] = [];
 
       for (const a of message.attachments || []) {
-        // a.localPath is the path relative to the workspace (same as old a.local)
+        // a.localPath is the path relative to the workspace.
         const fullPath = `${workspacePath}/${a.localPath}`;
         const mimeType = getImageMimeType(a.localPath);
 


### PR DESCRIPTION
## Summary

Next small split from #25. This removes a stale, unused attachment shape from `src/agent.ts`.

- delete the unused `PendingMessage` interface
- remove the nearby outdated comment that still referenced the old `a.local` field
- keep runtime behavior unchanged

## Why

Recent cleanup standardized attachment metadata on `localPath`. `PendingMessage` still described the old `{ local: string }[]` shape, but it was no longer used anywhere.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.
