### PR TITLE
feat(sandbox): add CPU/memory resource limits for image-mode containers

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -177,6 +177,25 @@ vault key 選擇邏輯：
 - 需要 per-user env/file credential isolation
 - 想比 shared container 更安全，但又不想直接上 Firecracker
 
+### 容器資源限制
+
+在 `settings.json` 中可設定每個 managed container 的 CPU 與記憶體上限：
+
+```json
+{
+  "sandboxCpus": "0.5",
+  "sandboxMemory": "512m"
+}
+```
+
+| 欄位            | 說明                             | 範例值           |
+| --------------- | -------------------------------- | ---------------- |
+| `sandboxCpus`   | CPU 核心數上限（浮點數字串）     | `"0.5"`, `"2"`   |
+| `sandboxMemory` | 記憶體上限（Docker memory 格式） | `"512m"`, `"2g"` |
+
+- 建立新 container 時，限制直接加進 `docker run` 參數
+- 已在執行的 container 會在下次 provision 時透過 `docker update` 立即套用新限制，不需重新建立
+
 ---
 
 ## `firecracker:<vm-id>:<host-path>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2623,9 +2623,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2643,9 +2640,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2663,9 +2657,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2683,9 +2674,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2703,9 +2691,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2723,9 +2708,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2743,9 +2725,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2763,9 +2742,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2970,9 +2946,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2990,9 +2963,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3010,9 +2980,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3030,9 +2997,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3050,9 +3014,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3070,9 +3031,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3090,9 +3048,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3110,9 +3065,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3422,9 +3374,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3442,9 +3391,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3462,9 +3408,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3482,9 +3425,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3502,9 +3442,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3522,9 +3459,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7098,9 +7032,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7122,9 +7053,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7146,9 +7074,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7170,9 +7095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,8 @@ export interface AgentConfig {
   logFormat?: "console" | "json";
   logLevel?: "trace" | "debug" | "info" | "warn" | "error";
   sentryDsn?: string;
+  sandboxCpus?: string;
+  sandboxMemory?: string;
 }
 
 const DEFAULTS: AgentConfig = {
@@ -71,8 +73,20 @@ export function loadAgentConfig(workspaceDir: string): AgentConfig {
   const logFormat = fromFile.logFormat ?? DEFAULTS.logFormat;
   const logLevel = fromFile.logLevel ?? DEFAULTS.logLevel;
   const sentryDsn = fromFile.sentryDsn ?? process.env.SENTRY_DSN;
+  const sandboxCpus = fromFile.sandboxCpus;
+  const sandboxMemory = fromFile.sandboxMemory;
 
-  return { provider, model, thinkingLevel, sessionScope, logFormat, logLevel, sentryDsn };
+  return {
+    provider,
+    model,
+    thinkingLevel,
+    sessionScope,
+    logFormat,
+    logLevel,
+    sentryDsn,
+    sandboxCpus,
+    sandboxMemory,
+  };
 }
 
 export function resolveWorkspaceDirFromArgv(args = process.argv.slice(2)): string | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { startLinkServer } from "./link-server.js";
 import { parseLoginCommand } from "./login.js";
 import { InMemoryLinkTokenStore } from "./link-token.js";
 import { DockerContainerManager } from "./provisioner.js";
+import { loadAgentConfig } from "./config.js";
 import { SandboxError, parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
 import { FileVaultManager } from "./vault.js";
 import {
@@ -249,8 +250,16 @@ if (bindingStore.isEnabled()) {
   );
 }
 
+const startupConfig = loadAgentConfig(workingDir);
+const sandboxLimits =
+  startupConfig.sandboxCpus || startupConfig.sandboxMemory
+    ? { cpus: startupConfig.sandboxCpus, memory: startupConfig.sandboxMemory }
+    : undefined;
+
 const provisioner =
-  sandbox.type === "image" ? new DockerContainerManager(sandbox.image, workingDir) : undefined;
+  sandbox.type === "image"
+    ? new DockerContainerManager(sandbox.image, workingDir, { limits: sandboxLimits })
+    : undefined;
 
 const linkTokenStore = new InMemoryLinkTokenStore();
 setInterval(() => linkTokenStore.purge(), 5 * 60 * 1000).unref();

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -18,9 +18,19 @@ export interface ContainerMount {
   target: string;
 }
 
+export interface ResourceLimits {
+  cpus?: string;
+  memory?: string;
+}
+
 export interface ProvisionOptions {
   containerName?: string;
   mounts?: ContainerMount[];
+}
+
+export interface DockerContainerManagerOptions {
+  limits?: ResourceLimits;
+  execFileImpl?: ExecFileAsync;
 }
 
 export class DockerContainerManager {
@@ -30,11 +40,21 @@ export class DockerContainerManager {
   private static readonly IMAGE_MODE_LABEL = "mama.sandbox=image";
   private static readonly VAULT_ID_LABEL_KEY = "mama.vault-id";
 
+  private readonly limits?: ResourceLimits;
+  private readonly execFileImpl: ExecFileAsync;
+
   constructor(
     private readonly image: string,
     private readonly workspaceDir: string,
-    private readonly execFileImpl: ExecFileAsync = execFileAsync,
-  ) {}
+    options: DockerContainerManagerOptions | ExecFileAsync = {},
+  ) {
+    if (typeof options === "function") {
+      this.execFileImpl = options;
+    } else {
+      this.limits = options.limits;
+      this.execFileImpl = options.execFileImpl ?? execFileAsync;
+    }
+  }
 
   static sanitizeSegment(value: string): string {
     const sanitized = value
@@ -89,6 +109,7 @@ export class DockerContainerManager {
     }
 
     this.setState(vaultId, "running", containerName);
+    await this.applyResourceLimits(containerName);
     return containerName;
   }
 
@@ -195,6 +216,7 @@ export class DockerContainerManager {
       DockerContainerManager.IMAGE_MODE_LABEL,
       "--label",
       `${DockerContainerManager.VAULT_ID_LABEL_KEY}=${vaultId}`,
+      ...this.resourceLimitArgs(),
       "-v",
       `${this.workspaceDir}:/workspace`,
       ...this.mountArgs(mounts),
@@ -202,6 +224,26 @@ export class DockerContainerManager {
       "sleep",
       "infinity",
     ]);
+  }
+
+  private resourceLimitArgs(): string[] {
+    const args: string[] = [];
+    if (this.limits?.cpus) args.push("--cpus", this.limits.cpus);
+    if (this.limits?.memory) args.push("--memory", this.limits.memory);
+    return args;
+  }
+
+  private async applyResourceLimits(containerName: string): Promise<void> {
+    if (!this.limits?.cpus && !this.limits?.memory) return;
+    const args = ["update", ...this.resourceLimitArgs(), containerName];
+    try {
+      await this.execFileImpl("docker", args);
+    } catch (err) {
+      log.logWarning(
+        `Failed to apply resource limits to container ${containerName}`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
   }
 
   private async hasBindMountDrift(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -52,6 +52,19 @@ describe("loadAgentConfig", () => {
     expect(config.sentryDsn).toBe("https://examplePublicKey@o0.ingest.sentry.io/0");
   });
 
+  test("reads sandboxCpus and sandboxMemory from settings.json", () => {
+    saveAgentConfig(tmpDir, { sandboxCpus: "0.5", sandboxMemory: "512m" });
+    const config = loadAgentConfig(tmpDir);
+    expect(config.sandboxCpus).toBe("0.5");
+    expect(config.sandboxMemory).toBe("512m");
+  });
+
+  test("sandboxCpus and sandboxMemory are undefined when not set", () => {
+    const config = loadAgentConfig(tmpDir);
+    expect(config.sandboxCpus).toBeUndefined();
+    expect(config.sandboxMemory).toBeUndefined();
+  });
+
   test("env vars override defaults but not settings.json", () => {
     process.env.MOM_AI_PROVIDER = "google";
     process.env.MOM_AI_MODEL = "gemini-2.0-flash";

--- a/test/provisioner.test.ts
+++ b/test/provisioner.test.ts
@@ -226,4 +226,98 @@ describe("DockerContainerManager", () => {
     await expect(manager.provision("slack-u123")).resolves.toBe("mama-sandbox-slack-u123");
     expect(execMock.mock.calls[2][1][0]).toBe("inspect");
   });
+
+  test("passes --cpus and --memory to docker run when limits are configured", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockRejectedValueOnce(new Error("No such object"))
+      .mockResolvedValueOnce({ stdout: "new-container-id\n" })
+      .mockResolvedValueOnce({ stdout: "" });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", {
+      limits: { cpus: "0.5", memory: "512m" },
+      execFileImpl: execMock as any,
+    });
+
+    await manager.provision("slack-u123");
+
+    expect(execMock).toHaveBeenNthCalledWith(2, "docker", [
+      "run",
+      "-d",
+      "--name",
+      "mama-sandbox-slack-u123",
+      "--label",
+      "mama.managed=true",
+      "--label",
+      "mama.sandbox=image",
+      "--label",
+      "mama.vault-id=slack-u123",
+      "--cpus",
+      "0.5",
+      "--memory",
+      "512m",
+      "-v",
+      "/tmp/workspace:/workspace",
+      "ubuntu:24.04",
+      "sleep",
+      "infinity",
+    ]);
+    expect(execMock).toHaveBeenNthCalledWith(3, "docker", [
+      "update",
+      "--cpus",
+      "0.5",
+      "--memory",
+      "512m",
+      "mama-sandbox-slack-u123",
+    ]);
+  });
+
+  test("applies limits to already-running containers via docker update", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockResolvedValueOnce({ stdout: "true\n" })
+      .mockResolvedValueOnce({ stdout: '["/tmp/workspace:/workspace"]\n' })
+      .mockResolvedValueOnce({ stdout: "" });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", {
+      limits: { cpus: "1", memory: "1g" },
+      execFileImpl: execMock as any,
+    });
+
+    await manager.provision("slack-u123");
+
+    expect(execMock).toHaveBeenNthCalledWith(3, "docker", [
+      "update",
+      "--cpus",
+      "1",
+      "--memory",
+      "1g",
+      "mama-sandbox-slack-u123",
+    ]);
+  });
+
+  test("skips docker update when no limits configured", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockResolvedValueOnce({ stdout: "true\n" })
+      .mockResolvedValueOnce({ stdout: '["/tmp/workspace:/workspace"]\n' });
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", execMock as any);
+
+    await manager.provision("slack-u123");
+
+    const updateCalls = execMock.mock.calls.filter((c) => c[1][0] === "update");
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("provision succeeds even when docker update fails", async () => {
+    const execMock = vi
+      .fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr?: string }>>()
+      .mockRejectedValueOnce(new Error("No such object"))
+      .mockResolvedValueOnce({ stdout: "new-container-id\n" })
+      .mockRejectedValueOnce(new Error("docker update unsupported"));
+    const manager = new DockerContainerManager("ubuntu:24.04", "/tmp/workspace", {
+      limits: { memory: "256m" },
+      execFileImpl: execMock as any,
+    });
+
+    await expect(manager.provision("slack-u123")).resolves.toBe("mama-sandbox-slack-u123");
+  });
 });


### PR DESCRIPTION
Add sandboxCpus and sandboxMemory settings to AgentConfig, wired into
DockerContainerManager so new containers get --cpus/--memory passed to
docker run, and existing containers receive docker update on each
provision call. Limits apply without container recreation.

https://claude.ai/code/session_01GGqVjDNXfPKc6xpYrpo2LN