### PR TITLE
feat(sandbox): add managed image sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ We actively track the upstream `pi-mom` and plan to:
 - **Multi-platform** — Slack, Telegram, and Discord adapters out of the box
 - **Persistent sessions** — session behavior is adapted per platform instead of forcing one thread model everywhere
 - **Concurrent conversations** — Slack threads, Discord replies/threads, and Telegram reply chains can run independently
-- **Sandbox execution** — run agent commands on host, in a container, or in a Firecracker VM
-- **Credential vaults** — `/login` stores credentials under `--state-dir` and injects env only into container/Firecracker runs
+- **Sandbox execution** — run agent commands on host, in a shared container, in a managed per-user container, or in a Firecracker VM
+- **Credential vaults** — `/login` stores credentials under `--state-dir` and injects env only into container/image/Firecracker runs
 - **Persistent memory** — workspace-level and channel-level `MEMORY.md` files
 - **Skills** — drop custom CLI tools into `skills/` directories
 - **Event system** — schedule one-shot or recurring tasks via JSON files
@@ -170,7 +170,7 @@ Or import this **App Manifest** directly (Settings → App Manifest → paste JS
 export MOM_SLACK_APP_TOKEN=xapp-...
 export MOM_SLACK_BOT_TOKEN=xoxb-...
 
-mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|firecracker:<vm-id>:<path>] <working-directory>
+mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|image:<image>|firecracker:<vm-id>:<path>] <working-directory>
 ```
 
 The bot responds when `@mentioned` in any channel or via DM.
@@ -189,7 +189,7 @@ The bot responds when `@mentioned` in any channel or via DM.
 ```bash
 export MOM_TELEGRAM_BOT_TOKEN=123456:ABC-...
 
-mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|firecracker:<vm-id>:<path>] <working-directory>
+mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|image:<image>|firecracker:<vm-id>:<path>] <working-directory>
 ```
 
 - **Private chats** — every message is forwarded to the bot automatically.
@@ -209,7 +209,7 @@ mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|firecracker:<vm
 ```bash
 export MOM_DISCORD_BOT_TOKEN=MTI...
 
-mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|firecracker:<vm-id>:<path>] <working-directory>
+mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|image:<image>|firecracker:<vm-id>:<path>] <working-directory>
 ```
 
 - **Server channels** — the bot responds when `@mentioned`.
@@ -226,16 +226,18 @@ mama [--state-dir=~/.mama] [--sandbox=host|container:<container>|firecracker:<vm
 | -------------------------------------- | --------- | -------------------------------------------------------- |
 | `--state-dir=<dir>`                    | `~/.mama` | Store credential vaults and bindings outside workspace   |
 | `--sandbox=host`                       | ✓         | Run commands directly on host; vault env is not injected |
-| `--sandbox=container:<name>`           |           | Run commands in an existing container                    |
+| `--sandbox=container:<name>`           |           | Run commands in an existing shared container             |
+| `--sandbox=image:<image>`              |           | Auto-provision one Docker container per platform user    |
 | `--sandbox=firecracker:<vm-id>:<path>` |           | Run commands inside a Firecracker microVM                |
 | `--download <channel-id>`              |           | Download channel history to stdout and exit (Slack only) |
 
 ### Sandbox and Vault Semantics
 
 - `host`: no vault env injection.
-- `container:<name>`: one container maps to one vault key: `container-<name>`.
+- `container:<name>`: one container maps to one shared vault key: `container-<name>`.
+- `image:<image>`: mama creates one container per resolved vault/user and injects that vault's env and file mounts.
 - `firecracker:*`: per-user vault routing via `bindings.json` first, then direct userId vault.
-- `docker:*` and `image:*` are reserved for future managed-container modes.
+- `docker:*` is not supported; use `container:*` or `image:*`.
 
 See [docs/sandbox.md](docs/sandbox.md) for the full sandbox/vault behavior matrix.
 
@@ -262,7 +264,7 @@ Built-in OAuth guides:
 - [GitHub OAuth](docs/oauth/github.md)
 - [Google Workspace CLI OAuth](docs/oauth/google-workspace.md)
 
-Credentials are stored under `<state-dir>/vaults` (default `~/.mama/vaults`). Runtime env injection only happens in `container` and `firecracker` modes.
+Credentials are stored under `<state-dir>/vaults` (default `~/.mama/vaults`). Runtime env injection only happens in `container`, `image`, and `firecracker` modes.
 
 ## Configuration
 
@@ -350,6 +352,18 @@ mama --sandbox=container:mama-tools /path/to/workspace
 ```
 
 `container:mama-tools` uses vault key `container-mama-tools`. If multiple users share the same container, they share that container vault.
+
+## Managed Per-User Container Sandbox
+
+```bash
+# Build the bundled image once
+docker build -f docker/mama-sandbox.Dockerfile -t mama-sandbox:tools .
+
+# Start mama with managed image sandboxes
+mama --sandbox=image:mama-sandbox:tools /path/to/workspace
+```
+
+In this mode mama creates one Docker container per resolved vault/user, mounts the workspace at `/workspace`, injects vault env on execution, mounts any credential files declared in the vault, and stops idle containers automatically.
 
 ## Firecracker Sandbox
 

--- a/docker/mama-sandbox.Dockerfile
+++ b/docker/mama-sandbox.Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NVM_DIR=/root/.nvm
+ENV CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+SHELL ["/bin/bash", "-lc"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bash \
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  gnupg \
+  jq \
+  less \
+  openssh-client \
+  unzip \
+  xz-utils \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null \
+  && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG NODE_VERSION=22
+
+RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
+  && source "$NVM_DIR/nvm.sh" \
+  && nvm install "$NODE_VERSION" \
+  && nvm alias default "$NODE_VERSION" \
+  && NODE_BIN_DIR="$NVM_DIR/versions/node/$(nvm version "$NODE_VERSION")/bin" \
+  && ln -sf "$NODE_BIN_DIR/node" /usr/local/bin/node \
+  && ln -sf "$NODE_BIN_DIR/npm" /usr/local/bin/npm \
+  && ln -sf "$NODE_BIN_DIR/npx" /usr/local/bin/npx \
+  && ln -sf "$NODE_BIN_DIR/corepack" /usr/local/bin/corepack \
+  && npm install -g @googleworkspace/cli \
+  && ln -sf "$NODE_BIN_DIR/gws" /usr/local/bin/gws
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+  && ln -sf /root/.local/bin/uv /usr/local/bin/uv \
+  && ln -sf /root/.local/bin/uvx /usr/local/bin/uvx
+
+RUN curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/root \
+  && ln -sf /root/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud \
+  && ln -sf /root/google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil \
+  && ln -sf /root/google-cloud-sdk/bin/bq /usr/local/bin/bq
+
+WORKDIR /workspace
+
+CMD ["sleep", "infinity"]

--- a/docker/mama-sandbox.Dockerfile
+++ b/docker/mama-sandbox.Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   jq \
   less \
   openssh-client \
+  python-is-python3 \
+  tini \
   unzip \
   xz-utils \
   zip \
@@ -56,4 +58,5 @@ RUN curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts --ins
 
 WORKDIR /workspace
 
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["sleep", "infinity"]

--- a/docs/oauth/google-workspace.md
+++ b/docs/oauth/google-workspace.md
@@ -2,7 +2,7 @@
 
 這份文件說明如何設定 mama `/login` 內建的 Google Workspace CLI OAuth。
 
-> 注意：目前 mama 會把 Google authorized_user JSON 存進 vault，並保存 target path metadata；但現有 `container` / `firecracker` runtime 尚未自動把 vault file 投影到 sandbox 內的 target path。env token 類 credential 會自動注入，file credential 的自動投影會在後續 PR 處理。
+> 注意：mama 會把 Google authorized_user JSON 存進 vault，並保存 target path metadata。`image` sandbox 會把這類 vault file 自動投影到 container 內的 target path；現有 `container` / `firecracker` runtime 仍不會自動做 file projection。
 
 ## 1. 建立 Google OAuth Client
 
@@ -75,4 +75,4 @@ export MOM_GOOGLE_WORKSPACE_CLI_OAUTH_SCOPES="https://www.googleapis.com/auth/dr
 
 - mama 使用 web OAuth callback，因此 Google OAuth client 必須是 `Web application`，不是 desktop app。
 - 如果 Google 沒有回傳 `refresh_token`，請撤銷既有 consent 後重新 `/login`。mama 會要求 `access_type=offline` 與 `prompt=consent`，但 Google 仍可能因既有授權而省略 refresh token。
-- file credential 自動投影尚未完成；目前請把這份文件視為 OAuth provisioning 設定，而不是完整 gws runtime 使用教學。
+- 若要讓 `gws.json` 自動出現在 `/root/.config/gws/credentials.json`，請使用 `image` sandbox。`container` / `firecracker` 目前仍只會保存 file credential metadata，不會自動投影。

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -8,9 +8,10 @@
 | ----------------------------------------------------------- | --------------------- | ------------------- | ----------------------------------------- | -------------------------------------------------------------- |
 | `host`                                                      | 宿主機                | 不注入              | 可存，但執行時不用                        | 最適合本機開發；不把 vault env 放進 host process               |
 | `container:<name>`                                          | 既有 Docker container | 注入                | `container-<name>`                        | one container one vault；多人共用同一 container 就共用該 vault |
+| `image:<image>`                                             | mama 管理的 Docker    | 注入                | binding / direct userId / generated vault | per-user container lifecycle 由 mama 管理                      |
 | `firecracker:<vm-id>:<host-path>[:<ssh-user>[:<ssh-port>]]` | Firecracker VM        | 注入                | binding 優先，再 fallback 到 userId vault | VM 需自行啟動，workspace 需在 VM 內掛到 `/workspace`           |
 
-目前 `docker:*` / `image:*` 不是可用模式；`image:*` 保留給未來由 mama 管理 per-user container lifecycle 的設計。
+`docker:*` 不是可用模式；請改用 `container:*` 或 `image:*`。
 
 ---
 
@@ -130,6 +131,38 @@ container-<name>
 
 ---
 
+## `image:<image>`
+
+```bash
+# Build the bundled image once
+docker build -f docker/mama-sandbox.Dockerfile -t mama-sandbox:tools .
+
+# Run mama with managed per-user containers
+mama --sandbox=image:mama-sandbox:tools /path/to/workspace
+```
+
+特性：
+
+- mama 會為每個 resolved vault / user 建立一個獨立 container
+- workspace 會固定 mount 到 `/workspace`
+- vault env 會在執行時注入
+- vault file credential 會依 target path 自動 bind mount 進 container
+- 閒置 container 會自動 stop；下次需要時再 start 或 recreate
+
+vault key 選擇邏輯：
+
+1. 先看 `bindings.json` 是否把 platform user 綁到指定 vault
+2. 若沒有 binding，但存在同名 `userId` vault，使用該 direct vault
+3. 若都沒有，建立一個 platform-scoped vault key，例如 `slack-u123`
+
+適合：
+
+- 多使用者共用一個 mama instance
+- 需要 per-user env/file credential isolation
+- 想比 shared container 更安全，但又不想直接上 Firecracker
+
+---
+
 ## `firecracker:<vm-id>:<host-path>`
 
 ```bash
@@ -226,4 +259,4 @@ OAuth callback URL 是：
 }
 ```
 
-目前 binding 主要影響 `firecracker` 這類 per-user routing 模式。`container:<name>` 會固定使用 container vault，因此不看 per-user binding。
+目前 binding 主要影響 `image` / `firecracker` 這類 per-user routing 模式。`container:<name>` 會固定使用 container vault，因此不看 per-user binding。

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -22,6 +22,7 @@ import { createMamaSettingsManager, syncLogToSessionManager } from "./context.js
 import { ActorExecutionResolver } from "./execution-resolver.js";
 import * as log from "./log.js";
 import type { UserBindingStore } from "./bindings.js";
+import type { DockerContainerManager } from "./provisioner.js";
 import { createExecutor, type Executor, type SandboxConfig } from "./sandbox.js";
 import { addLifecycleBreadcrumb, metricAttributes } from "./sentry.js";
 import type { VaultManager } from "./vault.js";
@@ -145,7 +146,8 @@ function buildSystemPrompt(
   skills: Skill[],
 ): string {
   const channelPath = `${workspacePath}/${channelId}`;
-  const isContainer = sandboxConfig.type === "container";
+  const isContainer = sandboxConfig.type === "container" || sandboxConfig.type === "image";
+  const isImageSandbox = sandboxConfig.type === "image";
   const isFirecracker = sandboxConfig.type === "firecracker";
 
   // Format channel mappings
@@ -160,17 +162,22 @@ function buildSystemPrompt(
       ? platform.users.map((u) => `${u.id}\t@${u.userName}\t${u.displayName}`).join("\n")
       : "(no users loaded)";
 
-  const envDescription = isContainer
-    ? `You are running inside a container (Docker runtime, Alpine Linux).
+  const envDescription = isImageSandbox
+    ? `You are running inside a managed per-user container.
 - Bash working directory: / (use cd or absolute paths)
-- Install tools with: apk add <package>
+- Install tools with the image's package manager
+- Your changes persist for this user's container until it is recreated`
+    : isContainer
+      ? `You are running inside a shared container.
+- Bash working directory: / (use cd or absolute paths)
+- Install tools with the container's package manager
 - Your changes persist across sessions`
-    : isFirecracker
-      ? `You are running inside a Firecracker microVM.
+      : isFirecracker
+        ? `You are running inside a Firecracker microVM.
 - Bash working directory: / (use cd or absolute paths)
 - Install tools with: apt-get install <package> (Debian-based)
 - Your changes persist across sessions`
-      : `You are running directly on the host machine.
+        : `You are running directly on the host machine.
 - Bash working directory: ${process.cwd()}
 - Be careful with system modifications`;
 
@@ -262,7 +269,7 @@ All \`at\` timestamps must include offset (e.g., \`+01:00\`). Periodic events us
 ### Platform and Credential Routing
 Set \`platform\` to the target bot platform (\`${platform.name}\` for this conversation). When only one platform is running, omitting \`platform\` is allowed for backward compatibility, but include it by default to avoid ambiguity.
 
-Set \`userId\` to the platform userId of whoever asked for the event. When the event fires, tool execution routes using that user's vault selection in per-user modes. In \`container:<name>\`, events use the container's single vault.
+Set \`userId\` to the platform userId of whoever asked for the event. When the event fires, tool execution routes using that user's vault selection in per-user modes. In \`container:<name>\`, events use the container's single shared vault.
 
 Prefer the \`event\` tool over manually writing JSON files; it fills \`platform\`, \`channelId\`, and \`userId\` for the current conversation automatically.
 
@@ -421,6 +428,7 @@ export async function createRunner(
   workspaceDir: string,
   vaultManager?: VaultManager,
   bindingStore?: UserBindingStore,
+  provisioner?: DockerContainerManager,
 ): Promise<AgentRunner> {
   const agentConfig = loadAgentConfig(workspaceDir);
 
@@ -433,8 +441,11 @@ export async function createRunner(
   const executionResolver =
     vaultManager &&
     sandboxConfig.type !== "host" &&
-    (vaultManager.isEnabled() || !!bindingStore || sandboxConfig.type === "container")
-      ? new ActorExecutionResolver(sandboxConfig, vaultManager, bindingStore)
+    (vaultManager.isEnabled() ||
+      !!bindingStore ||
+      sandboxConfig.type === "container" ||
+      sandboxConfig.type === "image")
+      ? new ActorExecutionResolver(sandboxConfig, vaultManager, bindingStore, provisioner)
       : undefined;
   let activeExecutor: Executor =
     executionResolver !== undefined

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -1,6 +1,8 @@
+import { existsSync } from "fs";
 import type { UserBindingStore } from "./bindings.js";
+import { DockerContainerManager, type ContainerMount } from "./provisioner.js";
 import { createExecutor, type Executor, type SandboxConfig } from "./sandbox.js";
-import type { VaultManager } from "./vault.js";
+import type { ResolvedVault, VaultManager } from "./vault.js";
 import { ensureSandboxVaultEntry, resolveActorVaultKey } from "./vault-routing.js";
 
 export interface ActorContext {
@@ -13,6 +15,7 @@ export class ActorExecutionResolver {
     private baseConfig: SandboxConfig,
     private vaultManager: VaultManager,
     private bindingStore?: UserBindingStore,
+    private provisioner?: DockerContainerManager,
   ) {}
 
   refresh(): void {
@@ -40,6 +43,38 @@ export class ActorExecutionResolver {
     const config = this.vaultManager.getSandboxConfig(vaultKey, this.baseConfig);
     const env =
       config.type !== "host" && vault && Object.keys(vault.env).length > 0 ? vault.env : undefined;
-    return createExecutor(config, env);
+    return createExecutor(config, env, this.getEnsureReady(vaultKey, config, vault));
+  }
+
+  private getEnsureReady(
+    vaultKey: string,
+    config: SandboxConfig,
+    vault?: ResolvedVault,
+  ): (() => Promise<void>) | undefined {
+    if (this.baseConfig.type !== "image" || config.type !== "container") {
+      return undefined;
+    }
+
+    return async () => {
+      const expected = config.container || DockerContainerManager.containerName(vaultKey);
+      const actual = await this.provisioner?.provision(vaultKey, {
+        containerName: expected,
+        mounts: vault ? this.resolveMounts(vault) : [],
+      });
+      if (actual && actual !== expected) {
+        throw new Error(
+          `Provisioner returned container "${actual}" for vault "${vaultKey}", expected "${expected}"`,
+        );
+      }
+    };
+  }
+
+  private resolveMounts(vault: ResolvedVault): ContainerMount[] {
+    const mountsByTarget = new Map<string, ContainerMount>();
+    for (const mount of vault.mounts) {
+      if (!existsSync(mount.source)) continue;
+      mountsByTarget.set(mount.target, { source: mount.source, target: mount.target });
+    }
+    return [...mountsByTarget.values()];
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { FileUserBindingStore } from "./bindings.js";
 import { startLinkServer } from "./link-server.js";
 import { parseLoginCommand } from "./login.js";
 import { InMemoryLinkTokenStore } from "./link-token.js";
+import { DockerContainerManager } from "./provisioner.js";
 import { SandboxError, parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
 import { FileVaultManager } from "./vault.js";
 import {
@@ -194,7 +195,7 @@ if (parsedArgs.downloadChannel) {
 // Normal bot mode - require working dir
 if (!parsedArgs.workingDir) {
   console.error(
-    "Usage: mama [--state-dir=<dir>] [--sandbox=host|container:<name>|firecracker:<vm-id>:<host-path>] <working-directory>",
+    "Usage: mama [--state-dir=<dir>] [--sandbox=host|container:<name>|image:<image>|firecracker:<vm-id>:<host-path>] <working-directory>",
   );
   console.error("       mama --download <channel-id>");
   process.exit(1);
@@ -231,7 +232,7 @@ if (vaultManager.isEnabled()) {
   console.log(
     sandbox.type === "container"
       ? "  Vault system enabled. Container vault active."
-      : sandbox.type === "firecracker"
+      : sandbox.type === "image" || sandbox.type === "firecracker"
         ? "  Vault system enabled. Per-user credential routing active."
         : "  Vault system enabled. Host mode will not inject vault env.",
   );
@@ -242,11 +243,14 @@ if (bindingStore.isEnabled()) {
   console.log(
     sandbox.type === "container"
       ? "  Binding store enabled. Container mode uses the container vault."
-      : sandbox.type === "firecracker"
+      : sandbox.type === "image" || sandbox.type === "firecracker"
         ? "  Binding store enabled. Platform user → vault routing active."
         : "  Binding store enabled. Host mode will not inject vault env.",
   );
 }
+
+const provisioner =
+  sandbox.type === "image" ? new DockerContainerManager(sandbox.image, workingDir) : undefined;
 
 const linkTokenStore = new InMemoryLinkTokenStore();
 setInterval(() => linkTokenStore.purge(), 5 * 60 * 1000).unref();
@@ -275,7 +279,7 @@ function ensureLoginVault(platform: string, platformUserId: string): string {
   );
 
   ensureSandboxVaultEntry(sandbox, vaultManager, platform, platformUserId, vaultId);
-  if (sandbox.type !== "container") {
+  if (sandbox.type !== "container" && sandbox.type !== "image") {
     vaultManager.addEntry(vaultId, createManagedVaultEntry(platform, platformUserId, vaultId));
   }
 
@@ -366,6 +370,14 @@ let isShuttingDown = false;
 const MAX_SESSIONS = 500;
 /** Idle timeout before a non-running session can be evicted (1 hour) */
 const IDLE_TIMEOUT_MS = 3600000;
+/** Idle timeout for managed image containers (10 minutes) */
+const IMAGE_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+
+if (provisioner) {
+  await provisioner.reconcile();
+  await provisioner.stopIdle(IMAGE_IDLE_TIMEOUT_MS);
+  setInterval(() => provisioner.stopIdle(IMAGE_IDLE_TIMEOUT_MS), IMAGE_IDLE_TIMEOUT_MS).unref();
+}
 
 async function getState(channelId: string, sessionKey?: string): Promise<ChannelState> {
   const key = sessionKey ?? channelId;
@@ -382,6 +394,7 @@ async function getState(channelId: string, sessionKey?: string): Promise<Channel
         workingDir,
         vaultManager,
         bindingStore,
+        provisioner,
       ),
       stopRequested: false,
       lastAccessedAt: Date.now(),
@@ -639,7 +652,9 @@ const sandboxDesc =
     ? "host"
     : sandbox.type === "container"
       ? `container:${sandbox.container}`
-      : `firecracker:${sandbox.vmId}`;
+      : sandbox.type === "image"
+        ? `image:${sandbox.image}`
+        : `firecracker:${sandbox.vmId}`;
 log.logStartup(workingDir, sandboxDesc);
 
 // Create platform bots

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -1,0 +1,360 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import * as log from "./log.js";
+
+const execFileAsync = promisify(execFile);
+type ExecFileAsync = typeof execFileAsync;
+
+type ContainerStatus = "running" | "stopped" | "missing";
+
+interface ContainerState {
+  status: ContainerStatus;
+  lastUsed: number;
+  containerName: string;
+}
+
+export interface ContainerMount {
+  source: string;
+  target: string;
+}
+
+export interface ProvisionOptions {
+  containerName?: string;
+  mounts?: ContainerMount[];
+}
+
+export class DockerContainerManager {
+  private state = new Map<string, ContainerState>();
+  private inflight = new Map<string, Promise<string>>();
+  private static readonly MANAGED_LABEL = "mama.managed=true";
+  private static readonly IMAGE_MODE_LABEL = "mama.sandbox=image";
+  private static readonly VAULT_ID_LABEL_KEY = "mama.vault-id";
+
+  constructor(
+    private readonly image: string,
+    private readonly workspaceDir: string,
+    private readonly execFileImpl: ExecFileAsync = execFileAsync,
+  ) {}
+
+  static sanitizeSegment(value: string): string {
+    const sanitized = value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    return sanitized || "unknown";
+  }
+
+  static vaultId(platform: string, platformUserId: string): string {
+    return `${DockerContainerManager.sanitizeSegment(platform)}-${DockerContainerManager.sanitizeSegment(platformUserId)}`;
+  }
+
+  static containerName(vaultId: string): string {
+    return `mama-sandbox-${vaultId}`;
+  }
+
+  async provision(vaultId: string, options: ProvisionOptions = {}): Promise<string> {
+    const existing = this.inflight.get(vaultId);
+    if (existing) return existing;
+
+    const pending = this.provisionInner(vaultId, options).finally(() => {
+      this.inflight.delete(vaultId);
+    });
+    this.inflight.set(vaultId, pending);
+    return pending;
+  }
+
+  private async provisionInner(vaultId: string, options: ProvisionOptions): Promise<string> {
+    const containerName = options.containerName ?? DockerContainerManager.containerName(vaultId);
+    const mounts = options.mounts ?? [];
+    const status = await this.inspectStatus(containerName);
+
+    try {
+      if (status !== "missing" && (await this.hasBindMountDrift(containerName, mounts))) {
+        log.logInfo(`Container ${containerName} mounts changed; recreating container`);
+        await this.execFileImpl("docker", ["rm", "-f", containerName]);
+        await this.runContainer(vaultId, containerName, mounts);
+        log.logInfo(`Container ${containerName} recreated`);
+      } else if (status === "running") {
+        log.logInfo(`Container ${containerName} already running`);
+      } else if (status === "stopped") {
+        await this.execFileImpl("docker", ["start", containerName]);
+        log.logInfo(`Container ${containerName} started`);
+      } else {
+        await this.runContainer(vaultId, containerName, mounts);
+        log.logInfo(`Container ${containerName} created`);
+      }
+    } catch (err) {
+      this.state.delete(vaultId);
+      throw err;
+    }
+
+    this.setState(vaultId, "running", containerName);
+    return containerName;
+  }
+
+  async stop(vaultId: string): Promise<void> {
+    const containerName = this.getContainerName(vaultId);
+    try {
+      await this.execFileImpl("docker", ["stop", containerName]);
+      this.setState(vaultId, "stopped", containerName);
+      log.logInfo(`Container ${containerName} stopped (idle)`);
+    } catch (err) {
+      log.logWarning(
+        `Failed to stop container ${containerName}`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  async remove(vaultId: string): Promise<void> {
+    const containerName = this.getContainerName(vaultId);
+    try {
+      await this.execFileImpl("docker", ["rm", "-f", containerName]);
+      this.state.delete(vaultId);
+      log.logInfo(`Container ${containerName} removed`);
+    } catch (err) {
+      log.logWarning(
+        `Failed to remove container ${containerName}`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  async stopIdle(maxIdleMs: number): Promise<void> {
+    const now = Date.now();
+    const toStop: string[] = [];
+    for (const [vaultId, containerState] of this.state) {
+      if (containerState.status === "running" && now - containerState.lastUsed > maxIdleMs) {
+        toStop.push(vaultId);
+      }
+    }
+    await Promise.all(toStop.map((vaultId) => this.stop(vaultId)));
+  }
+
+  async reconcile(): Promise<void> {
+    const discovered = new Set<string>();
+    const labeledNames = await this.listContainerNamesByLabel();
+    for (const name of labeledNames) discovered.add(name);
+    const legacyNames = await this.listContainerNamesByPrefix();
+    for (const name of legacyNames) discovered.add(name);
+
+    this.state.clear();
+
+    for (const containerName of discovered) {
+      const details = await this.inspectContainerDetails(containerName);
+      if (!details) continue;
+
+      const vaultId = details.vaultId || this.vaultIdFromContainerName(containerName);
+      if (!vaultId) {
+        log.logWarning(`Skipping unmanaged-style container without vault id`, containerName);
+        continue;
+      }
+
+      const status: ContainerStatus = details.running ? "running" : "stopped";
+      const lastUsed = details.startedAtMs ?? Date.now();
+      this.state.set(vaultId, { status, lastUsed, containerName });
+    }
+
+    const running = Array.from(this.state.values()).filter((s) => s.status === "running").length;
+    const stopped = this.state.size - running;
+    log.logInfo(
+      `Reconciled ${this.state.size} managed containers (running=${running}, stopped=${stopped})`,
+    );
+  }
+
+  private setState(vaultId: string, status: ContainerStatus, containerName: string): void {
+    this.state.set(vaultId, { status, lastUsed: Date.now(), containerName });
+  }
+
+  private getContainerName(vaultId: string): string {
+    return this.state.get(vaultId)?.containerName ?? DockerContainerManager.containerName(vaultId);
+  }
+
+  private mountArgs(mounts: ContainerMount[]): string[] {
+    return mounts.flatMap((mount) => ["-v", this.toBindSpec(mount)]);
+  }
+
+  private toBindSpec(mount: ContainerMount): string {
+    return `${mount.source}:${mount.target}`;
+  }
+
+  private async runContainer(
+    vaultId: string,
+    containerName: string,
+    mounts: ContainerMount[],
+  ): Promise<void> {
+    log.logInfo(`Creating container ${containerName} from image ${this.image}`);
+    await this.execFileImpl("docker", [
+      "run",
+      "-d",
+      "--name",
+      containerName,
+      "--label",
+      DockerContainerManager.MANAGED_LABEL,
+      "--label",
+      DockerContainerManager.IMAGE_MODE_LABEL,
+      "--label",
+      `${DockerContainerManager.VAULT_ID_LABEL_KEY}=${vaultId}`,
+      "-v",
+      `${this.workspaceDir}:/workspace`,
+      ...this.mountArgs(mounts),
+      this.image,
+      "sleep",
+      "infinity",
+    ]);
+  }
+
+  private async hasBindMountDrift(
+    containerName: string,
+    mounts: ContainerMount[],
+  ): Promise<boolean> {
+    const expected = this.expectedBinds(mounts);
+    const actual = await this.inspectBindMounts(containerName);
+    return !this.sameBinds(expected, actual);
+  }
+
+  private expectedBinds(mounts: ContainerMount[]): string[] {
+    return [`${this.workspaceDir}:/workspace`, ...mounts.map((mount) => this.toBindSpec(mount))]
+      .slice()
+      .sort();
+  }
+
+  private sameBinds(expected: string[], actual: string[]): boolean {
+    if (expected.length !== actual.length) {
+      return false;
+    }
+
+    return expected.every((bind, index) => bind === actual[index]);
+  }
+
+  private async inspectBindMounts(containerName: string): Promise<string[]> {
+    const { stdout } = await this.execFileImpl("docker", [
+      "inspect",
+      "-f",
+      "{{json .HostConfig.Binds}}",
+      containerName,
+    ]);
+    const payload = stdout.trim();
+    const parsed = JSON.parse(payload.length > 0 ? payload : "null") as unknown;
+
+    if (parsed === null) {
+      return [];
+    }
+
+    if (!Array.isArray(parsed) || parsed.some((bind) => typeof bind !== "string")) {
+      throw new Error(`Unexpected docker bind mount payload for container "${containerName}"`);
+    }
+
+    return [...parsed].sort();
+  }
+
+  private async inspectStatus(containerName: string): Promise<ContainerStatus> {
+    try {
+      const { stdout } = await this.execFileImpl("docker", [
+        "inspect",
+        "-f",
+        "{{.State.Running}}",
+        containerName,
+      ]);
+      return stdout.trim() === "true" ? "running" : "stopped";
+    } catch {
+      return "missing";
+    }
+  }
+
+  private async listContainerNamesByLabel(): Promise<string[]> {
+    try {
+      const { stdout } = await this.execFileImpl("docker", [
+        "ps",
+        "-a",
+        "--filter",
+        `label=${DockerContainerManager.MANAGED_LABEL}`,
+        "--filter",
+        `label=${DockerContainerManager.IMAGE_MODE_LABEL}`,
+        "--format",
+        "{{.Names}}",
+      ]);
+      return this.parseNameLines(stdout);
+    } catch (err) {
+      log.logWarning(
+        "Failed to list labeled managed containers",
+        err instanceof Error ? err.message : String(err),
+      );
+      return [];
+    }
+  }
+
+  private async listContainerNamesByPrefix(): Promise<string[]> {
+    try {
+      const { stdout } = await this.execFileImpl("docker", [
+        "ps",
+        "-a",
+        "--filter",
+        `name=${DockerContainerManager.containerName("")}`,
+        "--format",
+        "{{.Names}}",
+      ]);
+      return this.parseNameLines(stdout);
+    } catch (err) {
+      log.logWarning(
+        "Failed to list legacy managed containers",
+        err instanceof Error ? err.message : String(err),
+      );
+      return [];
+    }
+  }
+
+  private parseNameLines(stdout: string): string[] {
+    return stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+
+  private async inspectContainerDetails(
+    containerName: string,
+  ): Promise<{ running: boolean; startedAtMs?: number; vaultId?: string } | undefined> {
+    try {
+      const { stdout } = await this.execFileImpl("docker", [
+        "inspect",
+        "-f",
+        `{{.State.Running}}\t{{.State.StartedAt}}\t{{index .Config.Labels "${DockerContainerManager.VAULT_ID_LABEL_KEY}"}}`,
+        containerName,
+      ]);
+      const [runningRaw, startedAtRaw, vaultIdRaw] = stdout.trim().split("\t");
+      const running = runningRaw === "true";
+      const startedAtMs = this.parseDockerTimestamp(startedAtRaw);
+      const vaultId = this.normalizeDockerValue(vaultIdRaw);
+      return { running, startedAtMs, vaultId };
+    } catch (err) {
+      log.logWarning(
+        `Failed to inspect container ${containerName} during reconcile`,
+        err instanceof Error ? err.message : String(err),
+      );
+      return undefined;
+    }
+  }
+
+  private normalizeDockerValue(value?: string): string | undefined {
+    if (!value || value === "<no value>") return undefined;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  private parseDockerTimestamp(value?: string): number | undefined {
+    const normalized = this.normalizeDockerValue(value);
+    if (!normalized || normalized.startsWith("0001-")) return undefined;
+    const parsed = Date.parse(normalized);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+
+  private vaultIdFromContainerName(containerName: string): string | undefined {
+    const prefix = DockerContainerManager.containerName("");
+    if (!containerName.startsWith(prefix)) return undefined;
+    const vaultId = containerName.slice(prefix.length);
+    return vaultId.length > 0 ? vaultId : undefined;
+  }
+}
+
+/** @deprecated Use DockerContainerManager */
+export const DockerProvisioner = DockerContainerManager;

--- a/src/sandbox/image.ts
+++ b/src/sandbox/image.ts
@@ -1,0 +1,33 @@
+import type { ImageSandboxConfig, SandboxAdapter } from "./types.js";
+import { SandboxError } from "./errors.js";
+import { execSimple } from "./utils.js";
+
+export function parseImageSandboxArg(value: string): ImageSandboxConfig | undefined {
+  if (!value.startsWith("image:")) {
+    return undefined;
+  }
+
+  const image = value.slice("image:".length);
+  if (!image) {
+    throw new SandboxError("Error: image sandbox requires image name (e.g., image:ubuntu:24.04)");
+  }
+  return { type: "image", image };
+}
+
+export async function validateImageSandbox(config: ImageSandboxConfig): Promise<void> {
+  try {
+    await execSimple("docker", ["--version"]);
+  } catch {
+    throw new SandboxError("Error: Docker is not installed or not in PATH");
+  }
+  console.log(`  Image auto-provisioning enabled. Image: ${config.image}`);
+}
+
+export const imageSandboxAdapter: SandboxAdapter<ImageSandboxConfig> = {
+  type: "image",
+  parse: parseImageSandboxArg,
+  validate: validateImageSandbox,
+  createExecutor: () => {
+    throw new SandboxError("Error: image sandbox must resolve to a concrete container executor");
+  },
+};

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -16,6 +16,7 @@ import {
   parseHostSandboxArg,
   validateHostSandbox,
 } from "./host.js";
+import { imageSandboxAdapter, parseImageSandboxArg, validateImageSandbox } from "./image.js";
 import { SandboxError } from "./errors.js";
 import type { Executor, SandboxAdapter, SandboxConfig } from "./types.js";
 
@@ -26,6 +27,7 @@ export type {
   Executor,
   FirecrackerSandboxConfig,
   HostSandboxConfig,
+  ImageSandboxConfig,
   SandboxAdapter,
   SandboxConfig,
 } from "./types.js";
@@ -43,10 +45,12 @@ export {
   validateFirecrackerSandbox,
 } from "./firecracker.js";
 export { hostSandboxAdapter, parseHostSandboxArg, validateHostSandbox } from "./host.js";
+export { imageSandboxAdapter, parseImageSandboxArg, validateImageSandbox } from "./image.js";
 
 const sandboxAdapters = [
   hostSandboxAdapter,
   containerSandboxAdapter,
+  imageSandboxAdapter,
   firecrackerSandboxAdapter,
 ] as const;
 const sandboxAdapterByType = new Map(
@@ -65,14 +69,14 @@ export function parseSandboxArg(value: string): SandboxConfig {
     }
   }
 
-  if (value.startsWith("docker:") || value.startsWith("image:")) {
+  if (value.startsWith("docker:")) {
     throw new SandboxError(
-      `Error: '${value}' is not supported yet. Use 'container:<container-name>' for the shared-container mode. Future 'docker:'/'image:' modes are reserved for per-session containers managed by mama.`,
+      `Error: '${value}' is not supported. Use 'container:<container-name>' for the shared-container mode or 'image:<image-name>' for mama-managed per-user containers.`,
     );
   }
 
   throw new SandboxError(
-    `Error: Invalid sandbox type '${value}'. Use 'host', 'container:<container-name>', or 'firecracker:<vm-id>:<host-path>'`,
+    `Error: Invalid sandbox type '${value}'. Use 'host', 'container:<container-name>', 'image:<image-name>', or 'firecracker:<vm-id>:<host-path>'`,
   );
 }
 

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -1,4 +1,8 @@
-export type SandboxConfig = HostSandboxConfig | ContainerSandboxConfig | FirecrackerSandboxConfig;
+export type SandboxConfig =
+  | HostSandboxConfig
+  | ContainerSandboxConfig
+  | ImageSandboxConfig
+  | FirecrackerSandboxConfig;
 
 export interface HostSandboxConfig {
   type: "host";
@@ -7,6 +11,11 @@ export interface HostSandboxConfig {
 export interface ContainerSandboxConfig {
   type: "container";
   container: string;
+}
+
+export interface ImageSandboxConfig {
+  type: "image";
+  image: string;
 }
 
 export interface FirecrackerSandboxConfig {

--- a/src/vault-routing.ts
+++ b/src/vault-routing.ts
@@ -1,4 +1,5 @@
 import type { UserBindingStore } from "./bindings.js";
+import { DockerContainerManager } from "./provisioner.js";
 import type { SandboxConfig } from "./sandbox.js";
 import type { VaultEntry, VaultManager } from "./vault.js";
 
@@ -22,17 +23,26 @@ export function resolveActorVaultKey(
     return userId;
   }
 
-  return userId;
+  return baseConfig.type === "image" ? DockerContainerManager.vaultId(platform, userId) : userId;
 }
 
 export function createManagedVaultEntry(
   platform: string,
   userId: string,
-  _vaultKey: string,
+  vaultKey: string,
+  withImageSandbox = false,
 ): VaultEntry {
   return {
     displayName: `${platform}:${userId}`,
     platform: asVaultPlatform(platform),
+    ...(withImageSandbox
+      ? {
+          sandbox: {
+            type: "image" as const,
+            container: DockerContainerManager.containerName(vaultKey),
+          },
+        }
+      : {}),
   };
 }
 
@@ -48,18 +58,22 @@ export function createSharedContainerVaultEntry(containerName: string): VaultEnt
 
 export function ensureSandboxVaultEntry(
   baseConfig: SandboxConfig,
-  vaultManager: Pick<VaultManager, "addEntry">,
-  _platform: string,
-  _userId: string,
+  vaultManager: Pick<VaultManager, "addEntry" | "ensureImageSandboxEntry">,
+  platform: string,
+  userId: string,
   vaultKey: string,
 ): void {
-  if (baseConfig.type === "container") {
-    vaultManager.addEntry(vaultKey, createSharedContainerVaultEntry(baseConfig.container));
+  if (baseConfig.type === "image") {
+    vaultManager.ensureImageSandboxEntry(
+      vaultKey,
+      createManagedVaultEntry(platform, userId, vaultKey, true),
+    );
     return;
   }
 
-  // Host and firecracker modes should not create credential entries merely
-  // because a user sent a message. `/login` owns first-time vault creation.
+  if (baseConfig.type === "container") {
+    vaultManager.addEntry(vaultKey, createSharedContainerVaultEntry(baseConfig.container));
+  }
 }
 
 function asVaultPlatform(platform: string): VaultEntry["platform"] | undefined {

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -218,10 +218,14 @@ export class FileVaultManager implements VaultManager {
     const override = vault.sandboxOverride;
 
     if (override.type === "image") {
-      throw new Error(
-        `vault "${userId}" sets sandbox.type=image, but image sandbox support is not enabled in this build. ` +
-          "Use sandbox.type=firecracker or merge the managed image sandbox change first.",
-      );
+      if (baseConfig.type !== "image") {
+        throw new Error(
+          `vault "${userId}" sets sandbox.type=image, but base sandbox is "${baseConfig.type}". ` +
+            "Use --sandbox=image:<image> to enable per-user managed containers.",
+        );
+      }
+      const container = override.container || `mama-sandbox-${userId}`;
+      return { type: "container", container };
     }
 
     if (override.type === "firecracker") {

--- a/test/provisioner.test.ts
+++ b/test/provisioner.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test, vi } from "vitest";
+import { DockerContainerManager } from "../src/provisioner.js";
+
+describe("DockerContainerManager", () => {
+  test("re-checks a cached container and starts it when it was stopped", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockResolvedValueOnce({ stdout: "true\n" })
+      .mockResolvedValueOnce({ stdout: '["/tmp/workspace:/workspace"]\n' })
+      .mockResolvedValueOnce({ stdout: "false\n" })
+      .mockResolvedValueOnce({ stdout: '["/tmp/workspace:/workspace"]\n' })
+      .mockResolvedValueOnce({ stdout: "started\n" });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    await manager.provision("slack-u123");
+    await manager.provision("slack-u123");
+
+    expect(execMock).toHaveBeenNthCalledWith(1, "docker", [
+      "inspect",
+      "-f",
+      "{{.State.Running}}",
+      "mama-sandbox-slack-u123",
+    ]);
+    expect(execMock).toHaveBeenNthCalledWith(2, "docker", [
+      "inspect",
+      "-f",
+      "{{json .HostConfig.Binds}}",
+      "mama-sandbox-slack-u123",
+    ]);
+    expect(execMock).toHaveBeenNthCalledWith(3, "docker", [
+      "inspect",
+      "-f",
+      "{{.State.Running}}",
+      "mama-sandbox-slack-u123",
+    ]);
+    expect(execMock).toHaveBeenNthCalledWith(4, "docker", [
+      "inspect",
+      "-f",
+      "{{json .HostConfig.Binds}}",
+      "mama-sandbox-slack-u123",
+    ]);
+    expect(execMock).toHaveBeenNthCalledWith(5, "docker", ["start", "mama-sandbox-slack-u123"]);
+  });
+
+  test("re-checks a cached container and recreates it when it was deleted", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockResolvedValueOnce({ stdout: "true\n" })
+      .mockResolvedValueOnce({ stdout: '["/tmp/workspace:/workspace"]\n' })
+      .mockRejectedValueOnce(new Error("No such object"))
+      .mockResolvedValueOnce({ stdout: "new-container-id\n" });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    await manager.provision("slack-u123");
+    await manager.provision("slack-u123");
+
+    expect(execMock).toHaveBeenNthCalledWith(4, "docker", [
+      "run",
+      "-d",
+      "--name",
+      "mama-sandbox-slack-u123",
+      "--label",
+      "mama.managed=true",
+      "--label",
+      "mama.sandbox=image",
+      "--label",
+      "mama.vault-id=slack-u123",
+      "-v",
+      "/tmp/workspace:/workspace",
+      "ubuntu:24.04",
+      "sleep",
+      "infinity",
+    ]);
+  });
+
+  test("provisions custom container names with extra vault mounts", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockRejectedValueOnce(new Error("No such object"))
+      .mockResolvedValueOnce({ stdout: "new-container-id\n" })
+      .mockResolvedValueOnce({ stdout: "" });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    await manager.provision("alice", {
+      containerName: "alice-box",
+      mounts: [{ source: "/tmp/vaults/alice/.ssh", target: "/root/.ssh" }],
+    });
+    await manager.stop("alice");
+
+    expect(execMock).toHaveBeenNthCalledWith(2, "docker", [
+      "run",
+      "-d",
+      "--name",
+      "alice-box",
+      "--label",
+      "mama.managed=true",
+      "--label",
+      "mama.sandbox=image",
+      "--label",
+      "mama.vault-id=alice",
+      "-v",
+      "/tmp/workspace:/workspace",
+      "-v",
+      "/tmp/vaults/alice/.ssh:/root/.ssh",
+      "ubuntu:24.04",
+      "sleep",
+      "infinity",
+    ]);
+    expect(execMock).toHaveBeenNthCalledWith(3, "docker", ["stop", "alice-box"]);
+  });
+
+  test("recreates existing containers when vault mounts change", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockResolvedValueOnce({ stdout: "true\n" })
+      .mockResolvedValueOnce({
+        stdout: '["/tmp/workspace:/workspace","/tmp/vaults/alice/.ssh:/root/.ssh"]\n',
+      })
+      .mockResolvedValueOnce({ stdout: "removed\n" })
+      .mockResolvedValueOnce({ stdout: "new-container-id\n" });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    await manager.provision("alice", {
+      containerName: "alice-box",
+      mounts: [{ source: "/tmp/vaults/alice/.kube", target: "/root/.kube" }],
+    });
+
+    expect(execMock).toHaveBeenNthCalledWith(3, "docker", ["rm", "-f", "alice-box"]);
+    expect(execMock).toHaveBeenNthCalledWith(4, "docker", [
+      "run",
+      "-d",
+      "--name",
+      "alice-box",
+      "--label",
+      "mama.managed=true",
+      "--label",
+      "mama.sandbox=image",
+      "--label",
+      "mama.vault-id=alice",
+      "-v",
+      "/tmp/workspace:/workspace",
+      "-v",
+      "/tmp/vaults/alice/.kube:/root/.kube",
+      "ubuntu:24.04",
+      "sleep",
+      "infinity",
+    ]);
+  });
+
+  test("stopIdle stops only containers idle longer than threshold", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockResolvedValueOnce({ stdout: "true\n" })
+      .mockResolvedValueOnce({ stdout: '["/tmp/workspace:/workspace"]\n' })
+      .mockResolvedValueOnce({ stdout: "true\n" })
+      .mockResolvedValueOnce({ stdout: '["/tmp/workspace:/workspace"]\n' });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    await manager.provision("slack-u111");
+    await manager.provision("slack-u222");
+
+    const stateField = (manager as any).state as Map<string, { status: string; lastUsed: number }>;
+    stateField.get("slack-u111")!.lastUsed = Date.now() - 7200000;
+
+    execMock.mockResolvedValue({ stdout: "" });
+    await manager.stopIdle(3600000);
+
+    const stopCalls = execMock.mock.calls.filter((c) => c[0] === "docker" && c[1][0] === "stop");
+    expect(stopCalls).toHaveLength(1);
+    expect(stopCalls[0][1]).toEqual(["stop", "mama-sandbox-slack-u111"]);
+  });
+
+  test("reconcile discovers labeled containers and restores state", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockResolvedValueOnce({ stdout: "mama-sandbox-slack-u123\n" })
+      .mockResolvedValueOnce({ stdout: "" })
+      .mockResolvedValueOnce({ stdout: "true\t2026-04-22T00:00:00.000000000Z\tslack-u123\n" });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    await manager.reconcile();
+
+    const stateField = (manager as any).state as Map<string, { status: string; lastUsed: number }>;
+    expect(stateField.get("slack-u123")?.status).toBe("running");
+    expect(stateField.get("slack-u123")?.lastUsed).toBe(Date.parse("2026-04-22T00:00:00.000Z"));
+  });
+
+  test("concurrent provision calls for the same vaultId share one docker run", async () => {
+    let startResolve: (value: { stdout: string }) => void = () => {};
+    const startPromise = new Promise<{ stdout: string }>((resolvePromise) => {
+      startResolve = resolvePromise;
+    });
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockRejectedValueOnce(new Error("No such object"))
+      .mockReturnValueOnce(startPromise);
+
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    const first = manager.provision("slack-u123");
+    const second = manager.provision("slack-u123");
+
+    startResolve({ stdout: "new-container-id\n" });
+    await Promise.all([first, second]);
+
+    expect(execMock).toHaveBeenCalledTimes(2);
+    expect(execMock.mock.calls[0][1][0]).toBe("inspect");
+    expect(execMock.mock.calls[1][1][0]).toBe("run");
+  });
+
+  test("failed docker start clears cached state and allows re-inspection", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockResolvedValueOnce({ stdout: "false\n" })
+      .mockRejectedValueOnce(new Error("docker start failed"))
+      .mockRejectedValueOnce(new Error("No such object"))
+      .mockResolvedValueOnce({ stdout: "new-id\n" });
+
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    await expect(manager.provision("slack-u123")).rejects.toThrow(/start failed/);
+
+    const stateField = (manager as any).state as Map<string, unknown>;
+    expect(stateField.has("slack-u123")).toBe(false);
+
+    await expect(manager.provision("slack-u123")).resolves.toBe("mama-sandbox-slack-u123");
+    expect(execMock.mock.calls[2][1][0]).toBe("inspect");
+  });
+});

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -24,6 +24,13 @@ describe("parseSandboxArg", () => {
     });
   });
 
+  test("parses image sandbox for managed per-user containers", () => {
+    expect(parseSandboxArg("image:ubuntu:24.04")).toEqual({
+      type: "image",
+      image: "ubuntu:24.04",
+    });
+  });
+
   test("parses firecracker sandbox with defaults", () => {
     expect(parseSandboxArg("firecracker:172.16.0.2:/home/user/workspace")).toEqual({
       type: "firecracker",
@@ -66,13 +73,6 @@ describe("parseSandboxArg", () => {
       "Use 'container:<container-name>' for the shared-container mode",
     );
   });
-
-  test("rejects image mode with migration hint", () => {
-    expect(() => parseSandboxArg("image:alpine:latest")).toThrowError(SandboxError);
-    expect(() => parseSandboxArg("image:alpine:latest")).toThrow(
-      "Future 'docker:'/'image:' modes are reserved for per-session containers managed by mama.",
-    );
-  });
 });
 
 describe("createExecutor", () => {
@@ -83,6 +83,12 @@ describe("createExecutor", () => {
   test("creates container executor", () => {
     expect(createExecutor({ type: "container", container: "mama-sandbox" })).toBeInstanceOf(
       ContainerExecutor,
+    );
+  });
+
+  test("rejects unresolved image executor", () => {
+    expect(() => createExecutor({ type: "image", image: "ubuntu:24.04" })).toThrowError(
+      SandboxError,
     );
   });
 

--- a/test/vault.test.ts
+++ b/test/vault.test.ts
@@ -9,7 +9,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { FileUserBindingStore } from "../src/bindings.js";
+import { ActorExecutionResolver } from "../src/execution-resolver.js";
+import { DockerContainerManager } from "../src/provisioner.js";
+import { HostExecutor } from "../src/sandbox.js";
+import { ensureSandboxVaultEntry, resolveActorVaultKey } from "../src/vault-routing.js";
 import { FileVaultManager, parseEnvFile, type VaultConfig } from "../src/vault.js";
 
 function mode(path: string): number {
@@ -154,5 +159,255 @@ describe("FileVaultManager", () => {
       sshUser: undefined,
       sshPort: 2222,
     });
+  });
+
+  test("applies image override in image mode", () => {
+    writeVaultJson({
+      vaults: {
+        U123: {
+          displayName: "Alice",
+          sandbox: { type: "image", container: "alice-box" },
+        },
+      },
+    });
+
+    const mgr = new FileVaultManager(tmpDir);
+    expect(mgr.getSandboxConfig("U123", { type: "image", image: "ubuntu:24.04" })).toEqual({
+      type: "container",
+      container: "alice-box",
+    });
+  });
+
+  test("defaults image container name from userId", () => {
+    writeVaultJson({
+      vaults: {
+        U123: {
+          displayName: "Alice",
+          sandbox: { type: "image" },
+        },
+      },
+    });
+
+    const mgr = new FileVaultManager(tmpDir);
+    expect(mgr.getSandboxConfig("U123", { type: "image", image: "ubuntu:24.04" })).toEqual({
+      type: "container",
+      container: "mama-sandbox-U123",
+    });
+  });
+
+  test("blocks image override when base sandbox is not image", () => {
+    writeVaultJson({
+      vaults: {
+        U123: {
+          displayName: "Alice",
+          sandbox: { type: "image", container: "alice-box" },
+        },
+      },
+    });
+
+    const mgr = new FileVaultManager(tmpDir);
+    expect(() => mgr.getSandboxConfig("U123", { type: "host" })).toThrow(/base sandbox is "host"/);
+  });
+});
+
+describe("ActorExecutionResolver image mode", () => {
+  let tmpDir: string;
+  let vaultsDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mama-image-vault-test-${Date.now()}-${Math.random()}`);
+    vaultsDir = join(tmpDir, "vaults");
+    mkdirSync(vaultsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeVaultJson(config: VaultConfig): void {
+    writeFileSync(join(vaultsDir, "vault.json"), JSON.stringify(config));
+  }
+
+  function writeBindings(bindings: unknown): void {
+    writeFileSync(join(vaultsDir, "bindings.json"), JSON.stringify(bindings));
+  }
+
+  test("uses platform-namespaced vault ids for new users", async () => {
+    writeVaultJson({ vaults: {} });
+    const mgr = new FileVaultManager(tmpDir);
+    const resolver = new ActorExecutionResolver({ type: "image", image: "ubuntu:24.04" }, mgr);
+
+    const executor = await resolver.resolve({ platform: "slack", userId: "U123" });
+
+    expect(executor.getSandboxConfig()).toEqual({
+      type: "container",
+      container: "mama-sandbox-slack-u123",
+    });
+    expect(mgr.resolve(DockerContainerManager.vaultId("slack", "U123"))?.displayName).toBe(
+      "slack:U123",
+    );
+  });
+
+  test("respects direct vault keys before creating generated ids", async () => {
+    writeVaultJson({
+      vaults: {
+        U123: {
+          displayName: "Alice",
+          sandbox: { type: "image" },
+        },
+      },
+    });
+    const mgr = new FileVaultManager(tmpDir);
+    const resolver = new ActorExecutionResolver({ type: "image", image: "ubuntu:24.04" }, mgr);
+
+    const executor = await resolver.resolve({ platform: "slack", userId: "U123" });
+
+    expect(executor.getSandboxConfig()).toEqual({
+      type: "container",
+      container: "mama-sandbox-U123",
+    });
+    expect(mgr.hasEntry("U123")).toBe(true);
+    expect(mgr.hasEntry(DockerContainerManager.vaultId("slack", "U123"))).toBe(false);
+  });
+
+  test("respects explicit bindings before creating generated ids", async () => {
+    writeVaultJson({
+      vaults: {
+        alice: {
+          displayName: "Alice",
+          sandbox: { type: "image", container: "alice-box" },
+        },
+      },
+    });
+    writeBindings({
+      bindings: [
+        {
+          platform: "slack",
+          platformUserId: "U123",
+          internalUserId: "alice",
+          vaultId: "alice",
+          status: "active",
+          createdAt: "2026-04-22T00:00:00.000Z",
+          updatedAt: "2026-04-22T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const mgr = new FileVaultManager(tmpDir);
+    const bindings = new FileUserBindingStore(tmpDir);
+    const resolver = new ActorExecutionResolver(
+      { type: "image", image: "ubuntu:24.04" },
+      mgr,
+      bindings,
+    );
+
+    const executor = await resolver.resolve({ platform: "slack", userId: "U123" });
+
+    expect(executor.getSandboxConfig()).toEqual({ type: "container", container: "alice-box" });
+    expect(mgr.hasEntry("alice")).toBe(true);
+    expect(mgr.hasEntry(DockerContainerManager.vaultId("slack", "U123"))).toBe(false);
+  });
+
+  test("login and execution use the same generated vault key in image mode", async () => {
+    writeVaultJson({ vaults: {} });
+    const mgr = new FileVaultManager(tmpDir);
+    const baseConfig = { type: "image", image: "ubuntu:24.04" } as const;
+    const vaultKey = resolveActorVaultKey(baseConfig, mgr, undefined, "slack", "U123");
+
+    ensureSandboxVaultEntry(baseConfig, mgr, "slack", "U123", vaultKey);
+
+    const resolver = new ActorExecutionResolver(baseConfig, mgr);
+    const executor = await resolver.resolve({ platform: "slack", userId: "U123" });
+
+    expect(vaultKey).toBe("slack-u123");
+    expect(executor.getSandboxConfig()).toEqual({
+      type: "container",
+      container: "mama-sandbox-slack-u123",
+    });
+  });
+
+  test("provisions custom containers with vault mounts", async () => {
+    writeVaultJson({
+      vaults: {
+        U123: {
+          displayName: "Alice",
+          mounts: [".ssh"],
+          sandbox: { type: "image", container: "alice-box" },
+        },
+      },
+    });
+    mkdirSync(join(vaultsDir, "U123", ".ssh"), { recursive: true });
+
+    const mgr = new FileVaultManager(tmpDir);
+    const provision = vi.fn().mockResolvedValue("alice-box");
+    const exec = vi
+      .spyOn(HostExecutor.prototype, "exec")
+      .mockResolvedValue({ stdout: "", stderr: "", code: 0 });
+    const resolver = new ActorExecutionResolver(
+      { type: "image", image: "ubuntu:24.04" },
+      mgr,
+      undefined,
+      { provision } as any,
+    );
+
+    const executor = await resolver.resolve({ platform: "slack", userId: "U123" });
+    await executor.exec("pwd");
+
+    expect(provision).toHaveBeenCalledWith("U123", {
+      containerName: "alice-box",
+      mounts: [{ source: join(vaultsDir, "U123", ".ssh"), target: "/root/.ssh" }],
+    });
+    expect(exec).toHaveBeenCalledWith("docker exec -w /workspace alice-box sh -c 'pwd'", undefined);
+  });
+
+  test("deduplicates mount targets and ignores missing files", async () => {
+    writeVaultJson({
+      vaults: {
+        U123: {
+          displayName: "Alice",
+          mounts: [
+            ".config/gws/credentials.json",
+            {
+              source: ".vault-secrets/gws/credentials.json",
+              target: "/root/.config/gws/credentials.json",
+            },
+            {
+              source: "gws.json",
+              target: "/root/.config/gws/credentials.json",
+            },
+          ],
+          sandbox: { type: "image", container: "alice-box" },
+        },
+      },
+    });
+    mkdirSync(join(vaultsDir, "U123"), { recursive: true });
+    writeFileSync(join(vaultsDir, "U123", "gws.json"), '{ "type": "authorized_user" }\n');
+
+    const mgr = new FileVaultManager(tmpDir);
+    const provision = vi.fn().mockResolvedValue("alice-box");
+    const exec = vi
+      .spyOn(HostExecutor.prototype, "exec")
+      .mockResolvedValue({ stdout: "", stderr: "", code: 0 });
+    const resolver = new ActorExecutionResolver(
+      { type: "image", image: "ubuntu:24.04" },
+      mgr,
+      undefined,
+      { provision } as any,
+    );
+
+    const executor = await resolver.resolve({ platform: "slack", userId: "U123" });
+    await executor.exec("pwd");
+
+    expect(provision).toHaveBeenCalledWith("U123", {
+      containerName: "alice-box",
+      mounts: [
+        {
+          source: join(vaultsDir, "U123", "gws.json"),
+          target: "/root/.config/gws/credentials.json",
+        },
+      ],
+    });
+    expect(exec).toHaveBeenCalledWith("docker exec -w /workspace alice-box sh -c 'pwd'", undefined);
   });
 });


### PR DESCRIPTION
## Summary

Next substantive split from #25. This adds managed `image:*` sandbox support for per-user Docker containers.

### Runtime
- add `image:<image>` sandbox parsing/validation
- add `DockerContainerManager` for provision / start / reconcile / idle stop
- wire image sandbox through `main.ts` and runner creation
- resolve image-mode execution through per-user vault routing
- auto-create / upgrade image-mode vault metadata as needed
- mount vault files into managed containers at their declared target paths

### Tests
- add `test/provisioner.test.ts`
- update sandbox parsing/executor tests for `image:*`
- extend vault/execution resolver coverage for image-mode routing and mounts

### Docs
- add bundled image Dockerfile at `docker/mama-sandbox.Dockerfile`
- document `image:*` usage in `README.md`
- update `docs/sandbox.md`
- update Google Workspace OAuth doc to note image-mode file projection

## Notes

- `image:*` is per-user / per-vault managed container mode.
- `container:*` remains the shared existing-container mode.
- No version bump in this PR.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run fmt:check`

Part of splitting #25 into smaller, reviewable PRs.
