### PR TITLE
feat(login): improve Telegram onboarding and OAuth coverage

### DIFF
--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -97,6 +97,7 @@ export class TelegramBot implements Bot {
     await this.client.api.setMyCommands([
       { command: "start", description: "Welcome message" },
       { command: "help", description: "Show available commands" },
+      { command: "login", description: "Store credentials in your private vault" },
       { command: "stop", description: "Stop ongoing conversation" },
       { command: "new", description: "Reset conversation history and start fresh" },
     ]);
@@ -354,6 +355,7 @@ export class TelegramBot implements Bot {
           "/new — Reset conversation history and start fresh",
           "/stop — Stop the current conversation",
           "/help — Show available commands",
+          "/login — Store credentials in your private vault",
         ].join("\n"),
       );
     });
@@ -368,6 +370,7 @@ export class TelegramBot implements Bot {
           "",
           "/start — Welcome message",
           "/help — Show this help",
+          "/login — Store credentials in your private vault",
           "/stop — Stop ongoing conversation",
           "/new — Reset conversation history and start fresh",
           "",

--- a/src/link-server.ts
+++ b/src/link-server.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "crypto";
-import { createServer, type IncomingMessage, type ServerResponse } from "http";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "http";
 import { resolveLinkBaseUrl } from "./config.js";
 import type { InMemoryLinkTokenStore } from "./link-token.js";
 import {
@@ -55,7 +55,7 @@ export function startLinkServer(
   linkTokenStore: InMemoryLinkTokenStore,
   vaultManager: VaultManager,
   notify: NotifyFn,
-): void {
+): Server {
   const oauthStates = new Map<string, PendingOAuthState>();
 
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
@@ -86,6 +86,7 @@ export function startLinkServer(
         : undefined;
       const oauthServices = getOAuthServices();
       const defaultMode: LoginCredentialKind = oauthServiceHint ? "oauth" : "api_key";
+      const existingSecrets = describeVaultSecrets(vaultManager, linkToken.vaultId);
 
       const title = oauthServiceHint ? `${oauthServiceHint.label} OAuth` : "Store Secret";
       const helpText = oauthServiceHint
@@ -107,6 +108,7 @@ export function startLinkServer(
           helpText,
           oauthServices,
           oauthServiceHint?.id,
+          existingSecrets,
         ),
       );
       return;
@@ -168,6 +170,8 @@ export function startLinkServer(
   server.on("error", (err) => {
     log.logWarning("Link server error", err.message);
   });
+
+  return server;
 }
 
 /**
@@ -485,6 +489,33 @@ const sharedPageStyles = `
     color: var(--err-text);
   }
 
+  .secrets-summary {
+    margin-top: 18px;
+    padding: 14px 16px;
+    border: 1px solid var(--panel-border);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+  }
+
+  .secrets-summary h2 {
+    margin: 0 0 8px;
+    font-size: 0.98rem;
+  }
+
+  .secrets-summary p {
+    font-size: 0.92rem;
+  }
+
+  .secrets-summary ul {
+    margin: 10px 0 0;
+    padding-left: 18px;
+    color: var(--text);
+  }
+
+  .secrets-summary li + li {
+    margin-top: 6px;
+  }
+
   .close-note {
     margin-top: 14px;
     font-size: 0.92rem;
@@ -539,6 +570,48 @@ function renderStatusPage(
   );
 }
 
+interface ExistingSecretsSummary {
+  envKeys: string[];
+  mountTargets: string[];
+}
+
+function describeVaultSecrets(vaultManager: VaultManager, vaultId: string): ExistingSecretsSummary {
+  const vault = vaultManager.resolve(vaultId);
+  if (!vault) {
+    return { envKeys: [], mountTargets: [] };
+  }
+
+  return {
+    envKeys: Object.keys(vault.env).sort((left, right) => left.localeCompare(right)),
+    mountTargets: [...new Set(vault.mounts.map((mount) => mount.target))].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+  };
+}
+
+function renderSecretsSummary(summary: ExistingSecretsSummary): string {
+  if (summary.envKeys.length === 0 && summary.mountTargets.length === 0) {
+    return `
+  <section class="secrets-summary">
+    <h2>Currently stored</h2>
+    <p>No secrets are stored in this vault yet.</p>
+  </section>`;
+  }
+
+  const envItems = summary.envKeys.map((envKey) => `<li><code>${esc(envKey)}</code></li>`).join("");
+  const mountItems = summary.mountTargets
+    .map((target) => `<li><code>${esc(target)}</code></li>`)
+    .join("");
+
+  return `
+  <section class="secrets-summary">
+    <h2>Currently stored</h2>
+    <p>Only secret names and mounted paths are shown here. Secret values are never displayed.</p>
+    ${summary.envKeys.length > 0 ? `<p><strong>Environment keys</strong></p><ul>${envItems}</ul>` : ""}
+    ${summary.mountTargets.length > 0 ? `<p><strong>Mounted secret files</strong></p><ul>${mountItems}</ul>` : ""}
+  </section>`;
+}
+
 function renderCredentialPage(
   token: string,
   title: string,
@@ -548,7 +621,8 @@ function renderCredentialPage(
   placeholder: string,
   helpText: string,
   oauthServices: OAuthService[],
-  oauthServiceIdHint?: string,
+  oauthServiceIdHint: string | undefined,
+  existingSecrets: ExistingSecretsSummary,
 ): string {
   const oauthOptions = oauthServices
     .map((service) => {
@@ -564,6 +638,7 @@ function renderCredentialPage(
   <h1>${esc(title)}</h1>
   <p>Your personal sandbox is already provisioned automatically.</p>
   <p>${esc(helpText)}</p>
+  ${renderSecretsSummary(existingSecrets)}
   <div class="mode">
     <label><input type="radio" name="mode" value="api_key" ${defaultMode === "api_key" ? "checked" : ""}> API key</label>
     <label><input type="radio" name="mode" value="oauth" ${defaultMode === "oauth" ? "checked" : ""}> OAuth login</label>

--- a/test/link-server.test.ts
+++ b/test/link-server.test.ts
@@ -1,0 +1,214 @@
+import { existsSync, rmSync } from "node:fs";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { startLinkServer } from "../src/link-server.js";
+import { InMemoryLinkTokenStore } from "../src/link-token.js";
+import { FileVaultManager } from "../src/vault.js";
+
+async function waitForListening(server: Server): Promise<void> {
+  if (server.listening) return;
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+}
+
+function baseUrl(server: Server): string {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Link server did not expose a TCP address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("link server", () => {
+  const servers: Server[] = [];
+  const dirs: string[] = [];
+  const originalFetch = globalThis.fetch;
+  const originalGitHubClientId = process.env.GITHUB_OAUTH_CLIENT_ID;
+  const originalGitHubClientSecret = process.env.GITHUB_OAUTH_CLIENT_SECRET;
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    if (originalGitHubClientId === undefined) {
+      delete process.env.GITHUB_OAUTH_CLIENT_ID;
+    } else {
+      process.env.GITHUB_OAUTH_CLIENT_ID = originalGitHubClientId;
+    }
+    if (originalGitHubClientSecret === undefined) {
+      delete process.env.GITHUB_OAUTH_CLIENT_SECRET;
+    } else {
+      process.env.GITHUB_OAUTH_CLIENT_SECRET = originalGitHubClientSecret;
+    }
+
+    await Promise.all(
+      servers.splice(0).map(
+        (server) =>
+          new Promise<void>((resolve, reject) => {
+            server.close((err) => (err ? reject(err) : resolve()));
+          }),
+      ),
+    );
+
+    for (const dir of dirs.splice(0)) {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("/link shows stored secret names and mounted files, but not secret values", async () => {
+    const stateDir = join(tmpdir(), `mama-link-server-${Date.now()}-${Math.random()}`);
+    dirs.push(stateDir);
+
+    const vaultManager = new FileVaultManager(stateDir);
+    vaultManager.addEntry("vault-u123", { displayName: "Alice" });
+    vaultManager.upsertEnv("vault-u123", {
+      OPENAI_API_KEY: "sk-secret-value",
+      GH_TOKEN: "ghp-secret-value",
+    });
+    vaultManager.upsertFile(
+      "vault-u123",
+      "gws.json",
+      '{\n  "type": "authorized_user"\n}\n',
+      "/root/.config/gws/credentials.json",
+    );
+
+    const tokenStore = new InMemoryLinkTokenStore();
+    const token = tokenStore.create("telegram", "U123", "123", "vault-u123", "");
+    const server = startLinkServer(0, tokenStore, vaultManager, async () => {});
+    servers.push(server);
+    await waitForListening(server);
+
+    const response = await originalFetch(`${baseUrl(server)}/link?token=${token.token}`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("Currently stored");
+    expect(html).toContain("OPENAI_API_KEY");
+    expect(html).toContain("GH_TOKEN");
+    expect(html).toContain("/root/.config/gws/credentials.json");
+    expect(html).not.toContain("sk-secret-value");
+    expect(html).not.toContain("ghp-secret-value");
+  });
+
+  test("/api/oauth/start returns an OAuth redirect URL for GitHub", async () => {
+    const stateDir = join(tmpdir(), `mama-link-server-${Date.now()}-${Math.random()}`);
+    dirs.push(stateDir);
+
+    process.env.GITHUB_OAUTH_CLIENT_ID = "github-client-id";
+    process.env.GITHUB_OAUTH_CLIENT_SECRET = "github-client-secret";
+
+    const vaultManager = new FileVaultManager(stateDir);
+    vaultManager.addEntry("vault-u234", { displayName: "Carol" });
+
+    const tokenStore = new InMemoryLinkTokenStore();
+    const token = tokenStore.create("telegram", "U234", "234", "vault-u234", "");
+    const server = startLinkServer(0, tokenStore, vaultManager, async () => {});
+    servers.push(server);
+    await waitForListening(server);
+
+    const response = await originalFetch(`${baseUrl(server)}/api/oauth/start`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: baseUrl(server),
+      },
+      body: JSON.stringify({ token: token.token, serviceId: "github" }),
+    });
+    const body = (await response.json()) as { redirectUrl: string };
+    const redirectUrl = new URL(body.redirectUrl);
+
+    expect(response.status).toBe(200);
+    expect(redirectUrl.origin).toBe("https://github.com");
+    expect(redirectUrl.pathname).toBe("/login/oauth/authorize");
+    expect(redirectUrl.searchParams.get("client_id")).toBe("github-client-id");
+    expect(redirectUrl.searchParams.get("redirect_uri")).toBe(`${baseUrl(server)}/oauth/callback`);
+    expect(redirectUrl.searchParams.get("scope")).toContain("repo");
+    expect(redirectUrl.searchParams.get("state")).toBeTruthy();
+    expect(redirectUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(redirectUrl.searchParams.get("code_challenge")).toBeTruthy();
+  });
+
+  test("OAuth callback stores GitHub tokens in the vault", async () => {
+    const stateDir = join(tmpdir(), `mama-link-server-${Date.now()}-${Math.random()}`);
+    dirs.push(stateDir);
+
+    process.env.GITHUB_OAUTH_CLIENT_ID = "github-client-id";
+    process.env.GITHUB_OAUTH_CLIENT_SECRET = "github-client-secret";
+
+    const vaultManager = new FileVaultManager(stateDir);
+    vaultManager.addEntry("vault-u345", { displayName: "Dana" });
+
+    const tokenStore = new InMemoryLinkTokenStore();
+    const token = tokenStore.create("telegram", "U345", "345", "vault-u345", "");
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const server = startLinkServer(0, tokenStore, vaultManager, notify);
+    servers.push(server);
+    await waitForListening(server);
+
+    const startResponse = await originalFetch(`${baseUrl(server)}/api/oauth/start`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: baseUrl(server),
+      },
+      body: JSON.stringify({ token: token.token, serviceId: "github" }),
+    });
+    const startBody = (await startResponse.json()) as { redirectUrl: string };
+    const redirectUrl = new URL(startBody.redirectUrl);
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    const tokenExchangeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      text: async () =>
+        JSON.stringify({
+          access_token: "gho_test_access_token",
+          refresh_token: "ghr_test_refresh_token",
+        }),
+    });
+    globalThis.fetch = tokenExchangeFetch as typeof fetch;
+
+    const callbackResponse = await originalFetch(
+      `${baseUrl(server)}/oauth/callback?state=${state}&code=test-code`,
+    );
+    const callbackHtml = await callbackResponse.text();
+
+    expect(callbackResponse.status).toBe(200);
+    expect(callbackHtml).toContain("GitHub OAuth connected successfully.");
+    expect(vaultManager.resolve("vault-u345")?.env).toMatchObject({
+      GITHUB_OAUTH_ACCESS_TOKEN: "gho_test_access_token",
+      GH_TOKEN: "gho_test_access_token",
+      GITHUB_OAUTH_REFRESH_TOKEN: "ghr_test_refresh_token",
+    });
+    expect(notify).toHaveBeenCalledWith(
+      "telegram",
+      "345",
+      expect.stringContaining("GitHub OAuth stored"),
+    );
+    expect(tokenExchangeFetch).toHaveBeenCalledWith(
+      "https://github.com/login/oauth/access_token",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  test("/link shows an empty-state message when the vault has no secrets yet", async () => {
+    const stateDir = join(tmpdir(), `mama-link-server-${Date.now()}-${Math.random()}`);
+    dirs.push(stateDir);
+
+    const vaultManager = new FileVaultManager(stateDir);
+    vaultManager.addEntry("vault-u999", { displayName: "Bob" });
+
+    const tokenStore = new InMemoryLinkTokenStore();
+    const token = tokenStore.create("telegram", "U999", "999", "vault-u999", "");
+    const server = startLinkServer(0, tokenStore, vaultManager, async () => {});
+    servers.push(server);
+    await waitForListening(server);
+
+    const response = await originalFetch(`${baseUrl(server)}/link?token=${token.token}`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("No secrets are stored in this vault yet.");
+  });
+});

--- a/test/oauth-link-server.test.ts
+++ b/test/oauth-link-server.test.ts
@@ -1,0 +1,380 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { startLinkServer } from "../src/link-server.js";
+import { InMemoryLinkTokenStore } from "../src/link-token.js";
+import { FileVaultManager } from "../src/vault.js";
+
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  GITHUB_OAUTH_CLIENT_ID: process.env.GITHUB_OAUTH_CLIENT_ID,
+  GITHUB_OAUTH_CLIENT_SECRET: process.env.GITHUB_OAUTH_CLIENT_SECRET,
+  GOOGLE_WORKSPACE_CLI_CLIENT_ID: process.env.GOOGLE_WORKSPACE_CLI_CLIENT_ID,
+  GOOGLE_WORKSPACE_CLI_CLIENT_SECRET: process.env.GOOGLE_WORKSPACE_CLI_CLIENT_SECRET,
+  MOM_LINK_URL: process.env.MOM_LINK_URL,
+};
+
+async function waitForListening(server: Server): Promise<void> {
+  if (server.listening) return;
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+}
+
+function baseUrl(server: Server): string {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Link server did not expose a TCP address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function createStateDir(dirs: string[]): string {
+  const stateDir = join(tmpdir(), `mama-oauth-test-${Date.now()}-${Math.random()}`);
+  dirs.push(stateDir);
+  return stateDir;
+}
+
+function configureGitHubOAuth(): void {
+  process.env.GITHUB_OAUTH_CLIENT_ID = "github-client-id";
+  process.env.GITHUB_OAUTH_CLIENT_SECRET = "github-client-secret";
+}
+
+function configureGoogleOAuth(): void {
+  process.env.GOOGLE_WORKSPACE_CLI_CLIENT_ID = "google-client-id";
+  process.env.GOOGLE_WORKSPACE_CLI_CLIENT_SECRET = "google-client-secret";
+}
+
+async function createFlow(
+  servers: Server[],
+  stateDir: string,
+  userId: string,
+  notify: typeof Promise.resolve extends (...args: any[]) => any
+    ? () => Promise<void>
+    : never = async () => {},
+): Promise<{
+  server: Server;
+  url: string;
+  vaultManager: FileVaultManager;
+  token: string;
+}> {
+  const vaultManager = new FileVaultManager(stateDir);
+  const vaultId = `vault-${userId.toLowerCase()}`;
+  vaultManager.addEntry(vaultId, { displayName: userId });
+
+  const tokenStore = new InMemoryLinkTokenStore();
+  const token = tokenStore.create("telegram", userId, userId.replace(/^U/, ""), vaultId, "");
+  const server = startLinkServer(0, tokenStore, vaultManager, notify);
+  servers.push(server);
+  await waitForListening(server);
+
+  return { server, url: baseUrl(server), vaultManager, token: token.token };
+}
+
+async function startOAuth(url: string, token: string, serviceId: string): Promise<URL> {
+  const response = await originalFetch(`${url}/api/oauth/start`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: url,
+    },
+    body: JSON.stringify({ token, serviceId }),
+  });
+  const body = (await response.json()) as { redirectUrl: string };
+  expect(response.status).toBe(200);
+  return new URL(body.redirectUrl);
+}
+
+function mockTokenExchange(options: { ok?: boolean; contentType?: string; body: string }): void {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: options.ok ?? true,
+    headers: { get: () => options.contentType ?? "application/json" },
+    text: async () => options.body,
+  }) as typeof fetch;
+}
+
+describe("OAuth link server flows", () => {
+  const servers: Server[] = [];
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+
+    await Promise.all(
+      servers.splice(0).map(
+        (server) =>
+          new Promise<void>((resolve, reject) => {
+            server.close((err) => (err ? reject(err) : resolve()));
+          }),
+      ),
+    );
+
+    for (const dir of dirs.splice(0)) {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects cross-origin OAuth start requests when MOM_LINK_URL is configured", async () => {
+    const stateDir = createStateDir(dirs);
+    process.env.MOM_LINK_URL = "https://mama.example.com";
+    configureGitHubOAuth();
+
+    const { url, token } = await createFlow(servers, stateDir, "U100");
+    const response = await originalFetch(`${url}/api/oauth/start`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "https://evil.example.com",
+      },
+      body: JSON.stringify({ token, serviceId: "github" }),
+    });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Cross-origin request rejected");
+  });
+
+  test("returns a clear error when GitHub OAuth is not configured", async () => {
+    const stateDir = createStateDir(dirs);
+    const { url, token } = await createFlow(servers, stateDir, "U110");
+
+    const response = await originalFetch(`${url}/api/oauth/start`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: url,
+      },
+      body: JSON.stringify({ token, serviceId: "github" }),
+    });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("GitHub is not configured");
+  });
+
+  test("renders provider authorization errors returned to the callback", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGitHubOAuth();
+
+    const { url, token } = await createFlow(servers, stateDir, "U120");
+    const redirectUrl = await startOAuth(url, token, "github");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    const response = await originalFetch(
+      `${url}/oauth/callback?state=${state}&error=access_denied`,
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(html).toContain("OAuth authorization failed: access_denied");
+  });
+
+  test("OAuth callback state is one-shot", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGitHubOAuth();
+
+    const { url, token } = await createFlow(servers, stateDir, "U200");
+    const redirectUrl = await startOAuth(url, token, "github");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    mockTokenExchange({ body: JSON.stringify({ access_token: "gho_once" }) });
+
+    const first = await originalFetch(`${url}/oauth/callback?state=${state}&code=ok`);
+    const second = await originalFetch(`${url}/oauth/callback?state=${state}&code=ok`);
+
+    expect(first.status).toBe(200);
+    expect(await second.text()).toContain("OAuth state is invalid or expired");
+  });
+
+  test("OAuth callback rejects expired state even when the login link is still valid", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGitHubOAuth();
+
+    let now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    const { url, token } = await createFlow(servers, stateDir, "U210");
+    const redirectUrl = await startOAuth(url, token, "github");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    now += 10 * 60 * 1000 + 1;
+    const response = await originalFetch(`${url}/oauth/callback?state=${state}&code=late`);
+    const html = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(html).toContain("OAuth state is invalid or expired");
+  });
+
+  test("GitHub OAuth accepts form-encoded token responses", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGitHubOAuth();
+
+    const { url, token, vaultManager } = await createFlow(servers, stateDir, "U220");
+    const redirectUrl = await startOAuth(url, token, "github");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    mockTokenExchange({
+      contentType: "text/plain",
+      body: "access_token=gho_form_encoded&refresh_token=ghr_form_encoded",
+    });
+
+    const response = await originalFetch(`${url}/oauth/callback?state=${state}&code=form`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("GitHub OAuth connected successfully.");
+    expect(vaultManager.resolve("vault-u220")?.env).toMatchObject({
+      GITHUB_OAUTH_ACCESS_TOKEN: "gho_form_encoded",
+      GH_TOKEN: "gho_form_encoded",
+      GITHUB_OAUTH_REFRESH_TOKEN: "ghr_form_encoded",
+    });
+  });
+
+  test("GitHub OAuth rejects callbacks without access_token", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGitHubOAuth();
+
+    const { url, token, vaultManager } = await createFlow(servers, stateDir, "U230");
+    const redirectUrl = await startOAuth(url, token, "github");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    mockTokenExchange({ body: JSON.stringify({ refresh_token: "ghr_only" }) });
+
+    const response = await originalFetch(`${url}/oauth/callback?state=${state}&code=no-access`);
+    const html = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(html).toContain("did not return an access_token");
+    expect(vaultManager.resolve("vault-u230")?.env).toEqual({});
+  });
+
+  test("OAuth callback returns a server error when vault persistence fails", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGitHubOAuth();
+
+    const { url, token, vaultManager } = await createFlow(servers, stateDir, "U240");
+    const redirectUrl = await startOAuth(url, token, "github");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    mockTokenExchange({ body: JSON.stringify({ access_token: "gho_ok" }) });
+    (vaultManager as any).upsertEnv = vi.fn(() => {
+      throw new Error("disk full");
+    });
+
+    const response = await originalFetch(`${url}/oauth/callback?state=${state}&code=store-fail`);
+    const html = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(html).toContain("could not be stored on the server");
+  });
+
+  test("notify failures do not break a successful GitHub OAuth callback", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGitHubOAuth();
+
+    const notify = vi.fn().mockRejectedValue(new Error("chat offline"));
+    const { url, token, vaultManager } = await createFlow(servers, stateDir, "U250", notify);
+    const redirectUrl = await startOAuth(url, token, "github");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    mockTokenExchange({ body: JSON.stringify({ access_token: "gho_notify_ok" }) });
+
+    const response = await originalFetch(`${url}/oauth/callback?state=${state}&code=notify`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("GitHub OAuth connected successfully.");
+    expect(vaultManager.resolve("vault-u250")?.env).toMatchObject({
+      GITHUB_OAUTH_ACCESS_TOKEN: "gho_notify_ok",
+      GH_TOKEN: "gho_notify_ok",
+    });
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  test("Google Workspace OAuth stores an authorized_user file mount", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGoogleOAuth();
+
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const { url, token, vaultManager } = await createFlow(servers, stateDir, "U300", notify);
+    const redirectUrl = await startOAuth(url, token, "google_workspace_cli");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    mockTokenExchange({
+      body: JSON.stringify({
+        access_token: "ya29.access-token",
+        refresh_token: "1//refresh-token",
+      }),
+    });
+
+    const response = await originalFetch(`${url}/oauth/callback?state=${state}&code=google-code`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("Google Workspace CLI OAuth connected successfully.");
+
+    const vault = vaultManager.resolve("vault-u300");
+    expect(vault?.env).toEqual({});
+    expect(vault?.mounts).toEqual([
+      {
+        source: join(stateDir, "vaults", "vault-u300", "gws.json"),
+        target: "/root/.config/gws/credentials.json",
+      },
+    ]);
+
+    const credentialFile = join(stateDir, "vaults", "vault-u300", "gws.json");
+    expect(readFileSync(credentialFile, "utf-8")).toContain('"refresh_token": "1//refresh-token"');
+    expect(readFileSync(credentialFile, "utf-8")).toContain('"type": "authorized_user"');
+    expect(notify).toHaveBeenCalledWith(
+      "telegram",
+      "300",
+      expect.stringContaining("Google Workspace CLI OAuth stored"),
+    );
+  });
+
+  test("Google Workspace OAuth rejects callbacks without refresh_token", async () => {
+    const stateDir = createStateDir(dirs);
+    configureGoogleOAuth();
+
+    const { url, token, vaultManager } = await createFlow(servers, stateDir, "U400");
+    const redirectUrl = await startOAuth(url, token, "google_workspace_cli");
+    const state = redirectUrl.searchParams.get("state");
+
+    expect(state).toBeTruthy();
+
+    mockTokenExchange({ body: JSON.stringify({ access_token: "ya29.access-token" }) });
+
+    const response = await originalFetch(`${url}/oauth/callback?state=${state}&code=google-code`);
+    const html = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(html).toContain("did not return a refresh_token");
+    expect(vaultManager.resolve("vault-u400")?.mounts).toEqual([]);
+    expect(existsSync(join(stateDir, "vaults", "vault-u400", "gws.json"))).toBe(false);
+  });
+});

--- a/test/telegram-bot.test.ts
+++ b/test/telegram-bot.test.ts
@@ -110,6 +110,41 @@ describe("TelegramBot extractMessageContext", () => {
   });
 });
 
+describe("TelegramBot startup", () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = join(tmpdir(), `mama-telegram-start-${Date.now()}`);
+    mkdirSync(workingDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  test("start registers /login in Telegram slash commands", async () => {
+    const bot = new TelegramBot(makeHandler(), { token: "TEST_TOKEN", workingDir });
+    const getMe = vi.fn().mockResolvedValue({ id: 99, username: "mama_bot" });
+    const setMyCommands = vi.fn().mockResolvedValue(undefined);
+    const command = vi.fn();
+    const on = vi.fn();
+    const start = vi.fn().mockResolvedValue(undefined);
+
+    (bot as any).client = {
+      api: { getMe, setMyCommands },
+      command,
+      on,
+      start,
+    };
+
+    await bot.start();
+
+    expect(setMyCommands).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ command: "login" })]),
+    );
+  });
+});
+
 describe("TelegramBot attachments", () => {
   let workingDir: string;
   const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary
- register /login in Telegram commands and help text
- show existing secret names and mounted credential paths in the onboarding page without exposing values
- expand login/OAuth tests for GitHub and Google happy paths, callback errors, CSRF/state handling, and persistence failures

## Validation
- npx vitest --run test/oauth-link-server.test.ts test/link-server.test.ts test/login.test.ts test/telegram-bot.test.ts
- npm run build
- pre-commit hooks (lint, fmt:check, full vitest) during git commit