### PR TITLE
refactor(store): clarify directory variable names

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -54,11 +54,11 @@ export class ChannelStore {
    * Get or create the directory for a channel/DM
    */
   getChannelDir(channelId: string): string {
-    const dir = join(this.workingDir, channelId);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+    const channelDir = join(this.workingDir, channelId);
+    if (!existsSync(channelDir)) {
+      mkdirSync(channelDir, { recursive: true });
     }
-    return dir;
+    return channelDir;
   }
 
   /**
@@ -214,9 +214,9 @@ export class ChannelStore {
     const filePath = join(this.workingDir, localPath);
 
     // Ensure directory exists
-    const dir = join(this.workingDir, localPath.substring(0, localPath.lastIndexOf("/")));
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+    const parentDir = join(this.workingDir, localPath.substring(0, localPath.lastIndexOf("/")));
+    if (!existsSync(parentDir)) {
+      mkdirSync(parentDir, { recursive: true });
     }
 
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary

Next small split from #25. This clarifies a couple of local directory variable names in `src/store.ts`.

- rename `dir` to `channelDir` in `getChannelDir()`
- rename `dir` to `parentDir` in `downloadAttachment()`
- keep behavior unchanged

## Why

These variables referred to different directories, but both were named `dir`, which made the code a little harder to scan during the ongoing cleanup work.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller reviewable PRs.
