### PR TITLE
fix(events): restore Slack synthetic notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We actively track the upstream `pi-mom` and plan to:
 - **Concurrent conversations** — Slack threads, Discord replies/threads, and Telegram reply chains can run independently
 - **Sandbox execution** — run agent commands on host, in a shared container, in a managed per-user container, or in a Firecracker VM
 - **Credential vaults** — `/login` stores credentials under `--state-dir` and injects env only into container/image/Firecracker runs
+- **Web session viewer** — users can open a read-only web view of the current session via `session` / `/session`
 - **Persistent memory** — workspace-level and channel-level `MEMORY.md` files
 - **Skills** — drop custom CLI tools into `skills/` directories
 - **Event system** — schedule one-shot or recurring tasks via JSON files
@@ -266,6 +267,17 @@ On Slack, you can also register native slash commands such as `/pi-login` and `/
 
 - `/pi-login` in a shared channel opens a DM and continues the credential flow there.
 - `/pi-new` only works in a Slack DM and resets that DM session context.
+
+## Web Session Viewer
+
+The same web portal used for `/login` can also render a read-only view of the current session.
+
+- Users can send `session`, `/session`, or `/pi-session` in a private conversation / DM.
+- mama returns an expiring read-only link to `/session?token=...`.
+- The page shows the current branch timeline, including user messages, assistant replies, tool results, and compaction / branch summary events.
+- For now, session links are only issued from private conversations to avoid leaking shared-channel history.
+
+This feature uses the same `MOM_LINK_URL` / `MOM_LINK_PORT` configuration as `/login`.
 
 Built-in OAuth guides:
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ The bot responds when `@mentioned` in any channel or via DM.
 
 - **Top-level channel messages** — share one persistent channel session.
 - **Thread replies** — fork from the channel session into an isolated thread session.
-- **Thread memory** — inherited at fork time only; thread changes do not merge back into the channel automatically.
+- **DM top-level messages** — share one persistent DM session.
+- **DM thread replies** — fork from the DM session into an isolated thread session.
+- **Thread memory** — inherited at fork time only; thread changes do not merge back into the parent session automatically.
 
 ---
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,114 @@
+# Events
+
+Events are JSON files written to the `events/` directory inside the workspace. The harness watches this directory and triggers the agent when a file appears.
+
+## Event Types
+
+### Immediate
+
+Triggers as soon as the harness sees the file. Useful for signaling from external scripts or webhooks.
+
+```json
+{
+  "type": "immediate",
+  "platform": "slack",
+  "conversationId": "C123",
+  "conversationKind": "shared",
+  "userId": "U123",
+  "text": "New GitHub issue opened"
+}
+```
+
+### One-shot
+
+Triggers once at a specific time. Use for reminders and future callbacks.
+
+```json
+{
+  "type": "one-shot",
+  "platform": "slack",
+  "conversationId": "C123",
+  "conversationKind": "shared",
+  "userId": "U123",
+  "text": "Remind Mario about dentist",
+  "at": "2025-12-15T09:00:00+01:00"
+}
+```
+
+`at` must be an ISO 8601 timestamp with UTC offset.
+
+### Periodic
+
+Triggers on a cron schedule. Persists until deleted.
+
+```json
+{
+  "type": "periodic",
+  "platform": "slack",
+  "conversationId": "C123",
+  "conversationKind": "shared",
+  "userId": "U123",
+  "text": "Check inbox and summarize",
+  "schedule": "0 9 * * 1-5",
+  "timezone": "Asia/Taipei"
+}
+```
+
+Cron format: `minute hour day-of-month month day-of-week`
+
+Common schedules:
+
+- `0 9 * * *` — daily at 09:00
+- `0 9 * * 1-5` — weekdays at 09:00
+- `0 0 1 * *` — first of each month at midnight
+
+## Routing Fields
+
+| Field              | Description                                                                                                                                                                                                                            |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `platform`         | Target bot platform (e.g. `slack`)                                                                                                                                                                                                     |
+| `conversationId`   | Channel or DM ID to post into                                                                                                                                                                                                          |
+| `conversationKind` | `"shared"` (channel) or `"direct"` (DM)                                                                                                                                                                                                |
+| `userId`           | Platform user ID of whoever requested the event; used for vault/credential routing in per-user modes                                                                                                                                   |
+| `sessionKey`       | Determines which AgentRunner (and its LLM context) handles the event                                                                                                                                                                   |
+| `threadTs`         | Sub-conversation target; when present, the response is posted inside that thread rather than as a top-level message. Semantics are platform-specific: Slack thread timestamp, Discord thread channel ID, Telegram reply-to message ID. |
+
+## Session Binding
+
+`sessionKey` determines which AgentRunner (and its LLM context) handles an event when it fires. Whether it is included depends on the event type:
+
+- **Immediate** — included. The event is an extension of the current turn, so the same session context applies.
+- **One-shot** — omitted. A reminder firing hours or days later has no meaningful connection to the session it was created in; it simply delivers a message to the conversation.
+- **Periodic** — included. Recurring tasks often need the context from the session where they were configured.
+
+## Thread Targeting
+
+`threadTs` controls whether a response is posted as a top-level message or as a reply inside a sub-conversation (Slack thread, Discord thread, Telegram reply chain). The same per-type reasoning applies:
+
+- **Immediate** — preserved. The reply belongs in the same sub-conversation as the current exchange.
+- **One-shot** — omitted. A reminder should be a prominent top-level message, not buried in a sub-conversation that may be days old.
+- **Periodic** — omitted. Recurring replies into an old sub-conversation create noise and reduce visibility.
+
+Summary:
+
+| Type        | `sessionKey` |    `threadTs`    |
+| ----------- | :----------: | :--------------: |
+| `immediate` |      ✓       | ✓ (if in thread) |
+| `one-shot`  |      —       |        —         |
+| `periodic`  |      ✓       |        —         |
+
+The `event` tool (available to the agent) fills all routing fields automatically and applies these rules. Use it instead of writing JSON by hand.
+
+## Lifecycle
+
+- **Immediate** and **one-shot** files are deleted automatically after the event fires.
+- **Periodic** files persist. Delete the file to cancel.
+- Maximum 5 events can be queued at once.
+
+## Silent Response
+
+For periodic events with nothing to report, respond with exactly `[SILENT]`. The harness deletes the status message and posts nothing to the platform, avoiding channel spam.
+
+## Debouncing
+
+When writing scripts that emit immediate events (email watchers, webhook handlers), always debounce. Collect events over a window and emit one summary event rather than one event per item.

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -103,6 +103,3 @@ export interface BotHandler {
   /** Reset a session: abort if running, delete history, remove from cache */
   handleNew(sessionKey: string, conversationId: string, bot: Bot): Promise<void>;
 }
-
-/** @deprecated Use BotHandler */
-export type MomHandler = BotHandler;

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -889,6 +889,12 @@ export class SlackBot implements Bot {
         return;
       }
 
+      const dmSessionKey = isDM
+        ? e.thread_ts
+          ? `${e.channel}:${e.thread_ts}`
+          : e.channel
+        : undefined;
+
       const slackEvent: SlackEvent = {
         type: isDM ? "dm" : "mention",
         conversationId: e.channel,
@@ -899,7 +905,7 @@ export class SlackBot implements Bot {
         user: e.user,
         text: (e.text || "").replace(/<@[A-Z0-9]+>/gi, "").trim(),
         files: e.files,
-        sessionKey: isDM ? e.channel : undefined,
+        sessionKey: dmSessionKey,
       };
 
       const attachmentsPromise = this.logUserMessage(slackEvent);
@@ -937,8 +943,9 @@ export class SlackBot implements Bot {
         const dmSessionKey = slackEvent.sessionKey!;
         // Check for stop command - execute immediately, don't queue!
         if (slackEvent.text.toLowerCase().trim() === "stop") {
-          if (this.handler.isRunning(dmSessionKey)) {
-            this.handler.handleStop(dmSessionKey, e.channel, this); // Don't await, don't queue
+          const stopTarget = this.resolveStopTarget(e.channel, e.thread_ts);
+          if (stopTarget) {
+            this.handler.handleStop(stopTarget, e.channel, this); // Don't await, don't queue
           } else {
             this.postMessage(e.channel, formatNothingRunning("slack"));
           }

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -18,6 +18,8 @@ import * as log from "../../log.js";
 import type { Attachment, ChannelStore } from "../../store.js";
 import { PRODUCT_NAME, formatForceStopped, formatNothingRunning } from "../../ui-copy.js";
 import { createSlackAdapters } from "./context.js";
+import { hasMaterializedSlackBranchSession } from "./branch-manager.js";
+import { resolveSlackSessionKey } from "./session.js";
 
 // ============================================================================
 // Exponential backoff utility for Slack API calls
@@ -135,9 +137,6 @@ export interface SlackContext {
   setWorking: (working: boolean) => Promise<void>;
   deleteMessage: () => Promise<void>;
 }
-
-/** @deprecated Use BotHandler from adapter.ts instead */
-export type MomHandler = BotHandler;
 
 // ============================================================================
 // Per-channel queue for sequential processing
@@ -444,6 +443,14 @@ export class SlackBot implements Bot {
     return queue;
   }
 
+  private resolveQueueKey(conversationId: string, sessionKey: string): string {
+    if (!sessionKey.includes(":")) return sessionKey;
+
+    return hasMaterializedSlackBranchSession(join(this.workingDir, conversationId), sessionKey)
+      ? sessionKey
+      : conversationId;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private buildHomeView(): { type: "home"; blocks: any[] } {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -607,16 +614,27 @@ export class SlackBot implements Bot {
    * When stop is called from a thread, the thread session (channelId:thread_ts) might
    * not be running — but the channel session (channelId) might be, because the bot's
    * reply to a top-level mention creates a thread. Check both, prefer thread first.
+   *
+   * For top-level stop requests, fall back to the only running scoped thread session in
+   * this conversation when there is exactly one candidate. This keeps DM/channel stop
+   * useful after thread sessions were introduced without guessing between multiple threads.
    */
   private resolveStopTarget(channelId: string, threadTs?: string): string | null {
     if (threadTs) {
-      const threadKey = `${channelId}:${threadTs}`;
+      const threadKey = resolveSlackSessionKey(channelId, threadTs);
       if (this.handler.isRunning(threadKey)) return threadKey;
-      // Fall back to channel session — the thread may have been spawned by a top-level run
       if (this.handler.isRunning(channelId)) return channelId;
       return null;
     }
-    return this.handler.isRunning(channelId) ? channelId : null;
+
+    if (this.handler.isRunning(channelId)) return channelId;
+
+    const runningInConversation = this.handler
+      .getRunningSessions()
+      .map((session) => session.sessionKey)
+      .filter((sessionKey) => sessionKey.startsWith(`${channelId}:`));
+
+    return runningInConversation.length === 1 ? runningInConversation[0] : null;
   }
 
   private createDirectCommandAdapters(
@@ -793,7 +811,7 @@ export class SlackBot implements Bot {
 
       // Top-level mentions use a persistent channel session.
       // Thread replies get their own isolated session (channelId:thread_ts).
-      const sessionKey = e.thread_ts ? `${e.channel}:${e.thread_ts}` : e.channel;
+      const sessionKey = resolveSlackSessionKey(e.channel, e.thread_ts);
 
       const slackEvent: SlackEvent = {
         type: "mention",
@@ -837,7 +855,7 @@ export class SlackBot implements Bot {
         return;
       }
 
-      this.getQueue(sessionKey).enqueue(async () => {
+      this.getQueue(this.resolveQueueKey(e.channel, sessionKey)).enqueue(async () => {
         slackEvent.attachments = await attachmentsPromise;
         const adapters = createSlackAdapters(slackEvent, this, false);
         return this.handler.handleEvent(
@@ -889,11 +907,7 @@ export class SlackBot implements Bot {
         return;
       }
 
-      const dmSessionKey = isDM
-        ? e.thread_ts
-          ? `${e.channel}:${e.thread_ts}`
-          : e.channel
-        : undefined;
+      const dmSessionKey = isDM ? resolveSlackSessionKey(e.channel, e.thread_ts) : undefined;
 
       const slackEvent: SlackEvent = {
         type: isDM ? "dm" : "mention",
@@ -956,7 +970,7 @@ export class SlackBot implements Bot {
           return;
         }
 
-        this.getQueue(dmSessionKey).enqueue(async () => {
+        this.getQueue(this.resolveQueueKey(e.channel, dmSessionKey)).enqueue(async () => {
           slackEvent.attachments = await attachmentsPromise;
           const adapters = createSlackAdapters(slackEvent, this, false);
           return this.handler.handleEvent(
@@ -1127,6 +1141,7 @@ export class SlackBot implements Bot {
       bot_id?: string;
       text?: string;
       ts?: string;
+      thread_ts?: string;
       subtype?: string;
       files?: Array<{ name: string }>;
     };
@@ -1178,6 +1193,7 @@ export class SlackBot implements Bot {
       this.logToFile(channelId, {
         date: new Date(parseFloat(msg.ts!) * 1000).toISOString(),
         ts: msg.ts!,
+        threadTs: msg.thread_ts,
         user: isMamaMessage ? "bot" : msg.user!,
         userName: isMamaMessage ? undefined : user?.userName,
         displayName: isMamaMessage ? undefined : user?.displayName,

--- a/src/adapters/slack/branch-manager.ts
+++ b/src/adapters/slack/branch-manager.ts
@@ -1,0 +1,193 @@
+import {
+  createManagedSessionFileAtPath,
+  createThreadSessionFileFromRootMessage,
+  extractSessionSuffix,
+  forkThreadSessionFile,
+  forkThreadSessionFileFromRootMessage,
+  getChannelSessionDir,
+  getThreadSessionFile,
+  resolveChannelSessionFile,
+  resolveManagedSessionFile,
+  ThreadRootNotFoundError,
+  tryResolveThreadSession,
+  type ThreadRootMessage,
+} from "../../session-store.js";
+import { findLogMessageById, type ConversationLogMessage } from "../../context.js";
+
+export interface SlackBranchBootstrapWaitOptions {
+  parentSessionKey: string;
+  sessionKey: string;
+  hasThreadSession: () => boolean;
+  isParentRunning: () => boolean;
+  sleep?: (ms: number) => Promise<void>;
+  pollMs?: number;
+}
+
+export interface SlackResolvedSessionScope {
+  sessionDir: string;
+  contextFile: string;
+  threadRootMessage: ConversationLogMessage | null;
+}
+
+export interface ResolveSlackSessionScopeOptions {
+  conversationDir: string;
+  sessionKey: string;
+  sleep?: (ms: number) => Promise<void>;
+  retryCount?: number;
+  retryDelayMs?: number;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildThreadRootSeed(message: ConversationLogMessage): ThreadRootMessage {
+  return {
+    text: message.text,
+    userName: message.userName,
+    user: message.user,
+    loggedAt: message.date ? new Date(message.date).getTime() : undefined,
+  };
+}
+
+async function forkThreadSessionFromRootWithRetry(
+  sourceSessionFile: string,
+  targetSessionFile: string,
+  cwd: string,
+  rootMessage: ConversationLogMessage,
+  sleep: (ms: number) => Promise<void>,
+  retryCount: number,
+  retryDelayMs: number,
+): Promise<string> {
+  const seed = buildThreadRootSeed(rootMessage);
+
+  for (let attempt = 0; attempt < retryCount; attempt++) {
+    try {
+      return forkThreadSessionFileFromRootMessage(sourceSessionFile, targetSessionFile, cwd, seed);
+    } catch (error) {
+      if (!(error instanceof ThreadRootNotFoundError)) throw error;
+      if (attempt === retryCount - 1) break;
+      await sleep(retryDelayMs);
+    }
+  }
+
+  return createThreadSessionFileFromRootMessage(targetSessionFile, cwd, seed, sourceSessionFile);
+}
+
+function createThreadSessionFromRootOrEmpty(
+  threadFile: string,
+  conversationDir: string,
+  threadRootMessage: ConversationLogMessage | null,
+  parentSession?: string,
+): string {
+  if (threadRootMessage) {
+    return createThreadSessionFileFromRootMessage(
+      threadFile,
+      conversationDir,
+      buildThreadRootSeed(threadRootMessage),
+      parentSession,
+    );
+  }
+  return createManagedSessionFileAtPath(threadFile, conversationDir);
+}
+
+export function hasMaterializedSlackBranchSession(
+  conversationDir: string,
+  sessionKey: string,
+): boolean {
+  if (!sessionKey.includes(":")) return false;
+  return tryResolveThreadSession(getThreadSessionFile(conversationDir, sessionKey)) !== null;
+}
+
+export async function waitForSlackBranchBootstrap(
+  options: SlackBranchBootstrapWaitOptions,
+): Promise<boolean> {
+  const {
+    parentSessionKey,
+    sessionKey,
+    hasThreadSession,
+    isParentRunning,
+    sleep = defaultSleep,
+    pollMs = 100,
+  } = options;
+
+  if (!sessionKey.includes(":")) return false;
+  if (sessionKey === parentSessionKey) return false;
+  if (hasThreadSession()) return false;
+
+  let waited = false;
+  while (isParentRunning() && !hasThreadSession()) {
+    waited = true;
+    await sleep(pollMs);
+  }
+
+  return waited;
+}
+
+export async function resolveSlackSessionScope(
+  options: ResolveSlackSessionScopeOptions,
+): Promise<SlackResolvedSessionScope> {
+  const {
+    conversationDir,
+    sessionKey,
+    sleep = defaultSleep,
+    retryCount = 5,
+    retryDelayMs = 100,
+  } = options;
+
+  const sessionDir = getChannelSessionDir(conversationDir);
+  if (!sessionKey.includes(":")) {
+    return {
+      sessionDir,
+      contextFile: resolveManagedSessionFile(sessionDir, conversationDir),
+      threadRootMessage: null,
+    };
+  }
+
+  const rootTs = extractSessionSuffix(sessionKey);
+  const threadRootMessage = await findLogMessageById(conversationDir, rootTs);
+  const threadFile = getThreadSessionFile(conversationDir, sessionKey);
+  const existing = tryResolveThreadSession(threadFile);
+  if (existing) {
+    return { sessionDir, contextFile: existing, threadRootMessage };
+  }
+
+  const conversationSource = resolveChannelSessionFile(conversationDir);
+  if (!conversationSource) {
+    return {
+      sessionDir,
+      contextFile: createThreadSessionFromRootOrEmpty(
+        threadFile,
+        conversationDir,
+        threadRootMessage,
+      ),
+      threadRootMessage,
+    };
+  }
+
+  try {
+    const contextFile = threadRootMessage
+      ? await forkThreadSessionFromRootWithRetry(
+          conversationSource,
+          threadFile,
+          conversationDir,
+          threadRootMessage,
+          sleep,
+          retryCount,
+          retryDelayMs,
+        )
+      : forkThreadSessionFile(conversationSource, threadFile, conversationDir);
+    return { sessionDir, contextFile, threadRootMessage };
+  } catch {
+    return {
+      sessionDir,
+      contextFile: createThreadSessionFromRootOrEmpty(
+        threadFile,
+        conversationDir,
+        threadRootMessage,
+        conversationSource,
+      ),
+      threadRootMessage,
+    };
+  }
+}

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -33,8 +33,15 @@ export function createSlackAdapters(
   const rootTs = resolveSlackRootTs(event.ts, event.thread_ts);
   const isThreaded = !!event.thread_ts;
 
-  /** Post first reply in-thread under the user's message, creating a thread if none exists */
+  /**
+   * Post the first visible reply.
+   * Normal Slack messages reply in-thread under the triggering user message.
+   * Synthetic event messages have no real Slack root ts, so they must post top-level.
+   */
   const postFirstMessage = async (text: string): Promise<string> => {
+    if (isEvent) {
+      return slack.postMessage(channelId, text);
+    }
     return slack.postInThread(channelId, event.ts, text);
   };
 

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -40,6 +40,9 @@ export function createSlackAdapters(
    */
   const postFirstMessage = async (text: string): Promise<string> => {
     if (isEvent) {
+      if (event.thread_ts) {
+        return slack.postInThread(channelId, event.thread_ts, text);
+      }
       return slack.postMessage(channelId, text);
     }
     return slack.postInThread(channelId, event.ts, text);

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -1,6 +1,7 @@
 import type { ChatMessage, ChatResponseContext, PlatformInfo } from "../../adapter.js";
 import * as log from "../../log.js";
 import type { SlackBot, SlackEvent } from "./bot.js";
+import { resolveSlackRootTs, resolveSlackSessionKey } from "./session.js";
 
 export const SLACK_FORMATTING_GUIDE = `## Slack Formatting (mrkdwn, NOT Markdown)
 Bold: *text*, Italic: _text_, Code: \`code\`, Block: \`\`\`code\`\`\`, Links: <url|text>
@@ -29,7 +30,7 @@ export function createSlackAdapters(
   // Extract event filename for status message
   const eventFilename = isEvent ? event.text.match(/^\[EVENT:([^:]+):/)?.[1] : undefined;
 
-  const rootTs = event.thread_ts ?? event.ts;
+  const rootTs = resolveSlackRootTs(event.ts, event.thread_ts);
   const isThreaded = !!event.thread_ts;
 
   /** Post first reply in-thread under the user's message, creating a thread if none exists */
@@ -39,9 +40,7 @@ export function createSlackAdapters(
 
   const message: ChatMessage = {
     id: event.ts,
-    sessionKey:
-      event.sessionKey ??
-      (event.thread_ts ? `${conversationId}:${event.thread_ts}` : conversationId),
+    sessionKey: event.sessionKey ?? resolveSlackSessionKey(conversationId, event.thread_ts),
     conversationKind: event.conversationKind,
     userId: event.user,
     userName: user?.userName,

--- a/src/adapters/slack/session.ts
+++ b/src/adapters/slack/session.ts
@@ -1,0 +1,7 @@
+export function resolveSlackSessionKey(channelId: string, threadTs?: string): string {
+  return threadTs ? `${channelId}:${threadTs}` : channelId;
+}
+
+export function resolveSlackRootTs(messageTs: string, threadTs?: string): string {
+  return threadTs || messageTs;
+}

--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -104,6 +104,7 @@ export class TelegramBot implements Bot {
       { command: "start", description: "Welcome message" },
       { command: "help", description: "Show available commands" },
       { command: "login", description: "Store credentials in your private vault" },
+      { command: "session", description: "Open the current session in the web viewer" },
       { command: "stop", description: "Stop ongoing conversation" },
       { command: "new", description: "Reset conversation history and start fresh" },
     ]);
@@ -425,6 +426,7 @@ export class TelegramBot implements Bot {
           "",
           "/new — Reset conversation history and start fresh",
           "/stop — Stop the current conversation",
+          "/session — Open the current session in the web viewer",
           "/help — Show available commands",
           "/login — Store credentials in your private vault",
         ].join("\n"),
@@ -442,6 +444,7 @@ export class TelegramBot implements Bot {
           "/start — Welcome message",
           "/help — Show this help",
           "/login — Store credentials in your private vault",
+          "/session — Open the current session in the web viewer",
           "/stop — Stop ongoing conversation",
           "/new — Reset conversation history and start fresh",
           "",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -937,6 +937,8 @@ export async function createRunner(
         conversationId,
         conversationKind: message.conversationKind,
         userId: message.userId,
+        sessionKey: message.sessionKey,
+        threadTs: platform.name === "slack" ? (message.threadTs ?? message.id) : message.threadTs,
       });
 
       // Set up file upload function

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -23,7 +23,12 @@ import type {
   PlatformInfo,
 } from "./adapter.js";
 import { loadAgentConfig } from "./config.js";
-import { createMamaSettingsManager, syncLogToSessionManager } from "./context.js";
+import {
+  createMamaSettingsManager,
+  findLogMessageById,
+  syncLogToSessionManager,
+  type ConversationLogMessage,
+} from "./context.js";
 import { ActorExecutionResolver } from "./execution-resolver.js";
 import * as log from "./log.js";
 import type { UserBindingStore } from "./bindings.js";
@@ -36,6 +41,7 @@ import {
   extractSessionSuffix,
   extractSessionUuid,
   forkThreadSessionFile,
+  forkThreadSessionFileFromRootMessage,
   getChannelSessionDir,
   getThreadSessionFile,
   openManagedSession,
@@ -67,6 +73,13 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 
 function getImageMimeType(filename: string): string | undefined {
   return IMAGE_MIME_TYPES[filename.toLowerCase().split(".").pop() || ""];
+}
+
+function buildThreadSessionName(message: ConversationLogMessage | null): string | undefined {
+  const text = message?.text?.trim();
+  if (!text) return undefined;
+  const userLabel = message?.userName || message?.user || "unknown";
+  return `[${userLabel}]: ${text}`;
 }
 
 async function getMemory(conversationDir: string): Promise<string> {
@@ -506,6 +519,8 @@ export async function createRunner(
   // Thread sessions use fixed files: {conversationDir}/sessions/{threadTs}.jsonl
   const sessionDir = getChannelSessionDir(conversationDir);
   const isThread = sessionKey.includes(":");
+  const rootTs = extractSessionSuffix(sessionKey);
+  const threadRootMessage = isThread ? await findLogMessageById(conversationDir, rootTs) : null;
 
   let sessionManager!: SessionManager;
   let contextFile!: string;
@@ -520,7 +535,21 @@ export async function createRunner(
       const conversationSource = resolveChannelSessionFile(conversationDir);
       if (conversationSource) {
         try {
-          contextFile = forkThreadSessionFile(conversationSource, threadFile, conversationDir);
+          contextFile = threadRootMessage
+            ? forkThreadSessionFileFromRootMessage(
+                conversationSource,
+                threadFile,
+                conversationDir,
+                {
+                  text: threadRootMessage.text,
+                  userName: threadRootMessage.userName,
+                  user: threadRootMessage.user,
+                  loggedAt: threadRootMessage.date
+                    ? new Date(threadRootMessage.date).getTime()
+                    : undefined,
+                },
+              )
+            : forkThreadSessionFile(conversationSource, threadFile, conversationDir);
           sessionManager = openManagedSession(contextFile, sessionDir, conversationDir);
         } catch {
           contextFile = createManagedSessionFileAtPath(threadFile, conversationDir);
@@ -536,9 +565,13 @@ export async function createRunner(
     contextFile = resolveManagedSessionFile(sessionDir, conversationDir);
     sessionManager = openManagedSession(contextFile, sessionDir, conversationDir);
   }
+  const threadSessionName = buildThreadSessionName(threadRootMessage);
+  if (isThread && threadSessionName && sessionManager.getSessionName() !== threadSessionName) {
+    sessionManager.appendSessionInfo(threadSessionName);
+  }
+
   const sessionUuid = extractSessionUuid(contextFile);
   // Used for Slack thread filtering — for non-Slack platforms this is effectively a no-op
-  const rootTs = extractSessionSuffix(sessionKey);
   const settingsManager = createMamaSettingsManager(join(conversationDir, ".."));
 
   // Create AuthStorage and ModelRegistry

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -9,7 +9,6 @@ import {
   getAgentDir,
   loadSkillsFromDir,
   ModelRegistry,
-  SessionManager,
   type Skill,
 } from "@mariozechner/pi-coding-agent";
 import { existsSync, readFileSync } from "fs";
@@ -25,7 +24,6 @@ import type {
 import { loadAgentConfig } from "./config.js";
 import {
   createMamaSettingsManager,
-  findLogMessageById,
   syncLogToSessionManager,
   type ConversationLogMessage,
 } from "./context.js";
@@ -36,19 +34,8 @@ import type { DockerContainerManager } from "./provisioner.js";
 import { createExecutor, type Executor, type SandboxConfig } from "./sandbox.js";
 import { addLifecycleBreadcrumb, metricAttributes } from "./sentry.js";
 import type { VaultManager } from "./vault.js";
-import {
-  createManagedSessionFileAtPath,
-  extractSessionSuffix,
-  extractSessionUuid,
-  forkThreadSessionFile,
-  forkThreadSessionFileFromRootMessage,
-  getChannelSessionDir,
-  getThreadSessionFile,
-  openManagedSession,
-  resolveChannelSessionFile,
-  resolveManagedSessionFile,
-  tryResolveThreadSession,
-} from "./session-store.js";
+import { extractSessionSuffix, extractSessionUuid, openManagedSession } from "./session-store.js";
+import { resolveSlackSessionScope } from "./adapters/slack/branch-manager.js";
 import { createMamaTools } from "./tools/index.js";
 import * as Sentry from "@sentry/node";
 
@@ -205,7 +192,10 @@ function buildSystemPrompt(
 ## Context
 - For current date/time, use: date
 - You have access to previous conversation context including tool results from prior turns.
-- For older history beyond your context, search log.jsonl (contains user messages and your final responses, but not tool results).
+- For older human-readable history beyond your context, search \`log.jsonl\` (contains user messages and your final responses, but not tool results).
+- Structured session history with tool results lives in \`${conversationPath}/sessions/\`.
+- The active top-level session is selected by \`${conversationPath}/sessions/current\`, which points to a timestamped \`.jsonl\` file in the same directory.
+- Slack thread/branch sessions use fixed files at \`${conversationPath}/sessions/<root_message_ts>.jsonl\` (for example \`${conversationPath}/sessions/1777386320.800769.jsonl\`).
 - User messages include a \`[in-thread:TS]\` marker when sent from within a Slack thread (TS is the root message timestamp). Without this marker, the message is a top-level channel message.
 
 ${platform.formattingGuide}
@@ -226,7 +216,11 @@ ${workspacePath}/
 ├── skills/                      # Global CLI tools you create
 └── ${conversationId}/           # This conversation
     ├── MEMORY.md                # Conversation-specific memory
-    ├── log.jsonl                # Message history (no tool results)
+    ├── log.jsonl                # Human-readable message history (no tool results)
+    ├── sessions/                # Structured session history used for context reconstruction
+    │   ├── current              # Active top-level session pointer
+    │   ├── <timestamp>_<id>.jsonl  # Top-level session files
+    │   └── <root_message_ts>.jsonl # Slack thread/branch session files
     ├── attachments/             # User-shared files
     ├── scratch/                 # Your working directory
     └── skills/                  # Conversation-specific tools
@@ -286,7 +280,7 @@ You can schedule events that wake you up at specific times or when external thin
 All \`at\` timestamps must include offset (e.g., \`+01:00\`). Periodic events use IANA timezone names. The harness runs in ${Intl.DateTimeFormat().resolvedOptions().timeZone}. When users mention times without timezone, assume ${Intl.DateTimeFormat().resolvedOptions().timeZone}.
 
 ### Platform and Credential Routing
-Set \`platform\` to the target bot platform (\`${platform.name}\` for this conversation). When only one platform is running, omitting \`platform\` is allowed for backward compatibility, but include it by default to avoid ambiguity.
+Set \`platform\` to the target bot platform (\`${platform.name}\` for this conversation). Include it explicitly to avoid ambiguity.
 
 Set \`userId\` to the platform userId of whoever asked for the event. When the event fires, tool execution routes using that user's vault selection in per-user modes. In \`container:<name>\`, events use the container's single shared vault.
 
@@ -343,6 +337,7 @@ Update this file whenever you modify the environment. On fresh container, read i
 ## Log Queries (for older history)
 Format: \`{"date":"...","ts":"...","user":"...","userName":"...","text":"...","isBot":false}\`
 The log contains user messages and your final responses (not tool calls/results).
+Use \`log.jsonl\` for quick grep-style history. Use \`${conversationPath}/sessions/\` when you need structured turns, tool outputs, or branch lineage.
 ${isContainer ? "Install jq: apt-get install jq" : ""}
 ${isFirecracker ? "Install jq: apt-get install jq" : ""}
 
@@ -355,6 +350,10 @@ grep -i "topic" log.jsonl | jq -c '{date: .date[0:19], user: (.userName // .user
 
 # Messages from specific user
 grep '"userName":"mario"' log.jsonl | tail -20 | jq -c '{date: .date[0:19], text}'
+
+# Inspect top-level session pointer and available session files
+cat sessions/current
+ls -1 sessions/
 \`\`\`
 
 ## Tools
@@ -515,56 +514,15 @@ export async function createRunner(
   );
 
   // Create session manager and settings manager
-  // Conversation sessions use {conversationDir}/sessions/current.
-  // Thread sessions use fixed files: {conversationDir}/sessions/{threadTs}.jsonl
-  const sessionDir = getChannelSessionDir(conversationDir);
+  // Slack top-level sessions use {conversationDir}/sessions/current.
+  // Slack branch sessions use fixed files: {conversationDir}/sessions/{rootTs}.jsonl
   const isThread = sessionKey.includes(":");
   const rootTs = extractSessionSuffix(sessionKey);
-  const threadRootMessage = isThread ? await findLogMessageById(conversationDir, rootTs) : null;
-
-  let sessionManager!: SessionManager;
-  let contextFile!: string;
-
-  if (isThread) {
-    const threadFile = getThreadSessionFile(conversationDir, sessionKey);
-    const existing = tryResolveThreadSession(threadFile);
-    if (existing) {
-      contextFile = existing;
-      sessionManager = openManagedSession(contextFile, sessionDir, conversationDir);
-    } else {
-      const conversationSource = resolveChannelSessionFile(conversationDir);
-      if (conversationSource) {
-        try {
-          contextFile = threadRootMessage
-            ? forkThreadSessionFileFromRootMessage(
-                conversationSource,
-                threadFile,
-                conversationDir,
-                {
-                  text: threadRootMessage.text,
-                  userName: threadRootMessage.userName,
-                  user: threadRootMessage.user,
-                  loggedAt: threadRootMessage.date
-                    ? new Date(threadRootMessage.date).getTime()
-                    : undefined,
-                },
-              )
-            : forkThreadSessionFile(conversationSource, threadFile, conversationDir);
-          sessionManager = openManagedSession(contextFile, sessionDir, conversationDir);
-        } catch {
-          contextFile = createManagedSessionFileAtPath(threadFile, conversationDir);
-          sessionManager = openManagedSession(contextFile, sessionDir, conversationDir);
-        }
-      } else {
-        contextFile = createManagedSessionFileAtPath(threadFile, conversationDir);
-        sessionManager = openManagedSession(contextFile, sessionDir, conversationDir);
-      }
-    }
-  } else {
-    // Direct/shared session: normal resolve
-    contextFile = resolveManagedSessionFile(sessionDir, conversationDir);
-    sessionManager = openManagedSession(contextFile, sessionDir, conversationDir);
-  }
+  const { sessionDir, contextFile, threadRootMessage } = await resolveSlackSessionScope({
+    conversationDir,
+    sessionKey,
+  });
+  const sessionManager = openManagedSession(contextFile, sessionDir, conversationDir);
   const threadSessionName = buildThreadSessionName(threadRootMessage);
   if (isThread && threadSessionName && sessionManager.getSessionName() !== threadSessionName) {
     sessionManager.appendSessionInfo(threadSessionName);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -938,7 +938,10 @@ export async function createRunner(
         conversationKind: message.conversationKind,
         userId: message.userId,
         sessionKey: message.sessionKey,
-        threadTs: platform.name === "slack" ? (message.threadTs ?? message.id) : message.threadTs,
+        // For Slack scheduled events, preserve thread targeting only when the
+        // request was created inside an existing thread. Top-level reminders
+        // should come back as top-level messages.
+        threadTs: message.threadTs,
       });
 
       // Set up file upload function

--- a/src/context.ts
+++ b/src/context.ts
@@ -252,11 +252,16 @@ export async function findLogMessageById(
   return null;
 }
 
+function stripSlackAttachmentBlock(text: string): string {
+  return text.replace(/\n*<slack_attachments>\n[\s\S]*?\n<\/slack_attachments>\s*$/g, "");
+}
+
 function normalizeComparableUserText(text: string): string {
-  return text.replace(
+  const withoutTimestamp = text.replace(
     /^\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}\]\s+(?=\[[^\]]+\](?:\s+\[in-thread:[^\]]+\])?:\s)/,
     "",
   );
+  return stripSlackAttachmentBlock(withoutTimestamp).trim();
 }
 
 function hasExistingSessionMessage(

--- a/src/context.ts
+++ b/src/context.ts
@@ -47,6 +47,12 @@ interface LogMessage {
   isBot?: boolean;
 }
 
+interface ExistingSessionMessage {
+  timestamp?: number;
+  rawText: string;
+  normalizedText: string;
+}
+
 /**
  * Thread filter for scoping log sync to a specific thread session.
  * When provided, only messages belonging to this thread are synced,
@@ -69,7 +75,7 @@ export interface ThreadFilter {
  *
  * @param sessionManager - The SessionManager to sync to
  * @param conversationDir - Path to the conversation directory containing log.jsonl
- * @param excludeSlackTs - Slack timestamp of current message (will be added via prompt(), not sync)
+ * @param excludeSlackTs - Current platform message ID/timestamp (will be added via prompt(), not sync)
  * @param timeRange - Optional time range to filter log entries (defaults to last 10 days)
  * @param threadFilter - Optional thread filter to scope sync to a specific thread
  * @returns Number of messages synced
@@ -89,10 +95,12 @@ export async function syncLogToSessionManager(
 
   if (!existsSync(logFile)) return 0;
 
-  // Build set of existing log-derived message keys from session entries.
-  // Deduping must use the embedded message.timestamp/content pair, not the
-  // session entry timestamp (ISO string), otherwise every refresh/run can
-  // re-import the same log.jsonl user messages again.
+  // Build a list of existing session messages for dedupe.
+  // Live user prompts carry a formatted timestamp in the text and use Date.now(),
+  // while log.jsonl uses the platform event timestamp. We therefore need a small
+  // fuzzy match window in addition to the exact timestamp/content match used for
+  // already-synced log entries.
+  const existingMessages: ExistingSessionMessage[] = [];
   const existingMessageKeys = new Set<string>();
   for (const entry of sessionManager.getEntries()) {
     if (entry.type !== "message") continue;
@@ -106,6 +114,11 @@ export async function syncLogToSessionManager(
       : typeof message.content === "string"
         ? message.content
         : "";
+    existingMessages.push({
+      timestamp: typeof message.timestamp === "number" ? message.timestamp : undefined,
+      rawText: contentText,
+      normalizedText: normalizeComparableUserText(contentText),
+    });
     if (typeof message.timestamp === "number") {
       existingMessageKeys.add(`${message.timestamp}:${contentText}`);
     }
@@ -127,6 +140,11 @@ export async function syncLogToSessionManager(
 
       // Skip the current message being processed (will be added via prompt())
       if (excludeSlackTs && slackTs === excludeSlackTs) continue;
+
+      // While queued messages are being processed, newer messages may already be present
+      // in log.jsonl. Do not look ahead into those future messages when building the
+      // current turn's context.
+      if (!isMessageAtOrBeforeCurrent(slackTs, excludeSlackTs)) continue;
 
       // Skip bot messages - added through agent flow
       if (logMsg.isBot) continue;
@@ -164,6 +182,7 @@ export async function syncLogToSessionManager(
       const msgTime = new Date(date).getTime() || Date.now();
       const messageKey = `${msgTime}:${messageText}`;
       if (existingMessageKeys.has(messageKey)) continue;
+      if (hasExistingSessionMessage(existingMessages, msgTime, messageText)) continue;
 
       // Skip messages outside the time range
       if (msgTime < range.start || msgTime > range.end) continue;
@@ -175,6 +194,11 @@ export async function syncLogToSessionManager(
       };
 
       newMessages.push({ timestamp: msgTime, message: userMessage });
+      existingMessages.push({
+        timestamp: msgTime,
+        rawText: messageText,
+        normalizedText: normalizeComparableUserText(messageText),
+      });
       existingMessageKeys.add(messageKey); // Track to avoid duplicates within this sync
     } catch {
       // Skip malformed lines
@@ -202,4 +226,50 @@ export async function syncLogToSessionManager(
 // without interfering with coding-agent's global settings files.
 export function createMamaSettingsManager(_workspaceDir: string): SettingsManager {
   return SettingsManager.inMemory();
+}
+
+function normalizeComparableUserText(text: string): string {
+  return text.replace(
+    /^\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}\]\s+(?=\[[^\]]+\](?:\s+\[in-thread:[^\]]+\])?:\s)/,
+    "",
+  );
+}
+
+function hasExistingSessionMessage(
+  existingMessages: ExistingSessionMessage[],
+  timestamp: number,
+  text: string,
+): boolean {
+  const normalizedText = normalizeComparableUserText(text);
+  return existingMessages.some((existing) => {
+    if (existing.timestamp === timestamp && existing.rawText === text) {
+      return true;
+    }
+    if (existing.normalizedText !== normalizedText || existing.timestamp === undefined) {
+      return false;
+    }
+    return existing.timestamp >= timestamp;
+  });
+}
+
+function isMessageAtOrBeforeCurrent(messageId: string, currentMessageId?: string): boolean {
+  if (!currentMessageId) return true;
+  const comparison = compareMessageIds(messageId, currentMessageId);
+  return comparison === null || comparison <= 0;
+}
+
+function compareMessageIds(a: string, b: string): number | null {
+  if (/^\d+$/.test(a) && /^\d+$/.test(b)) {
+    const left = BigInt(a);
+    const right = BigInt(b);
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+
+  const left = Number(a);
+  const right = Number(b);
+  if (Number.isFinite(left) && Number.isFinite(right)) {
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+
+  return null;
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -37,7 +37,7 @@ export interface TimeRange {
  */
 const DEFAULT_SYNC_DAYS = 10;
 
-interface LogMessage {
+export interface ConversationLogMessage {
   date?: string;
   ts?: string;
   threadTs?: string;
@@ -132,7 +132,7 @@ export async function syncLogToSessionManager(
 
   for (const line of logLines) {
     try {
-      const logMsg: LogMessage = JSON.parse(line);
+      const logMsg: ConversationLogMessage = JSON.parse(line);
 
       const slackTs = logMsg.ts;
       const date = logMsg.date;
@@ -226,6 +226,30 @@ export async function syncLogToSessionManager(
 // without interfering with coding-agent's global settings files.
 export function createMamaSettingsManager(_workspaceDir: string): SettingsManager {
   return SettingsManager.inMemory();
+}
+
+export async function findLogMessageById(
+  conversationDir: string,
+  messageId: string,
+): Promise<ConversationLogMessage | null> {
+  const logFile = join(conversationDir, "log.jsonl");
+  if (!existsSync(logFile)) return null;
+
+  const logContent = await readFile(logFile, "utf-8");
+  const logLines = logContent.trim().split("\n").filter(Boolean);
+
+  for (let i = logLines.length - 1; i >= 0; i--) {
+    try {
+      const entry = JSON.parse(logLines[i]) as ConversationLogMessage;
+      if (entry.ts === messageId) {
+        return entry;
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return null;
 }
 
 function normalizeComparableUserText(text: string): string {

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,7 +10,7 @@
  * - createMamaSettingsManager: Creates an in-memory SettingsManager for AgentSession
  */
 
-import type { UserMessage } from "@mariozechner/pi-ai";
+import type { Message, UserMessage } from "@mariozechner/pi-ai";
 import {
   type SessionManager,
   type SessionMessageEntry,
@@ -89,16 +89,25 @@ export async function syncLogToSessionManager(
 
   if (!existsSync(logFile)) return 0;
 
-  // Build set of existing timestamps from session entries
-  // We use ts (Slack timestamp) as the unique key instead of message content
-  const existingTimestamps = new Set<string>();
+  // Build set of existing log-derived message keys from session entries.
+  // Deduping must use the embedded message.timestamp/content pair, not the
+  // session entry timestamp (ISO string), otherwise every refresh/run can
+  // re-import the same log.jsonl user messages again.
+  const existingMessageKeys = new Set<string>();
   for (const entry of sessionManager.getEntries()) {
-    if (entry.type === "message") {
-      const msgEntry = entry as SessionMessageEntry;
-      // SessionMessageEntry has a timestamp field (number, Unix ms)
-      if (msgEntry.timestamp) {
-        existingTimestamps.add(msgEntry.timestamp.toString());
-      }
+    if (entry.type !== "message") continue;
+    const msgEntry = entry as SessionMessageEntry;
+    const message = msgEntry.message as Message;
+    const contentText = Array.isArray(message.content)
+      ? message.content
+          .filter((part): part is { type: "text"; text: string } => part.type === "text")
+          .map((part) => part.text)
+          .join("\n\n")
+      : typeof message.content === "string"
+        ? message.content
+        : "";
+    if (typeof message.timestamp === "number") {
+      existingMessageKeys.add(`${message.timestamp}:${contentText}`);
     }
   }
 
@@ -148,16 +157,13 @@ export async function syncLogToSessionManager(
         }
       }
 
-      // Skip if this Slack timestamp is already in the session (dedupe by ts, not content)
-      // Convert Slack ts (e.g., "1234567890.123456") to Unix ms for comparison
-      const slackTsMs = Math.floor(parseFloat(slackTs) * 1000).toString();
-      if (existingTimestamps.has(slackTsMs)) continue;
-
       // Build the message text as it would appear in context
       const threadContext = logMsg.threadTs ? ` [in-thread:${logMsg.threadTs}]` : "";
       const messageText = `[${logMsg.userName || logMsg.user || "unknown"}]${threadContext}: ${logMsg.text || ""}`;
 
       const msgTime = new Date(date).getTime() || Date.now();
+      const messageKey = `${msgTime}:${messageText}`;
+      if (existingMessageKeys.has(messageKey)) continue;
 
       // Skip messages outside the time range
       if (msgTime < range.start || msgTime > range.end) continue;
@@ -169,7 +175,7 @@ export async function syncLogToSessionManager(
       };
 
       newMessages.push({ timestamp: msgTime, message: userMessage });
-      existingTimestamps.add(slackTsMs); // Track to avoid duplicates within this sync
+      existingMessageKeys.add(messageKey); // Track to avoid duplicates within this sync
     } catch {
       // Skip malformed lines
     }

--- a/src/events.ts
+++ b/src/events.ts
@@ -100,8 +100,11 @@ export class EventsWatcher {
     this.scanExisting();
 
     // Watch for changes
-    this.watcher = watch(this.eventsDir, (_eventType, filename) => {
+    this.watcher = watch(this.eventsDir, (eventType, filename) => {
       if (!filename || !filename.endsWith(".json")) return;
+      log.logInfo(
+        `Events watcher fs event: ${String(eventType)} ${filename} (exists=${existsSync(join(this.eventsDir, filename))})`,
+      );
       this.debounce(filename, () => this.handleFileChange(filename));
     });
 
@@ -201,14 +204,17 @@ export class EventsWatcher {
 
   private handleFileChange(filename: string): void {
     const filePath = join(this.eventsDir, filename);
+    const exists = existsSync(filePath);
+    const known = this.knownFiles.has(filename);
+    log.logInfo(`Handling event file change: ${filename} (exists=${exists}, known=${known})`);
 
-    if (!existsSync(filePath)) {
+    if (!exists) {
       // fs.watch can briefly report a file as missing during create/rename churn.
       // Confirm deletion before canceling scheduled events.
       void this.handleDelete(filename);
-    } else if (this.knownFiles.has(filename)) {
+    } else if (known) {
       // File was modified - cancel existing and re-schedule
-      this.cancelScheduled(filename);
+      this.cancelScheduled(filename, "file-modified");
       void this.handleFile(filename);
     } else {
       // New file
@@ -221,25 +227,31 @@ export class EventsWatcher {
 
     const filePath = join(this.eventsDir, filename);
     for (let i = 0; i < MAX_RETRIES; i++) {
-      await this.sleep(RETRY_BASE_MS * 2 ** i);
-      if (existsSync(filePath)) {
+      const delay = RETRY_BASE_MS * 2 ** i;
+      await this.sleep(delay);
+      const exists = existsSync(filePath);
+      log.logInfo(`Confirming event deletion: ${filename} after ${delay}ms (exists=${exists})`);
+      if (exists) {
         return;
       }
     }
 
     log.logInfo(`Event file deleted: ${filename}`);
-    this.cancelScheduled(filename);
+    this.cancelScheduled(filename, "confirmed-delete");
     this.knownFiles.delete(filename);
   }
 
-  private cancelScheduled(filename: string): void {
+  private cancelScheduled(filename: string, reason = "unspecified"): void {
     const timer = this.timers.get(filename);
+    const cron = this.crons.get(filename);
+    log.logInfo(
+      `Canceling scheduled event: ${filename} (reason=${reason}, timer=${Boolean(timer)}, cron=${Boolean(cron)})`,
+    );
     if (timer) {
       clearTimeout(timer);
       this.timers.delete(filename);
     }
 
-    const cron = this.crons.get(filename);
     if (cron) {
       cron.stop();
       this.crons.delete(filename);
@@ -248,6 +260,7 @@ export class EventsWatcher {
 
   private async handleFile(filename: string): Promise<void> {
     const filePath = join(this.eventsDir, filename);
+    log.logInfo(`Loading event file: ${filename} from ${filePath}`);
 
     // Parse with retries
     let event: MamaEvent | null = null;
@@ -271,11 +284,14 @@ export class EventsWatcher {
         `Failed to parse event file after ${MAX_RETRIES} retries: ${filename}`,
         lastError?.message,
       );
-      this.deleteFile(filename);
+      this.deleteFile(filename, "parse-failed");
       return;
     }
 
     this.knownFiles.add(filename);
+    log.logInfo(
+      `Parsed event file: ${filename} (${event.type} for ${event.platform}/${event.conversationId})`,
+    );
 
     // Schedule based on type
     switch (event.type) {
@@ -410,7 +426,7 @@ export class EventsWatcher {
       const stat = statSync(filePath);
       if (stat.mtimeMs < this.startTime) {
         log.logInfo(`Stale immediate event, deleting: ${filename}`);
-        this.deleteFile(filename);
+        this.deleteFile(filename, "stale-immediate");
         return;
       }
     } catch {
@@ -429,12 +445,14 @@ export class EventsWatcher {
     if (atTime <= now) {
       // Past - delete without executing
       log.logInfo(`One-shot event in the past, deleting: ${filename}`);
-      this.deleteFile(filename);
+      this.deleteFile(filename, "one-shot-in-past");
       return;
     }
 
     const delay = atTime - now;
-    log.logInfo(`Scheduling one-shot event: ${filename} in ${Math.round(delay / 1000)}s`);
+    log.logInfo(
+      `Scheduling one-shot event: ${filename} in ${Math.round(delay / 1000)}s (at=${event.at}, now=${new Date(now).toISOString()})`,
+    );
 
     const timer = setTimeout(() => {
       this.timers.delete(filename);
@@ -443,6 +461,7 @@ export class EventsWatcher {
     }, delay);
 
     this.timers.set(filename, timer);
+    log.logInfo(`Stored one-shot timer: ${filename} (active timers=${this.timers.size})`);
   }
 
   private handlePeriodic(filename: string, event: PeriodicEvent): void {
@@ -460,7 +479,7 @@ export class EventsWatcher {
       );
     } catch (err) {
       log.logWarning(`Invalid cron schedule for ${filename}: ${event.schedule}`, String(err));
-      this.deleteFile(filename);
+      this.deleteFile(filename, "invalid-cron");
     }
   }
 
@@ -485,7 +504,7 @@ export class EventsWatcher {
     if (!bot) {
       log.logWarning(`No bot configured for event platform '${event.platform}'`, filename);
       if (deleteAfter) {
-        this.deleteFile(filename);
+        this.deleteFile(filename, "missing-bot");
       }
       return;
     }
@@ -508,18 +527,19 @@ export class EventsWatcher {
 
     if (enqueued && deleteAfter) {
       // Delete file after successful enqueue (immediate and one-shot)
-      this.deleteFile(filename);
+      this.deleteFile(filename, "executed-and-enqueued");
     } else if (!enqueued) {
       log.logWarning(`Event queue full, discarded: ${filename}`);
       // Still delete immediate/one-shot even if discarded
       if (deleteAfter) {
-        this.deleteFile(filename);
+        this.deleteFile(filename, "queue-full-discarded");
       }
     }
   }
 
-  private deleteFile(filename: string): void {
+  private deleteFile(filename: string, reason = "unspecified"): void {
     const filePath = join(this.eventsDir, filename);
+    log.logInfo(`Deleting event file: ${filename} (reason=${reason})`);
     try {
       unlinkSync(filePath);
     } catch (err) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -72,6 +72,7 @@ const RETRY_BASE_MS = 100;
 
 export class EventsWatcher {
   private timers: Map<string, NodeJS.Timeout> = new Map();
+  private timerEventTypes: Map<string, "one-shot"> = new Map();
   private crons: Map<string, Cron> = new Map();
   private debounceTimers: Map<string, NodeJS.Timeout> = new Map();
   private startTime: number;
@@ -132,6 +133,7 @@ export class EventsWatcher {
       clearTimeout(timer);
     }
     this.timers.clear();
+    this.timerEventTypes.clear();
 
     // Cancel all cron jobs
     for (const cron of this.crons.values()) {
@@ -236,6 +238,13 @@ export class EventsWatcher {
       }
     }
 
+    if (this.timerEventTypes.get(filename) === "one-shot" && this.timers.has(filename)) {
+      log.logInfo(
+        `Ignoring deleted one-shot file after scheduling: ${filename} (timer remains active)`,
+      );
+      return;
+    }
+
     log.logInfo(`Event file deleted: ${filename}`);
     this.cancelScheduled(filename, "confirmed-delete");
     this.knownFiles.delete(filename);
@@ -250,6 +259,7 @@ export class EventsWatcher {
     if (timer) {
       clearTimeout(timer);
       this.timers.delete(filename);
+      this.timerEventTypes.delete(filename);
     }
 
     if (cron) {
@@ -456,11 +466,13 @@ export class EventsWatcher {
 
     const timer = setTimeout(() => {
       this.timers.delete(filename);
+      this.timerEventTypes.delete(filename);
       log.logInfo(`Executing one-shot event: ${filename}`);
       this.execute(filename, event);
     }, delay);
 
     this.timers.set(filename, timer);
+    this.timerEventTypes.set(filename, "one-shot");
     log.logInfo(`Stored one-shot timer: ${filename} (active timers=${this.timers.size})`);
   }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -18,7 +18,12 @@ import * as log from "./log.js";
 // Event Types
 // ============================================================================
 
-export interface ImmediateEvent {
+interface ScopedEventFields {
+  sessionKey?: string;
+  threadTs?: string;
+}
+
+export interface ImmediateEvent extends ScopedEventFields {
   type: "immediate";
   platform: string;
   conversationId: string;
@@ -28,7 +33,7 @@ export interface ImmediateEvent {
   text: string;
 }
 
-export interface OneShotEvent {
+export interface OneShotEvent extends ScopedEventFields {
   type: "one-shot";
   platform: string;
   conversationId: string;
@@ -38,7 +43,7 @@ export interface OneShotEvent {
   at: string; // ISO 8601 with timezone offset
 }
 
-export interface PeriodicEvent {
+export interface PeriodicEvent extends ScopedEventFields {
   type: "periodic";
   platform: string;
   conversationId: string;
@@ -337,6 +342,8 @@ export class EventsWatcher {
       data.conversationKind,
     );
     const userId = typeof data.userId === "string" ? data.userId : undefined;
+    const sessionKey = typeof data.sessionKey === "string" ? data.sessionKey : undefined;
+    const threadTs = typeof data.threadTs === "string" ? data.threadTs : undefined;
 
     switch (data.type) {
       case "immediate":
@@ -347,6 +354,8 @@ export class EventsWatcher {
           conversationKind,
           userId,
           text: data.text,
+          sessionKey,
+          threadTs,
         };
 
       case "one-shot":
@@ -361,6 +370,8 @@ export class EventsWatcher {
           userId,
           text: data.text,
           at: data.at,
+          sessionKey,
+          threadTs,
         };
 
       case "periodic":
@@ -379,6 +390,8 @@ export class EventsWatcher {
           text: data.text,
           schedule: data.schedule,
           timezone: data.timezone,
+          sessionKey,
+          threadTs,
         };
 
       default:
@@ -531,7 +544,8 @@ export class EventsWatcher {
       user: event.userId ?? "EVENT",
       text: message,
       ts: `event:${filename}`,
-      sessionKey: event.conversationId,
+      thread_ts: event.threadTs,
+      sessionKey: event.sessionKey ?? event.conversationId,
     };
 
     // Enqueue for processing

--- a/src/events.ts
+++ b/src/events.ts
@@ -203,20 +203,29 @@ export class EventsWatcher {
     const filePath = join(this.eventsDir, filename);
 
     if (!existsSync(filePath)) {
-      // File was deleted
-      this.handleDelete(filename);
+      // fs.watch can briefly report a file as missing during create/rename churn.
+      // Confirm deletion before canceling scheduled events.
+      void this.handleDelete(filename);
     } else if (this.knownFiles.has(filename)) {
       // File was modified - cancel existing and re-schedule
       this.cancelScheduled(filename);
-      this.handleFile(filename);
+      void this.handleFile(filename);
     } else {
       // New file
-      this.handleFile(filename);
+      void this.handleFile(filename);
     }
   }
 
-  private handleDelete(filename: string): void {
+  private async handleDelete(filename: string): Promise<void> {
     if (!this.knownFiles.has(filename)) return;
+
+    const filePath = join(this.eventsDir, filename);
+    for (let i = 0; i < MAX_RETRIES; i++) {
+      await this.sleep(RETRY_BASE_MS * 2 ** i);
+      if (existsSync(filePath)) {
+        return;
+      }
+    }
 
     log.logInfo(`Event file deleted: ${filename}`);
     this.cancelScheduled(filename);

--- a/src/events.ts
+++ b/src/events.ts
@@ -18,12 +18,7 @@ import * as log from "./log.js";
 // Event Types
 // ============================================================================
 
-interface ScopedEventFields {
-  sessionKey?: string;
-  threadTs?: string;
-}
-
-export interface ImmediateEvent extends ScopedEventFields {
+export interface ImmediateEvent {
   type: "immediate";
   platform: string;
   conversationId: string;
@@ -31,9 +26,13 @@ export interface ImmediateEvent extends ScopedEventFields {
   /** Creator userId — routes tool execution to that user's vault selection when fired. */
   userId?: string;
   text: string;
+  /** Determines which AgentRunner handles the event. */
+  sessionKey?: string;
+  /** Sub-conversation target (Slack thread ts, Discord thread id, Telegram reply-to id). */
+  threadTs?: string;
 }
 
-export interface OneShotEvent extends ScopedEventFields {
+export interface OneShotEvent {
   type: "one-shot";
   platform: string;
   conversationId: string;
@@ -41,9 +40,10 @@ export interface OneShotEvent extends ScopedEventFields {
   userId?: string;
   text: string;
   at: string; // ISO 8601 with timezone offset
+  // No sessionKey or threadTs: reminders fire as top-level messages regardless of where they were created.
 }
 
-export interface PeriodicEvent extends ScopedEventFields {
+export interface PeriodicEvent {
   type: "periodic";
   platform: string;
   conversationId: string;
@@ -52,6 +52,9 @@ export interface PeriodicEvent extends ScopedEventFields {
   text: string;
   schedule: string; // cron syntax
   timezone: string; // IANA timezone
+  /** Determines which AgentRunner handles the event. */
+  sessionKey?: string;
+  // No threadTs: recurring events always fire as top-level messages.
 }
 
 export type MamaEvent = ImmediateEvent | OneShotEvent | PeriodicEvent;
@@ -370,8 +373,6 @@ export class EventsWatcher {
           userId,
           text: data.text,
           at: data.at,
-          sessionKey,
-          threadTs,
         };
 
       case "periodic":
@@ -391,7 +392,6 @@ export class EventsWatcher {
           schedule: data.schedule,
           timezone: data.timezone,
           sessionKey,
-          threadTs,
         };
 
       default:
@@ -537,6 +537,7 @@ export class EventsWatcher {
     // Create synthetic BotEvent. Keep a stable conversation session key so recurring
     // reminders share context, but use a unique synthetic message id because
     // some adapters treat ts/message id as a reply target.
+    const scopedEvent = event as { sessionKey?: string; threadTs?: string };
     const syntheticEvent: BotEvent = {
       type: "mention",
       conversationId: event.conversationId,
@@ -544,8 +545,8 @@ export class EventsWatcher {
       user: event.userId ?? "EVENT",
       text: message,
       ts: `event:${filename}`,
-      thread_ts: event.threadTs,
-      sessionKey: event.sessionKey ?? event.conversationId,
+      thread_ts: scopedEvent.threadTs,
+      sessionKey: scopedEvent.sessionKey ?? event.conversationId,
     };
 
     // Enqueue for processing

--- a/src/login/portal.ts
+++ b/src/login/portal.ts
@@ -1,6 +1,8 @@
 import { createHash, randomBytes } from "crypto";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "http";
 import { resolveLinkBaseUrl } from "../config.js";
+import { handleSessionViewRequest } from "../session-view/portal.js";
+import type { InMemorySessionViewTokenStore } from "../session-view/store.js";
 import type { InMemoryLinkTokenStore } from "./session.js";
 import {
   getOAuthServices,
@@ -245,100 +247,113 @@ export function startLinkServer(
   linkTokenStore: InMemoryLinkTokenStore,
   vaultManager: VaultManager,
   notify: NotifyFn,
+  sessionViewTokenStore?: InMemorySessionViewTokenStore,
 ): Server {
   const oauthStates = new Map<string, PendingOAuthState>();
 
-  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-    const url = new URL(req.url ?? "/", requestBaseUrl(req));
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    try {
+      const url = new URL(req.url ?? "/", requestBaseUrl(req));
 
-    if (req.method === "GET" && url.pathname === "/health") {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true }));
-      return;
-    }
+      if (req.method === "GET" && url.pathname === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
 
-    if (req.method === "GET" && url.pathname === "/link") {
-      const rawToken = url.searchParams.get("token") ?? "";
-      const linkToken = linkTokenStore.peek(rawToken);
+      if (await handleSessionViewRequest(req, res, url, sessionViewTokenStore)) {
+        return;
+      }
 
-      if (!linkToken) {
-        res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+      if (req.method === "GET" && url.pathname === "/link") {
+        const rawToken = url.searchParams.get("token") ?? "";
+        const linkToken = linkTokenStore.peek(rawToken);
+
+        if (!linkToken) {
+          res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+          res.end(
+            renderErrorPage(
+              "This link is invalid or has expired. Ask the bot for a new /login link.",
+            ),
+          );
+          return;
+        }
+
+        const oauthServiceHint = linkToken.providerId
+          ? resolveOAuthService(linkToken.providerId)
+          : undefined;
+        const oauthServices = getOAuthServices();
+        const defaultMode: LoginCredentialKind = oauthServiceHint ? "oauth" : "api_key";
+        const existingSecrets = describeVaultSecrets(vaultManager, linkToken.vaultId);
+
+        const title = oauthServiceHint ? `${oauthServiceHint.label} OAuth` : "Store Secret";
+        const helpText = oauthServiceHint
+          ? `Authorize ${oauthServiceHint.label} and store tokens in your vault.`
+          : "Set any environment variable key/value pair in your vault.";
+        const secretLabel = "Secret value";
+        const placeholder = "sk-...";
+        const initialEnvKey = "";
+
+        res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
         res.end(
-          renderErrorPage(
-            "This link is invalid or has expired. Ask the bot for a new /login link.",
+          renderCredentialPage(
+            rawToken,
+            title,
+            defaultMode,
+            initialEnvKey,
+            secretLabel,
+            placeholder,
+            helpText,
+            oauthServices,
+            oauthServiceHint?.id,
+            existingSecrets,
           ),
         );
         return;
       }
 
-      const oauthServiceHint = linkToken.providerId
-        ? resolveOAuthService(linkToken.providerId)
-        : undefined;
-      const oauthServices = getOAuthServices();
-      const defaultMode: LoginCredentialKind = oauthServiceHint ? "oauth" : "api_key";
-      const existingSecrets = describeVaultSecrets(vaultManager, linkToken.vaultId);
+      if (req.method === "POST" && url.pathname === "/api/link/complete") {
+        if (!enforceCsrf(req, res)) return;
+        void readJsonBody(req, res, async (body) => {
+          await handleLinkComplete(body, linkTokenStore, vaultManager, notify, res);
+        });
+        return;
+      }
 
-      const title = oauthServiceHint ? `${oauthServiceHint.label} OAuth` : "Store Secret";
-      const helpText = oauthServiceHint
-        ? `Authorize ${oauthServiceHint.label} and store tokens in your vault.`
-        : "Set any environment variable key/value pair in your vault.";
-      const secretLabel = "Secret value";
-      const placeholder = "sk-...";
-      const initialEnvKey = "";
+      if (req.method === "POST" && url.pathname === "/api/oauth/start") {
+        if (!enforceCsrf(req, res)) return;
+        void readJsonBody(req, res, async (body) => {
+          await handleOAuthStart(body, req, linkTokenStore, oauthStates, res);
+        });
+        return;
+      }
 
-      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-      res.end(
-        renderCredentialPage(
-          rawToken,
-          title,
-          defaultMode,
-          initialEnvKey,
-          secretLabel,
-          placeholder,
-          helpText,
-          oauthServices,
-          oauthServiceHint?.id,
-          existingSecrets,
-        ),
-      );
-      return;
+      if (req.method === "GET" && url.pathname === "/oauth/callback") {
+        void handleOAuthCallback(
+          url,
+          req,
+          linkTokenStore,
+          vaultManager,
+          notify,
+          oauthStates,
+          res,
+        ).catch((err: Error) => {
+          log.logWarning("OAuth callback failed", err.message);
+          res.writeHead(500, { "Content-Type": "text/html; charset=utf-8" });
+          res.end(renderErrorPage("OAuth callback failed. Please retry /login."));
+        });
+        return;
+      }
+
+      res.writeHead(404);
+      res.end();
+    } catch (err) {
+      log.logWarning("Link server request error", err instanceof Error ? err.message : String(err));
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+      }
+      res.end(JSON.stringify({ error: "Internal server error" }));
     }
-
-    if (req.method === "POST" && url.pathname === "/api/link/complete") {
-      if (!enforceCsrf(req, res)) return;
-      void readJsonBody(req, res, async (body) => {
-        await handleLinkComplete(body, linkTokenStore, vaultManager, notify, res);
-      });
-      return;
-    }
-
-    if (req.method === "POST" && url.pathname === "/api/oauth/start") {
-      if (!enforceCsrf(req, res)) return;
-      void readJsonBody(req, res, async (body) => {
-        await handleOAuthStart(body, req, linkTokenStore, oauthStates, res);
-      });
-      return;
-    }
-
-    if (req.method === "GET" && url.pathname === "/oauth/callback") {
-      void handleOAuthCallback(
-        url,
-        req,
-        linkTokenStore,
-        vaultManager,
-        notify,
-        oauthStates,
-        res,
-      ).catch((err: Error) => {
-        log.logWarning("OAuth callback failed", err.message);
-        res.writeHead(500, { "Content-Type": "text/html; charset=utf-8" });
-        res.end(renderErrorPage("OAuth callback failed. Please retry /login."));
-      });
-      return;
-    }
-
-    res.writeHead(404);
-    res.end();
   });
 
   // Bind to loopback when MOM_LINK_URL is unset so the credential UI and OAuth

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,9 @@ import { FileUserBindingStore } from "./bindings.js";
 import { parseLoginCommand } from "./login/index.js";
 import { startLinkServer } from "./login/portal.js";
 import { InMemoryLinkTokenStore } from "./login/session.js";
+import { parseSessionViewCommand } from "./session-view/command.js";
+import { resolveExistingSessionFile } from "./session-view/service.js";
+import { InMemorySessionViewTokenStore } from "./session-view/store.js";
 import { DockerContainerManager } from "./provisioner.js";
 import { loadAgentConfig } from "./config.js";
 import { SandboxError, parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
@@ -262,9 +265,11 @@ const provisioner =
     : undefined;
 
 const linkTokenStore = new InMemoryLinkTokenStore();
+const sessionViewTokenStore = new InMemorySessionViewTokenStore();
 setInterval(() => linkTokenStore.purge(), 5 * 60 * 1000).unref();
+setInterval(() => sessionViewTokenStore.purge(), 5 * 60 * 1000).unref();
 
-function normalizeLoginBaseUrl(): string | undefined {
+function normalizePortalBaseUrl(): string | undefined {
   if (MOM_LINK_URL) {
     return MOM_LINK_URL.replace(/\/+$/, "");
   }
@@ -327,7 +332,7 @@ async function handleLoginCommand(
     return true;
   }
 
-  const baseUrl = normalizeLoginBaseUrl();
+  const baseUrl = normalizePortalBaseUrl();
   if (!baseUrl) {
     await replyWithContext(
       responseCtx,
@@ -362,6 +367,58 @@ async function handleLoginCommand(
   await replyWithContext(
     responseCtx,
     `Open this link to store credentials in ${vaultLabel} (expires in 15 minutes):\n${baseUrl}/link?token=${token.token}`,
+  );
+  return true;
+}
+
+async function handleSessionViewCommand(
+  platform: string,
+  platformUserId: string,
+  conversationId: string,
+  sessionKey: string,
+  responseCtx: BotAdapters["responseCtx"],
+  commandText: string,
+  privateConversation: boolean,
+): Promise<boolean> {
+  if (!parseSessionViewCommand(commandText)) return false;
+
+  if (!privateConversation) {
+    await replyWithContext(
+      responseCtx,
+      "為了保護對話內容，`/session` 目前只能在與機器人的私訊 / DM 中使用。",
+    );
+    return true;
+  }
+
+  const baseUrl = normalizePortalBaseUrl();
+  if (!baseUrl) {
+    await replyWithContext(
+      responseCtx,
+      "Session viewer is not configured. Set `MOM_LINK_URL` or `MOM_LINK_PORT` on the server.",
+    );
+    return true;
+  }
+
+  const sessionFile = resolveExistingSessionFile(workingDir, conversationId, sessionKey);
+  if (!sessionFile) {
+    await replyWithContext(
+      responseCtx,
+      "目前還沒有可查看的 session。先和機器人對話一次，建立 session 後再試。",
+    );
+    return true;
+  }
+
+  const token = sessionViewTokenStore.create(
+    platform as "slack" | "discord" | "telegram",
+    platformUserId,
+    conversationId,
+    sessionKey,
+    sessionFile,
+  );
+
+  await replyWithContext(
+    responseCtx,
+    `Open this read-only session link (expires in 24 hours):\n${baseUrl}/session?token=${token.token}`,
   );
   return true;
 }
@@ -549,15 +606,27 @@ const handler: BotHandler = {
     }
 
     const sessionKey = event.sessionKey ?? `${conversationId}:${event.thread_ts ?? event.ts}`;
+    const privateConversation = isPrivateConversation(event);
     const handledLogin = await handleLoginCommand(
       adapters.platform.name,
       event.user,
       conversationId,
       adapters.responseCtx,
       event.text,
-      isPrivateConversation(event),
+      privateConversation,
     );
     if (handledLogin) return;
+
+    const handledSessionView = await handleSessionViewCommand(
+      adapters.platform.name,
+      event.user,
+      conversationId,
+      sessionKey,
+      adapters.responseCtx,
+      event.text,
+      privateConversation,
+    );
+    if (handledSessionView) return;
 
     const state = await getState(conversationId, sessionKey);
 
@@ -726,6 +795,7 @@ if (MOM_LINK_PORT) {
       const bot = botsByPlatform[platform];
       if (bot) await bot.postMessage(conversationId, message);
     },
+    sessionViewTokenStore,
   );
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,10 @@ import {
 import { addLifecycleBreadcrumb, applyRunScope } from "./sentry.js";
 import { ChannelStore } from "./store.js";
 import { formatNothingRunning, formatStopped, formatStopping } from "./ui-copy.js";
+import {
+  hasMaterializedSlackBranchSession,
+  waitForSlackBranchBootstrap,
+} from "./adapters/slack/branch-manager.js";
 import * as Sentry from "@sentry/node";
 
 // ============================================================================
@@ -627,6 +631,22 @@ const handler: BotHandler = {
       privateConversation,
     );
     if (handledSessionView) return;
+
+    const conversationDir = join(workingDir, conversationId);
+    const waitedForParent =
+      adapters.platform.name === "slack"
+        ? await waitForSlackBranchBootstrap({
+            parentSessionKey: conversationId,
+            sessionKey,
+            hasThreadSession: () => hasMaterializedSlackBranchSession(conversationDir, sessionKey),
+            isParentRunning: () => conversationStates.get(conversationId)?.running === true,
+          })
+        : false;
+    if (waitedForParent) {
+      log.logInfo(
+        `[${conversationId}] Delayed thread bootstrap until parent session sealed: ${sessionKey}`,
+      );
+    }
 
     const state = await getState(conversationId, sessionKey);
 

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -3,6 +3,13 @@ import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync 
 import { join } from "path";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 
+export class ThreadRootNotFoundError extends Error {
+  constructor(sessionFile: string) {
+    super(`Thread root message not found in source session: ${sessionFile}`);
+    this.name = "ThreadRootNotFoundError";
+  }
+}
+
 export interface ThreadRootMessage {
   text?: string;
   userName?: string;
@@ -250,14 +257,19 @@ function buildComparableRootMessageText(rootMessage: ThreadRootMessage): string 
   const userLabel = rootMessage.userName || rootMessage.user || "unknown";
   const text = rootMessage.text?.trim();
   if (!text) return null;
-  return `[${userLabel}]: ${text}`;
+  return normalizeComparableUserText(`[${userLabel}]: ${text}`);
+}
+
+function stripSlackAttachmentBlock(text: string): string {
+  return text.replace(/\n*<slack_attachments>\n[\s\S]*?\n<\/slack_attachments>\s*$/g, "");
 }
 
 function normalizeComparableUserText(text: string): string {
-  return text.replace(
+  const withoutTimestamp = text.replace(
     /^\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}\]\s+(?=\[[^\]]+\](?:\s+\[in-thread:[^\]]+\])?:\s)/,
     "",
   );
+  return stripSlackAttachmentBlock(withoutTimestamp).trim();
 }
 
 function getCurrentSessionPath(sessionDir: string): string | null {
@@ -315,6 +327,46 @@ export function forkThreadSessionFile(
   return targetSessionFile;
 }
 
+export function createThreadSessionFileFromRootMessage(
+  targetSessionFile: string,
+  cwd: string,
+  rootMessage: ThreadRootMessage,
+  parentSession?: string,
+): string {
+  const sessionDir = getFileDir(targetSessionFile);
+  mkdirSync(sessionDir, { recursive: true });
+  rmSync(targetSessionFile, { force: true });
+
+  const header = {
+    type: "session",
+    version: 3,
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    cwd,
+    ...(parentSession ? { parentSession } : {}),
+  };
+  const rootText = buildComparableRootMessageText(rootMessage);
+  if (!rootText) {
+    writeFileSync(targetSessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+    return targetSessionFile;
+  }
+
+  const rootEntry = {
+    type: "message",
+    id: randomUUID().slice(0, 8),
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "user",
+      content: [{ type: "text", text: rootText }],
+      ...(rootMessage.loggedAt !== undefined ? { timestamp: rootMessage.loggedAt } : {}),
+    },
+  };
+  const content = [header, rootEntry].map((entry) => JSON.stringify(entry)).join("\n");
+  writeFileSync(targetSessionFile, `${content}\n`, "utf-8");
+  return targetSessionFile;
+}
+
 export function forkThreadSessionFileFromRootMessage(
   sourceSessionFile: string,
   targetSessionFile: string,
@@ -323,7 +375,7 @@ export function forkThreadSessionFileFromRootMessage(
 ): string {
   const snapshotEntries = resolveThreadSnapshotEntries(sourceSessionFile, rootMessage);
   if (!snapshotEntries) {
-    return forkThreadSessionFile(sourceSessionFile, targetSessionFile, cwd);
+    throw new ThreadRootNotFoundError(sourceSessionFile);
   }
 
   const sessionDir = getFileDir(targetSessionFile);

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -3,6 +3,25 @@ import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync 
 import { join } from "path";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 
+export interface ThreadRootMessage {
+  text?: string;
+  userName?: string;
+  user?: string;
+  loggedAt?: number;
+}
+
+interface SessionMessageEntryLike {
+  type: string;
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  message?: {
+    role?: string;
+    timestamp?: number;
+    content?: Array<{ type?: string; text?: string }> | string;
+  };
+}
+
 /**
  * Returns the shared session directory for a conversation.
  * Channel sessions use a current pointer within this directory.
@@ -167,6 +186,80 @@ function getFileDir(sessionFile: string): string {
   return sessionFile.substring(0, sessionFile.lastIndexOf("/"));
 }
 
+function resolveThreadSnapshotEntries(
+  sourceSessionFile: string,
+  rootMessage: ThreadRootMessage,
+): SessionMessageEntryLike[] | null {
+  const targetText = buildComparableRootMessageText(rootMessage);
+  if (!targetText) return null;
+
+  const entries = SessionManager.open(sourceSessionFile).getEntries() as SessionMessageEntryLike[];
+  const matchIndex = findRootMessageIndex(entries, targetText, rootMessage.loggedAt);
+  if (matchIndex === -1) return null;
+
+  const nextTopLevelUserIndex = entries.findIndex(
+    (entry, index) => index > matchIndex && isUserMessageEntry(entry),
+  );
+  const endIndex = nextTopLevelUserIndex === -1 ? entries.length : nextTopLevelUserIndex;
+  return entries.slice(0, endIndex);
+}
+
+function findRootMessageIndex(
+  entries: SessionMessageEntryLike[],
+  targetText: string,
+  loggedAt?: number,
+): number {
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!isUserMessageEntry(entry)) continue;
+
+    const comparableText = normalizeComparableUserText(getMessageText(entry));
+    if (comparableText !== targetText) continue;
+
+    const messageTimestamp = entry.message?.timestamp;
+    if (
+      loggedAt !== undefined &&
+      typeof messageTimestamp === "number" &&
+      messageTimestamp < loggedAt
+    ) {
+      continue;
+    }
+
+    return i;
+  }
+
+  return -1;
+}
+
+function isUserMessageEntry(entry: SessionMessageEntryLike): boolean {
+  return entry.type === "message" && entry.message?.role === "user";
+}
+
+function getMessageText(entry: SessionMessageEntryLike): string {
+  const content = entry.message?.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  return content
+    .filter((part): part is { type?: string; text?: string } => part.type === "text")
+    .map((part) => part.text ?? "")
+    .join("\n\n");
+}
+
+function buildComparableRootMessageText(rootMessage: ThreadRootMessage): string | null {
+  const userLabel = rootMessage.userName || rootMessage.user || "unknown";
+  const text = rootMessage.text?.trim();
+  if (!text) return null;
+  return `[${userLabel}]: ${text}`;
+}
+
+function normalizeComparableUserText(text: string): string {
+  return text.replace(
+    /^\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}\]\s+(?=\[[^\]]+\](?:\s+\[in-thread:[^\]]+\])?:\s)/,
+    "",
+  );
+}
+
 function getCurrentSessionPath(sessionDir: string): string | null {
   const pointerFile = join(sessionDir, "current");
   if (!existsSync(pointerFile)) return null;
@@ -219,5 +312,33 @@ export function forkThreadSessionFile(
   }
   rmSync(targetSessionFile, { force: true });
   renameSync(forkedFile, targetSessionFile);
+  return targetSessionFile;
+}
+
+export function forkThreadSessionFileFromRootMessage(
+  sourceSessionFile: string,
+  targetSessionFile: string,
+  cwd: string,
+  rootMessage: ThreadRootMessage,
+): string {
+  const snapshotEntries = resolveThreadSnapshotEntries(sourceSessionFile, rootMessage);
+  if (!snapshotEntries) {
+    return forkThreadSessionFile(sourceSessionFile, targetSessionFile, cwd);
+  }
+
+  const sessionDir = getFileDir(targetSessionFile);
+  mkdirSync(sessionDir, { recursive: true });
+  rmSync(targetSessionFile, { force: true });
+
+  const header = {
+    type: "session",
+    version: 3,
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    cwd,
+    parentSession: sourceSessionFile,
+  };
+  const content = [header, ...snapshotEntries].map((entry) => JSON.stringify(entry)).join("\n");
+  writeFileSync(targetSessionFile, `${content}\n`, "utf-8");
   return targetSessionFile;
 }

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -88,6 +88,10 @@ export function openManagedSession(
   sessionDir: string,
   cwd: string,
 ): SessionManager {
+  if (shouldRecreatePreinitializedSession(sessionFile)) {
+    rmSync(sessionFile, { force: true });
+  }
+
   const SessionManagerCtor = SessionManager as unknown as {
     new (cwd: string, sessionDir: string, sessionFile: string, persist: boolean): SessionManager;
   };
@@ -141,6 +145,22 @@ function hasSessionHeader(sessionFile: string): boolean {
     return false;
   }
   return false;
+}
+
+function shouldRecreatePreinitializedSession(sessionFile: string): boolean {
+  if (!existsSync(sessionFile)) return false;
+
+  try {
+    const entries = readFileSync(sessionFile, "utf-8")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { type?: string });
+
+    return entries.length === 1 && entries[0]?.type === "session";
+  } catch {
+    return false;
+  }
 }
 
 function getFileDir(sessionFile: string): string {

--- a/src/session-view/command.ts
+++ b/src/session-view/command.ts
@@ -1,0 +1,15 @@
+export interface ParsedSessionViewCommand {
+  command: "session" | "/session" | "/pi-session";
+}
+
+export function parseSessionViewCommand(text: string): ParsedSessionViewCommand | null {
+  const tokens = text.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+
+  const command = tokens[0].toLowerCase();
+  if (command !== "session" && command !== "/session" && command !== "/pi-session") {
+    return null;
+  }
+
+  return { command: command as ParsedSessionViewCommand["command"] };
+}

--- a/src/session-view/portal.ts
+++ b/src/session-view/portal.ts
@@ -1,6 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "http";
 import * as log from "../log.js";
-import { loadSessionViewModel, type SessionViewItem } from "./service.js";
+import {
+  loadSessionViewModel,
+  resolveRequestedSessionFile,
+  type SessionViewItem,
+  type SessionViewRelation,
+} from "./service.js";
 import type { InMemorySessionViewTokenStore } from "./store.js";
 
 export async function handleSessionViewRequest(
@@ -31,13 +36,21 @@ export async function handleSessionViewRequest(
     return true;
   }
 
+  const requestedSession = url.searchParams.get("session");
+  const targetSessionFile = resolveRequestedSessionFile(entry.sessionFile, requestedSession);
+  if (!targetSessionFile) {
+    res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(renderStatusPage("Session unavailable", "The selected session link is invalid."));
+    return true;
+  }
+
   try {
-    const model = loadSessionViewModel(entry.sessionFile);
+    const model = loadSessionViewModel(targetSessionFile);
     res.writeHead(200, {
       "Content-Type": "text/html; charset=utf-8",
       "Cache-Control": "no-store",
     });
-    res.end(renderSessionPage(model, entry.expiresAt));
+    res.end(renderSessionPage(model, entry.token, entry.expiresAt));
   } catch (error) {
     log.logWarning(
       `[${entry.conversationId}] Failed to render session ${entry.sessionFile}`,
@@ -54,17 +67,28 @@ function renderSessionPage(
   model: {
     title: string;
     sessionId: string;
+    fileName: string;
     createdAt: string;
     updatedAt: string;
     entryCount: number;
     items: SessionViewItem[];
+    parent?: SessionViewRelation;
+    forks: SessionViewRelation[];
   },
+  token: string,
   expiresAt: number,
 ): string {
   const items =
     model.items.length > 0
-      ? model.items.map((item) => renderItem(item)).join("\n")
+      ? model.items.map((item) => renderItem(item, token)).join("\n")
       : `<div class="system-event"><span class="event-dot"></span><span class="event-text">No messages yet — send one to the bot, then refresh.</span></div>`;
+
+  const relatedSections = model.parent
+    ? `<section class="related-card stack">
+        <p class="eyebrow">Forked from</p>
+        ${renderRelationCard(model.parent, token)}
+      </section>`
+    : "";
 
   return renderHtmlDocument(
     `${model.title} · Session Viewer`,
@@ -81,12 +105,15 @@ function renderSessionPage(
       </div>
       <div class="stat-row">
         ${renderSummaryItem("ID", model.sessionId.slice(0, 8))}
+        ${renderSummaryItem("File", model.fileName)}
         ${renderSummaryItem("Created", formatDate(model.createdAt))}
         ${renderSummaryItem("Updated", formatDate(model.updatedAt))}
         ${renderSummaryItem("Entries", String(model.entryCount))}
         ${renderSummaryItem("Expires", formatDate(new Date(expiresAt).toISOString()))}
       </div>
     </header>
+
+    ${relatedSections}
 
     <main class="timeline-shell">
       <div class="timeline-list">
@@ -100,6 +127,32 @@ function renderSummaryItem(label: string, value: string): string {
   return `<span class="stat-chip"><span class="stat-label">${esc(label)}</span><strong class="stat-value">${esc(value)}</strong></span>`;
 }
 
+function renderRelationCard(relation: SessionViewRelation, token: string): string {
+  const href = `/session?token=${encodeURIComponent(token)}&session=${encodeURIComponent(relation.fileName)}`;
+  const summary = relation.summary ? `<p class="related-summary">${esc(relation.summary)}</p>` : "";
+  return `<a class="related-link" href="${href}">
+    <span class="related-copy">
+      <strong class="related-title">${esc(relation.title)}</strong>
+      ${summary}
+      <span class="related-meta">${esc(formatDate(relation.updatedAt))} · ${esc(String(relation.entryCount))} entries · ${esc(relation.fileName)}</span>
+    </span>
+    <span class="related-arrow" aria-hidden="true">→</span>
+  </a>`;
+}
+
+function renderForkLinks(relations: SessionViewRelation[] | undefined, token: string): string {
+  if (!relations || relations.length === 0) return "";
+  return `<div class="fork-links">${relations
+    .map((relation) => {
+      const href = `/session?token=${encodeURIComponent(token)}&session=${encodeURIComponent(relation.fileName)}`;
+      return `<a class="fork-link" href="${href}" title="Open ${esc(relation.title)}">
+        <span class="fork-dot" aria-hidden="true"></span>
+        <span class="fork-text">Thread</span>
+      </a>`;
+    })
+    .join("")}</div>`;
+}
+
 function parseUserBody(raw: string): { username: string | null; content: string } {
   // [timestamp] [username]: content
   let m = raw.match(/^\[[^\]]+\]\s*\[([^\]]+)\]:\s*([\s\S]*)$/);
@@ -110,7 +163,7 @@ function parseUserBody(raw: string): { username: string | null; content: string 
   return { username: null, content: raw };
 }
 
-function renderItem(item: SessionViewItem): string {
+function renderItem(item: SessionViewItem, token?: string): string {
   if (item.kind === "system") {
     const parts = [item.title, item.body].filter((x): x is string => Boolean(x)).map(esc);
     const time = item.meta
@@ -141,9 +194,11 @@ function renderItem(item: SessionViewItem): string {
       : { username: null, content: "" };
     const initial = username ? esc(username.slice(0, 2).toUpperCase()) : "U";
     const body = content ? `<pre class="msg-body">${esc(content)}</pre>` : "";
+    const forks = renderForkLinks(item.forks, token ?? "");
     return `<div class="msg-row msg-user">
   <div class="user-bubble">
     ${body}
+    ${forks}
     ${time}
   </div>
   <div class="msg-avatar user-avatar" title="${username ? esc(username) : "User"}">${initial}</div>
@@ -152,10 +207,12 @@ function renderItem(item: SessionViewItem): string {
 
   // assistant
   const body = item.body ? `<pre class="msg-body">${esc(item.body)}</pre>` : "";
+  const forks = renderForkLinks(item.forks, token ?? "");
   return `<div class="msg-row msg-assistant">
   <div class="msg-avatar asst-avatar" aria-hidden="true">A</div>
   <div class="asst-card">
     ${body}
+    ${forks}
     ${time}
   </div>
 </div>`;
@@ -357,6 +414,115 @@ const styles = `
   }
 
   /* ── Timeline shell ───────────────────────────────────────────────────── */
+
+  .fork-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+  }
+
+  .fork-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(239, 68, 68, 0.18);
+    background: rgba(254, 242, 242, 0.95);
+    color: #b91c1c;
+    text-decoration: none;
+    font-size: 0.74rem;
+    font-weight: 600;
+    line-height: 1;
+    transition: transform 120ms, background 120ms, border-color 120ms;
+  }
+
+  .fork-link:hover {
+    transform: translateY(-1px);
+    background: #fff1f2;
+    border-color: rgba(239, 68, 68, 0.28);
+  }
+
+  .fork-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #ef4444;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.12);
+    flex-shrink: 0;
+  }
+
+  .fork-text {
+    white-space: nowrap;
+  }
+
+  .related-card {
+    padding: 18px 20px;
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    background: rgba(255,255,255,0.78);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.04);
+    backdrop-filter: blur(12px);
+  }
+
+  .related-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .related-link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 14px;
+    border-radius: 14px;
+    border: 1px solid var(--border);
+    background: rgba(255,255,255,0.82);
+    color: inherit;
+    text-decoration: none;
+    transition: transform 120ms, border-color 120ms, box-shadow 120ms, background 120ms;
+  }
+
+  .related-link:hover {
+    transform: translateY(-1px);
+    border-color: rgba(0,0,0,0.16);
+    background: #fff;
+    box-shadow: 0 8px 18px rgba(0,0,0,0.05);
+  }
+
+  .related-copy {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .related-title {
+    color: var(--text);
+    font-size: 0.94rem;
+    line-height: 1.3;
+  }
+
+  .related-summary {
+    color: var(--muted);
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+
+  .related-meta {
+    color: var(--subtle);
+    font-size: 0.74rem;
+    line-height: 1.4;
+  }
+
+  .related-arrow {
+    flex-shrink: 0;
+    color: var(--subtle);
+    font-size: 1rem;
+  }
 
   .timeline-shell {
     padding: 20px 0;

--- a/src/session-view/portal.ts
+++ b/src/session-view/portal.ts
@@ -153,12 +153,12 @@ function renderForkLinks(relations: SessionViewRelation[] | undefined, token: st
     .join("")}</div>`;
 }
 
-function parseUserBody(raw: string): { username: string | null; content: string } {
-  // [timestamp] [username]: content
-  let m = raw.match(/^\[[^\]]+\]\s*\[([^\]]+)\]:\s*([\s\S]*)$/);
+export function parseUserBody(raw: string): { username: string | null; content: string } {
+  // [timestamp] [username] [in-thread:ts]: content
+  let m = raw.match(/^\[[^\]]+\]\s*\[([^\]]+)\](?:\s*\[in-thread:[^\]]+\])?:\s*([\s\S]*)$/);
   if (m) return { username: m[1], content: m[2] };
-  // [username]: content
-  m = raw.match(/^\[([^\]]+)\]:\s*([\s\S]*)$/);
+  // [username] [in-thread:ts]: content
+  m = raw.match(/^\[([^\]]+)\](?:\s*\[in-thread:[^\]]+\])?:\s*([\s\S]*)$/);
   if (m) return { username: m[1], content: m[2] };
   return { username: null, content: raw };
 }

--- a/src/session-view/portal.ts
+++ b/src/session-view/portal.ts
@@ -1,0 +1,628 @@
+import type { IncomingMessage, ServerResponse } from "http";
+import * as log from "../log.js";
+import { loadSessionViewModel, type SessionViewItem } from "./service.js";
+import type { InMemorySessionViewTokenStore } from "./store.js";
+
+export async function handleSessionViewRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+  sessionViewTokenStore?: InMemorySessionViewTokenStore,
+): Promise<boolean> {
+  if (req.method !== "GET" || url.pathname !== "/session") {
+    return false;
+  }
+
+  const token = url.searchParams.get("token")?.trim();
+  if (!token || !sessionViewTokenStore) {
+    res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(
+      renderStatusPage("Session unavailable", "This session link is invalid or has expired."),
+    );
+    return true;
+  }
+
+  const entry = sessionViewTokenStore.peek(token);
+  if (!entry) {
+    res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(
+      renderStatusPage("Session unavailable", "This session link is invalid or has expired."),
+    );
+    return true;
+  }
+
+  try {
+    const model = loadSessionViewModel(entry.sessionFile);
+    res.writeHead(200, {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    });
+    res.end(renderSessionPage(model, entry.expiresAt));
+  } catch (error) {
+    log.logWarning(
+      `[${entry.conversationId}] Failed to render session ${entry.sessionFile}`,
+      error instanceof Error ? error.message : String(error),
+    );
+    res.writeHead(500, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(renderStatusPage("Session unavailable", "The session could not be loaded right now."));
+  }
+
+  return true;
+}
+
+function renderSessionPage(
+  model: {
+    title: string;
+    sessionId: string;
+    createdAt: string;
+    updatedAt: string;
+    entryCount: number;
+    items: SessionViewItem[];
+  },
+  expiresAt: number,
+): string {
+  const items =
+    model.items.length > 0
+      ? model.items.map((item) => renderItem(item)).join("\n")
+      : `<div class="system-event"><span class="event-dot"></span><span class="event-text">No messages yet — send one to the bot, then refresh.</span></div>`;
+
+  return renderHtmlDocument(
+    `${model.title} · Session Viewer`,
+    `<header class="hero-card">
+      <div class="hero-top">
+        <div class="hero-title-group">
+          <span class="hero-wordmark">mama</span>
+          <h1 class="hero-title">${esc(model.title)}</h1>
+        </div>
+        <button class="refresh-btn" onclick="window.location.reload()">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M12.5 2.5A6 6 0 1 0 13 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M10 2.5h2.5V5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          Refresh
+        </button>
+      </div>
+      <div class="stat-row">
+        ${renderSummaryItem("ID", model.sessionId.slice(0, 8))}
+        ${renderSummaryItem("Created", formatDate(model.createdAt))}
+        ${renderSummaryItem("Updated", formatDate(model.updatedAt))}
+        ${renderSummaryItem("Entries", String(model.entryCount))}
+        ${renderSummaryItem("Expires", formatDate(new Date(expiresAt).toISOString()))}
+      </div>
+    </header>
+
+    <main class="timeline-shell">
+      <div class="timeline-list">
+        ${items}
+      </div>
+    </main>`,
+  );
+}
+
+function renderSummaryItem(label: string, value: string): string {
+  return `<span class="stat-chip"><span class="stat-label">${esc(label)}</span><strong class="stat-value">${esc(value)}</strong></span>`;
+}
+
+function parseUserBody(raw: string): { username: string | null; content: string } {
+  // [timestamp] [username]: content
+  let m = raw.match(/^\[[^\]]+\]\s*\[([^\]]+)\]:\s*([\s\S]*)$/);
+  if (m) return { username: m[1], content: m[2] };
+  // [username]: content
+  m = raw.match(/^\[([^\]]+)\]:\s*([\s\S]*)$/);
+  if (m) return { username: m[1], content: m[2] };
+  return { username: null, content: raw };
+}
+
+function renderItem(item: SessionViewItem): string {
+  if (item.kind === "system") {
+    const parts = [item.title, item.body].filter((x): x is string => Boolean(x)).map(esc);
+    const time = item.meta
+      ? ` · <time class="event-time">${esc(formatDate(item.meta))}</time>`
+      : "";
+    return `<div class="system-event"><span class="event-dot"></span><span class="event-text">${parts.join(" — ")}</span>${time}</div>`;
+  }
+
+  if (item.kind === "tool") {
+    const toneClass = item.tone === "err" ? " tone-err" : item.tone === "ok" ? " tone-ok" : "";
+    const body = item.body ? `<pre class="tool-output${toneClass}">${esc(item.body)}</pre>` : "";
+    const time = item.meta ? `<time class="tool-time">${esc(formatDate(item.meta))}</time>` : "";
+    return `<div class="tool-block">
+  <div class="tool-header">
+    <span class="tool-icon"><svg width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M1.5 2L5 5.5 1.5 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M6 9h2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg></span>
+    <span class="tool-name">${esc(item.title)}</span>
+    ${time}
+  </div>
+  ${body}
+</div>`;
+  }
+
+  const time = item.meta ? `<time class="msg-time">${esc(formatDate(item.meta))}</time>` : "";
+
+  if (item.kind === "user") {
+    const { username, content } = item.body
+      ? parseUserBody(item.body)
+      : { username: null, content: "" };
+    const initial = username ? esc(username.slice(0, 2).toUpperCase()) : "U";
+    const body = content ? `<pre class="msg-body">${esc(content)}</pre>` : "";
+    return `<div class="msg-row msg-user">
+  <div class="user-bubble">
+    ${body}
+    ${time}
+  </div>
+  <div class="msg-avatar user-avatar" title="${username ? esc(username) : "User"}">${initial}</div>
+</div>`;
+  }
+
+  // assistant
+  const body = item.body ? `<pre class="msg-body">${esc(item.body)}</pre>` : "";
+  return `<div class="msg-row msg-assistant">
+  <div class="msg-avatar asst-avatar" aria-hidden="true">A</div>
+  <div class="asst-card">
+    ${body}
+    ${time}
+  </div>
+</div>`;
+}
+
+function renderStatusPage(title: string, message: string): string {
+  return renderHtmlDocument(
+    title,
+    `<section class="card stack">
+      <p class="eyebrow">mama</p>
+      <h1>${esc(title)}</h1>
+      <div class="status err">${esc(message)}</div>
+    </section>`,
+  );
+}
+
+function renderHtmlDocument(title: string, shellContent: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${esc(title)}</title>
+  <style>${styles}</style>
+</head>
+<body>
+  <main class="shell">
+    ${shellContent}
+  </main>
+</body>
+</html>`;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function esc(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+const styles = `
+  @import url('https://fonts.googleapis.com/css2?family=Lora:wght@400;600&family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+  :root {
+    --bg: #f0ece3;
+    --surface: #ffffff;
+    --border: rgba(0, 0, 0, 0.08);
+    --text: #18181b;
+    --muted: #71717a;
+    --subtle: #a1a1aa;
+
+    --user-bg: #18181b;
+    --user-text: #fafafa;
+    --user-time: rgba(250, 250, 250, 0.5);
+
+    --asst-border: #22c55e;
+    --asst-avatar-bg: #f0fdf4;
+    --asst-avatar-text: #16a34a;
+
+    --tool-bg: #0d1117;
+    --tool-header: #161b22;
+    --tool-text: #c9d1d9;
+    --tool-accent: #58a6ff;
+    --tool-ok: #3fb950;
+    --tool-err: #f85149;
+    --tool-time: #484f58;
+
+    --ok-bg: #f0fdf4;
+    --ok-text: #15803d;
+    --err-bg: #fef2f2;
+    --err-text: #b91c1c;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    min-height: 100vh;
+    padding: 40px 20px 80px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: var(--bg);
+    background-image:
+      radial-gradient(ellipse 80% 40% at 50% -10%, rgba(255,255,255,0.6) 0%, transparent 70%);
+    color: var(--text);
+    font-family: 'DM Sans', 'Segoe UI', system-ui, sans-serif;
+    font-size: 15px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .shell {
+    width: 100%;
+    max-width: 780px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  /* ── Hero ─────────────────────────────────────────────────────────────── */
+
+  .hero-card {
+    padding: 28px 32px 24px;
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    background: var(--surface);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.06);
+  }
+
+  .hero-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+  }
+
+  .hero-wordmark {
+    display: block;
+    margin-bottom: 6px;
+    color: var(--subtle);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .hero-title {
+    font-family: 'Lora', Georgia, serif;
+    font-size: clamp(1.4rem, 2.5vw, 1.75rem);
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    color: var(--text);
+    text-wrap: balance;
+  }
+
+  .refresh-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font: 500 0.8rem/1 'DM Sans', sans-serif;
+    cursor: pointer;
+    transition: color 120ms, border-color 120ms, background 120ms;
+    white-space: nowrap;
+  }
+
+  .refresh-btn:hover {
+    color: var(--text);
+    border-color: rgba(0,0,0,0.2);
+    background: rgba(0,0,0,0.03);
+  }
+
+  .refresh-btn:focus-visible {
+    outline: 2px solid var(--text);
+    outline-offset: 2px;
+  }
+
+  .stat-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .stat-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: #f4f4f5;
+    font-size: 0.775rem;
+    line-height: 1;
+  }
+
+  .stat-label {
+    color: var(--muted);
+    font-weight: 500;
+  }
+
+  .stat-value {
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  /* ── Timeline shell ───────────────────────────────────────────────────── */
+
+  .timeline-shell {
+    padding: 20px 0;
+  }
+
+  .timeline-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  /* ── Message rows ─────────────────────────────────────────────────────── */
+
+  .msg-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    padding: 2px 0;
+  }
+
+  /* ── User messages ────────────────────────────────────────────────────── */
+
+  .msg-user {
+    justify-content: flex-end;
+  }
+
+  .user-bubble {
+    max-width: 85%;
+    padding: 12px 16px;
+    border-radius: 18px 18px 4px 18px;
+    background: var(--user-bg);
+    color: var(--user-text);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.12);
+  }
+
+  .msg-user .msg-body {
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--user-text);
+  }
+
+  .msg-user .msg-time {
+    display: block;
+    margin-top: 6px;
+    font-size: 0.72rem;
+    color: var(--user-time);
+    text-align: right;
+  }
+
+  /* ── Avatars ──────────────────────────────────────────────────────────── */
+
+  .msg-avatar {
+    flex: 0 0 28px;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    font-size: 0.68rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    letter-spacing: 0;
+    flex-shrink: 0;
+  }
+
+  .user-avatar {
+    background: #eff6ff;
+    border: 1.5px solid #93c5fd;
+    color: #1d4ed8;
+  }
+
+  .asst-avatar {
+    background: var(--asst-avatar-bg);
+    border: 1.5px solid var(--asst-border);
+    color: var(--asst-avatar-text);
+    margin-bottom: 2px;
+  }
+
+  /* ── Assistant messages ───────────────────────────────────────────────── */
+
+  .msg-assistant {
+    align-items: flex-end;
+    gap: 8px;
+    max-width: 85%;
+  }
+
+  .asst-card {
+    min-width: 0;
+    padding: 14px 18px;
+    border: 1px solid var(--border);
+    border-radius: 18px 18px 18px 4px;
+    background: var(--surface);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  }
+
+  .msg-assistant .msg-body {
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 0.9rem;
+    line-height: 1.65;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--text);
+  }
+
+  .msg-assistant .msg-time {
+    display: block;
+    margin-top: 8px;
+    font-size: 0.72rem;
+    color: var(--subtle);
+  }
+
+  /* ── Tool blocks ──────────────────────────────────────────────────────── */
+
+  .tool-block {
+    max-width: 92%;
+    margin-left: 36px;
+    border-radius: 10px;
+    overflow: hidden;
+    border: 1px solid rgba(255,255,255,0.06);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.16);
+    margin: 6px 0;
+  }
+
+  .tool-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    background: var(--tool-header);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    overflow: hidden;
+  }
+
+  .tool-icon {
+    color: var(--tool-accent);
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .tool-name {
+    flex: 1;
+    font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--tool-accent);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .tool-time {
+    flex-shrink: 0;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.7rem;
+    color: var(--tool-time);
+  }
+
+  .tool-output {
+    display: block;
+    padding: 12px 14px;
+    background: var(--tool-bg);
+    color: var(--tool-text);
+    font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+    font-size: 0.78rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+
+  .tool-output.tone-ok { color: var(--tool-ok); }
+  .tool-output.tone-err { color: var(--tool-err); }
+
+  /* ── System events ────────────────────────────────────────────────────── */
+
+  .system-event {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px 0;
+    color: var(--subtle);
+    font-size: 0.775rem;
+  }
+
+  .event-dot {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--subtle);
+    flex-shrink: 0;
+    opacity: 0.6;
+  }
+
+  .event-text {
+    color: var(--muted);
+  }
+
+  .event-time {
+    color: var(--subtle);
+    font-style: normal;
+  }
+
+  /* ── Status page ──────────────────────────────────────────────────────── */
+
+  .card {
+    padding: 28px 32px;
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    background: var(--surface);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.06);
+  }
+
+  .stack > * + * { margin-top: 14px; }
+
+  .eyebrow {
+    color: var(--subtle);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    font-family: 'Lora', Georgia, serif;
+    font-size: clamp(1.4rem, 2.5vw, 1.75rem);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+  }
+
+  p { color: var(--muted); font-size: 0.9rem; line-height: 1.5; }
+
+  .status {
+    padding: 12px 16px;
+    border-radius: 10px;
+    font-size: 0.9rem;
+  }
+
+  .status.err {
+    background: var(--err-bg);
+    color: var(--err-text);
+    border: 1px solid rgba(185, 28, 28, 0.12);
+  }
+
+  /* ── Responsive ───────────────────────────────────────────────────────── */
+
+  @media (max-width: 600px) {
+    body { padding: 20px 12px 60px; }
+
+    .hero-card, .card { padding: 20px; border-radius: 16px; }
+
+    .hero-top { flex-direction: column; gap: 12px; }
+
+    .refresh-btn { align-self: flex-start; }
+
+    .user-bubble { max-width: 88%; }
+
+    .asst-avatar { display: none; }
+
+    .asst-card { border-radius: 4px 14px 14px 14px; }
+  }
+`;

--- a/src/session-view/service.ts
+++ b/src/session-view/service.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from "path";
+import { basename, dirname, join, resolve } from "path";
 import { existsSync, readdirSync } from "fs";
 import {
   SessionManager,
@@ -19,15 +19,31 @@ export interface SessionViewItem {
   body?: string;
   meta?: string;
   tone?: "default" | "ok" | "err" | "muted";
+  entryId?: string;
+  forks?: SessionViewRelation[];
+}
+
+export interface SessionViewRelation {
+  kind: "parent" | "fork";
+  fileName: string;
+  sessionId: string;
+  title: string;
+  updatedAt: string;
+  entryCount: number;
+  summary?: string;
+  anchorEntryId?: string;
 }
 
 export interface SessionViewModel {
   sessionId: string;
+  fileName: string;
   title: string;
   createdAt: string;
   updatedAt: string;
   entryCount: number;
   items: SessionViewItem[];
+  parent?: SessionViewRelation;
+  forks: SessionViewRelation[];
 }
 
 export function resolveExistingSessionFile(
@@ -43,81 +59,159 @@ export function resolveExistingSessionFile(
 }
 
 export function loadSessionViewModel(sessionFile: string): SessionViewModel {
-  const sessionFiles = resolveSessionFiles(sessionFile);
-  const allItems: SessionViewItem[] = [];
-  let createdAt = "";
-  let updatedAt = "";
-  let totalEntries = 0;
-  let sessionId = "";
-  let title = "";
+  const resolvedFile = resolve(sessionFile);
+  const sm = SessionManager.open(resolvedFile);
+  const header = sm.getHeader();
+  if (!header) throw new Error(`No valid session found: ${sessionFile}`);
 
-  for (let i = 0; i < sessionFiles.length; i++) {
-    const file = sessionFiles[i];
-    const sm = SessionManager.open(file);
-    const header = sm.getHeader();
-    if (!header) continue;
+  const entries = sm.getEntries();
+  const updatedAt = entries.at(-1)?.timestamp ?? header.timestamp;
+  const title = sm.getSessionName() || `Session ${header.id.slice(0, 8)}`;
 
-    const entries = sm.getEntries();
-    totalEntries += entries.length;
+  const parent = header.parentSession
+    ? buildSessionRelation(resolve(header.parentSession), "parent")
+    : undefined;
+  const forks = listRelatedSessionFiles(resolvedFile)
+    .filter((candidate) => candidate !== resolvedFile)
+    .map((candidate) => buildSessionRelation(candidate, "fork", resolvedFile))
+    .filter((relation): relation is SessionViewRelation => relation !== null)
+    .sort((a, b) => (a.updatedAt < b.updatedAt ? -1 : a.updatedAt > b.updatedAt ? 1 : 0));
 
-    if (!createdAt || header.timestamp < createdAt) createdAt = header.timestamp;
-    const lastTs = entries.at(-1)?.timestamp ?? header.timestamp;
-    if (!updatedAt || lastTs > updatedAt) updatedAt = lastTs;
-
-    sessionId = header.id;
-    const sessionName = sm.getSessionName() || `Session ${header.id.slice(0, 8)}`;
-    title = sessionName;
-
-    if (sessionFiles.length > 1) {
-      allItems.push({
-        kind: "system",
-        title: i === 0 ? `Session started — ${sessionName}` : `New session — ${sessionName}`,
-        meta: header.timestamp,
-        tone: "muted",
-      });
-    }
-
-    for (const entry of entries) {
-      const item = mapEntryToItem(entry);
-      if (item) allItems.push(item);
-    }
+  const forksByEntryId = new Map<string, SessionViewRelation[]>();
+  for (const fork of forks) {
+    if (!fork.anchorEntryId) continue;
+    const bucket = forksByEntryId.get(fork.anchorEntryId) ?? [];
+    bucket.push(fork);
+    forksByEntryId.set(fork.anchorEntryId, bucket);
   }
 
-  if (!createdAt) throw new Error(`No valid sessions found near: ${sessionFile}`);
+  const items = entries.flatMap((entry) => {
+    const item = mapEntryToItem(entry);
+    if (!item) return [];
+    if (item.entryId) {
+      const anchoredForks = forksByEntryId.get(item.entryId);
+      if (anchoredForks) {
+        item.forks = anchoredForks;
+      }
+    }
+    return [item];
+  });
 
   return {
-    sessionId,
+    sessionId: header.id,
+    fileName: basename(resolvedFile),
     title,
-    createdAt,
+    createdAt: header.timestamp,
     updatedAt,
-    entryCount: totalEntries,
-    items: allItems,
+    entryCount: entries.length,
+    items,
+    parent: parent ?? undefined,
+    forks,
   };
 }
 
-function resolveSessionFiles(sessionFile: string): string[] {
+export function resolveRequestedSessionFile(
+  baseSessionFile: string,
+  requestedFileName?: string | null,
+): string | null {
+  const resolvedBase = resolve(baseSessionFile);
+  if (!requestedFileName) return resolvedBase;
+
+  const trimmed = requestedFileName.trim();
+  if (!trimmed) return resolvedBase;
+
+  const fileName = basename(trimmed);
+  if (fileName !== trimmed || !fileName.endsWith(".jsonl")) return null;
+
+  const candidate = join(dirname(resolvedBase), fileName);
+  if (!existsSync(candidate)) return null;
+
+  try {
+    return SessionManager.open(candidate).getHeader() ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+function listRelatedSessionFiles(sessionFile: string): string[] {
   const dir = dirname(sessionFile);
-  if (!existsSync(dir)) return [sessionFile];
+  if (!existsSync(dir)) return [];
 
-  const files = readdirSync(dir)
+  return readdirSync(dir)
     .filter((name) => name.endsWith(".jsonl"))
-    .map((f) => join(dir, f));
+    .map((fileName) => join(dir, fileName));
+}
 
-  if (files.length === 0) return [sessionFile];
-
-  // Sort by session header timestamp so channel + thread sessions appear chronologically
-  const withTimestamp = files.flatMap((f) => {
-    try {
-      const sm = SessionManager.open(f);
-      const header = sm.getHeader();
-      return header ? [{ f, ts: header.timestamp }] : [];
-    } catch {
-      return [];
+function buildSessionRelation(
+  sessionFile: string,
+  kind: "parent" | "fork",
+  expectedParent?: string,
+): SessionViewRelation | null {
+  try {
+    const sm = SessionManager.open(sessionFile);
+    const header = sm.getHeader();
+    if (!header) return null;
+    if (kind === "fork" && resolve(header.parentSession ?? "") !== expectedParent) {
+      return null;
     }
-  });
 
-  withTimestamp.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
-  return withTimestamp.length > 0 ? withTimestamp.map((x) => x.f) : [sessionFile];
+    const entries = sm.getEntries();
+    const updatedAt = entries.at(-1)?.timestamp ?? header.timestamp;
+    const anchorEntryId =
+      kind === "fork" && expectedParent
+        ? findForkAnchorEntryId(SessionManager.open(expectedParent).getEntries(), entries)
+        : undefined;
+    return {
+      kind,
+      fileName: basename(sessionFile),
+      sessionId: header.id,
+      title: sm.getSessionName() || `Session ${header.id.slice(0, 8)}`,
+      updatedAt,
+      entryCount: entries.length,
+      summary: extractSessionSummary(entries),
+      anchorEntryId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function findForkAnchorEntryId(
+  parentEntries: SessionEntry[],
+  childEntries: SessionEntry[],
+): string | undefined {
+  let sharedCount = 0;
+  while (
+    sharedCount < parentEntries.length &&
+    sharedCount < childEntries.length &&
+    parentEntries[sharedCount]?.id === childEntries[sharedCount]?.id
+  ) {
+    sharedCount += 1;
+  }
+
+  for (let i = sharedCount - 1; i >= 0; i--) {
+    const entry = parentEntries[i];
+    if (entry?.type === "message" && entry.message.role === "user") {
+      return entry.id;
+    }
+  }
+
+  return sharedCount > 0 ? parentEntries[sharedCount - 1]?.id : undefined;
+}
+
+function extractSessionSummary(entries: SessionEntry[]): string | undefined {
+  for (const entry of entries) {
+    if (entry.type !== "message") continue;
+    const item = mapEntryToItem(entry);
+    if (!item?.body) continue;
+    return collapseSummary(item.body);
+  }
+  return undefined;
+}
+
+function collapseSummary(text: string): string {
+  const singleLine = text.replace(/\s+/g, " ").trim();
+  return singleLine.length > 96 ? `${singleLine.slice(0, 93)}…` : singleLine;
 }
 
 function mapEntryToItem(entry: SessionEntry): SessionViewItem | null {
@@ -205,6 +299,7 @@ function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
         title: "User",
         body: contentToText(message.content),
         meta: entry.timestamp,
+        entryId: entry.id,
       };
     case "assistant": {
       const assistantBody = assistantContentToText(message.content);
@@ -215,6 +310,7 @@ function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
         body: assistantBody,
         meta:
           metaParts.length > 0 ? `${entry.timestamp} · ${metaParts.join(" · ")}` : entry.timestamp,
+        entryId: entry.id,
       };
     }
     case "toolResult":
@@ -224,6 +320,7 @@ function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
         body: contentToText(message.content),
         meta: entry.timestamp,
         tone: message.isError ? "err" : "ok",
+        entryId: entry.id,
       };
     case "bashExecution": {
       const command = String(message.command ?? "").trim();
@@ -234,6 +331,7 @@ function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
         title: "Bash execution",
         body: body || "(no output)",
         meta: entry.timestamp,
+        entryId: entry.id,
       };
     }
     case "custom":
@@ -243,6 +341,7 @@ function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
         body: contentToText(message.content),
         meta: entry.timestamp,
         tone: "muted",
+        entryId: entry.id,
       };
     case "branchSummary":
       return {
@@ -251,6 +350,7 @@ function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
         body: String(message.summary ?? ""),
         meta: entry.timestamp,
         tone: "muted",
+        entryId: entry.id,
       };
     case "compactionSummary":
       return {
@@ -259,6 +359,7 @@ function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
         body: String(message.summary ?? ""),
         meta: entry.timestamp,
         tone: "muted",
+        entryId: entry.id,
       };
     default:
       return {
@@ -267,6 +368,7 @@ function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
         body: contentToText(message.content),
         meta: entry.timestamp,
         tone: "muted",
+        entryId: entry.id,
       };
   }
 }

--- a/src/session-view/service.ts
+++ b/src/session-view/service.ts
@@ -1,0 +1,365 @@
+import { dirname, join } from "path";
+import { existsSync, readdirSync } from "fs";
+import {
+  SessionManager,
+  type BranchSummaryEntry,
+  type CompactionEntry,
+  type SessionEntry,
+  type SessionMessageEntry,
+} from "@mariozechner/pi-coding-agent";
+import {
+  getThreadSessionFile,
+  resolveChannelSessionFile,
+  tryResolveThreadSession,
+} from "../session-store.js";
+
+export interface SessionViewItem {
+  kind: "user" | "assistant" | "tool" | "system";
+  title: string;
+  body?: string;
+  meta?: string;
+  tone?: "default" | "ok" | "err" | "muted";
+}
+
+export interface SessionViewModel {
+  sessionId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  entryCount: number;
+  items: SessionViewItem[];
+}
+
+export function resolveExistingSessionFile(
+  workingDir: string,
+  conversationId: string,
+  sessionKey: string,
+): string | null {
+  const conversationDir = join(workingDir, conversationId);
+  if (sessionKey.includes(":")) {
+    return tryResolveThreadSession(getThreadSessionFile(conversationDir, sessionKey));
+  }
+  return resolveChannelSessionFile(conversationDir);
+}
+
+export function loadSessionViewModel(sessionFile: string): SessionViewModel {
+  const sessionFiles = resolveSessionFiles(sessionFile);
+  const allItems: SessionViewItem[] = [];
+  let createdAt = "";
+  let updatedAt = "";
+  let totalEntries = 0;
+  let sessionId = "";
+  let title = "";
+
+  for (let i = 0; i < sessionFiles.length; i++) {
+    const file = sessionFiles[i];
+    const sm = SessionManager.open(file);
+    const header = sm.getHeader();
+    if (!header) continue;
+
+    const entries = sm.getEntries();
+    totalEntries += entries.length;
+
+    if (!createdAt || header.timestamp < createdAt) createdAt = header.timestamp;
+    const lastTs = entries.at(-1)?.timestamp ?? header.timestamp;
+    if (!updatedAt || lastTs > updatedAt) updatedAt = lastTs;
+
+    sessionId = header.id;
+    const sessionName = sm.getSessionName() || `Session ${header.id.slice(0, 8)}`;
+    title = sessionName;
+
+    if (sessionFiles.length > 1) {
+      allItems.push({
+        kind: "system",
+        title: i === 0 ? `Session started — ${sessionName}` : `New session — ${sessionName}`,
+        meta: header.timestamp,
+        tone: "muted",
+      });
+    }
+
+    for (const entry of entries) {
+      const item = mapEntryToItem(entry);
+      if (item) allItems.push(item);
+    }
+  }
+
+  if (!createdAt) throw new Error(`No valid sessions found near: ${sessionFile}`);
+
+  return {
+    sessionId,
+    title,
+    createdAt,
+    updatedAt,
+    entryCount: totalEntries,
+    items: allItems,
+  };
+}
+
+function resolveSessionFiles(sessionFile: string): string[] {
+  const dir = dirname(sessionFile);
+  if (!existsSync(dir)) return [sessionFile];
+
+  const files = readdirSync(dir)
+    .filter((name) => name.endsWith(".jsonl"))
+    .map((f) => join(dir, f));
+
+  if (files.length === 0) return [sessionFile];
+
+  // Sort by session header timestamp so channel + thread sessions appear chronologically
+  const withTimestamp = files.flatMap((f) => {
+    try {
+      const sm = SessionManager.open(f);
+      const header = sm.getHeader();
+      return header ? [{ f, ts: header.timestamp }] : [];
+    } catch {
+      return [];
+    }
+  });
+
+  withTimestamp.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  return withTimestamp.length > 0 ? withTimestamp.map((x) => x.f) : [sessionFile];
+}
+
+function mapEntryToItem(entry: SessionEntry): SessionViewItem | null {
+  switch (entry.type) {
+    case "message":
+      return mapMessageEntry(entry);
+    case "model_change":
+      return {
+        kind: "system",
+        title: "Model changed",
+        body: `${entry.provider} / ${entry.modelId}`,
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+    case "thinking_level_change":
+      return {
+        kind: "system",
+        title: "Thinking level changed",
+        body: entry.thinkingLevel,
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+    case "compaction":
+      return mapCompactionEntry(entry);
+    case "branch_summary":
+      return mapBranchSummaryEntry(entry);
+    case "custom_message":
+      return {
+        kind: "system",
+        title: `Custom message · ${entry.customType}`,
+        body: contentToText(entry.content),
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+    case "custom":
+      return {
+        kind: "system",
+        title: `Custom data · ${entry.customType}`,
+        body: entry.data === undefined ? "(no data)" : JSON.stringify(entry.data, null, 2),
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+    case "label":
+      return {
+        kind: "system",
+        title: "Label updated",
+        body: entry.label || "(cleared)",
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+    case "session_info":
+      return entry.name
+        ? {
+            kind: "system",
+            title: "Session renamed",
+            body: entry.name,
+            meta: entry.timestamp,
+            tone: "muted",
+          }
+        : null;
+    default:
+      return null;
+  }
+}
+
+function mapMessageEntry(entry: SessionMessageEntry): SessionViewItem {
+  const message = entry.message as unknown as Record<string, unknown> & {
+    role?: string;
+    content?: unknown;
+    provider?: string;
+    model?: string;
+    toolName?: string;
+    isError?: boolean;
+    command?: string;
+    output?: string;
+    stopReason?: string;
+    customType?: string;
+    summary?: string;
+  };
+
+  switch (message.role) {
+    case "user":
+      return {
+        kind: "user",
+        title: "User",
+        body: contentToText(message.content),
+        meta: entry.timestamp,
+      };
+    case "assistant": {
+      const assistantBody = assistantContentToText(message.content);
+      const metaParts = [message.provider, message.model, message.stopReason].filter(Boolean);
+      return {
+        kind: "assistant",
+        title: "Assistant",
+        body: assistantBody,
+        meta:
+          metaParts.length > 0 ? `${entry.timestamp} · ${metaParts.join(" · ")}` : entry.timestamp,
+      };
+    }
+    case "toolResult":
+      return {
+        kind: "tool",
+        title: `Tool result · ${String(message.toolName ?? "unknown")}`,
+        body: contentToText(message.content),
+        meta: entry.timestamp,
+        tone: message.isError ? "err" : "ok",
+      };
+    case "bashExecution": {
+      const command = String(message.command ?? "").trim();
+      const output = String(message.output ?? "").trim();
+      const body = [command ? `$ ${command}` : "", output].filter(Boolean).join("\n\n");
+      return {
+        kind: "tool",
+        title: "Bash execution",
+        body: body || "(no output)",
+        meta: entry.timestamp,
+      };
+    }
+    case "custom":
+      return {
+        kind: "system",
+        title: `Custom message · ${String(message.customType ?? "custom")}`,
+        body: contentToText(message.content),
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+    case "branchSummary":
+      return {
+        kind: "system",
+        title: "Branch summary",
+        body: String(message.summary ?? ""),
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+    case "compactionSummary":
+      return {
+        kind: "system",
+        title: "Compaction summary",
+        body: String(message.summary ?? ""),
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+    default:
+      return {
+        kind: "system",
+        title: `Message · ${String(message.role ?? "unknown")}`,
+        body: contentToText(message.content),
+        meta: entry.timestamp,
+        tone: "muted",
+      };
+  }
+}
+
+function mapCompactionEntry(entry: CompactionEntry): SessionViewItem {
+  return {
+    kind: "system",
+    title: "Context compacted",
+    body: entry.summary,
+    meta: `${entry.timestamp} · ${entry.tokensBefore} tokens before compaction`,
+    tone: "muted",
+  };
+}
+
+function mapBranchSummaryEntry(entry: BranchSummaryEntry): SessionViewItem {
+  return {
+    kind: "system",
+    title: "Branch summary",
+    body: entry.summary,
+    meta: entry.timestamp,
+    tone: "muted",
+  };
+}
+
+function assistantContentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  const textBlocks: string[] = [];
+  const thinkingBlocks: string[] = [];
+  const toolCalls: string[] = [];
+  const otherBlocks: string[] = [];
+
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const value = block as Record<string, unknown>;
+    if (value.type === "text" && typeof value.text === "string") {
+      textBlocks.push(value.text);
+      continue;
+    }
+    if (value.type === "thinking" && typeof value.thinking === "string") {
+      thinkingBlocks.push(value.thinking);
+      continue;
+    }
+    if (value.type === "toolCall") {
+      const name = typeof value.name === "string" ? value.name : "tool";
+      const args = value.arguments === undefined ? "" : JSON.stringify(value.arguments, null, 2);
+      toolCalls.push([name, args].filter(Boolean).join("\n"));
+      continue;
+    }
+    if (value.type === "image") {
+      otherBlocks.push(`[image ${String(value.mimeType ?? "unknown")}]`);
+    }
+  }
+
+  const sections = [
+    textBlocks.join("\n\n").trim(),
+    thinkingBlocks.length > 0
+      ? [`[thinking]`, thinkingBlocks.join("\n\n")].filter(Boolean).join("\n")
+      : "",
+    toolCalls.length > 0 ? [`[tool calls]`, toolCalls.join("\n\n")].filter(Boolean).join("\n") : "",
+    otherBlocks.join("\n"),
+  ].filter(Boolean);
+
+  return sections.join("\n\n");
+}
+
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  const lines: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const value = block as Record<string, unknown>;
+    if (value.type === "text" && typeof value.text === "string") {
+      lines.push(value.text);
+      continue;
+    }
+    if (value.type === "thinking" && typeof value.thinking === "string") {
+      lines.push(`[thinking]\n${value.thinking}`);
+      continue;
+    }
+    if (value.type === "toolCall") {
+      const name = typeof value.name === "string" ? value.name : "tool";
+      const args = value.arguments === undefined ? "" : JSON.stringify(value.arguments, null, 2);
+      lines.push([`[toolCall] ${name}`, args].filter(Boolean).join("\n"));
+      continue;
+    }
+    if (value.type === "image") {
+      lines.push(`[image ${String(value.mimeType ?? "unknown")}]`);
+    }
+  }
+
+  return lines.join("\n\n");
+}

--- a/src/session-view/store.ts
+++ b/src/session-view/store.ts
@@ -1,0 +1,55 @@
+import { randomBytes } from "crypto";
+
+export interface SessionViewToken {
+  token: string;
+  platform: "slack" | "discord" | "telegram";
+  platformUserId: string;
+  conversationId: string;
+  sessionKey: string;
+  sessionFile: string;
+  expiresAt: number;
+}
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+export class InMemorySessionViewTokenStore {
+  private tokens = new Map<string, SessionViewToken>();
+
+  create(
+    platform: "slack" | "discord" | "telegram",
+    platformUserId: string,
+    conversationId: string,
+    sessionKey: string,
+    sessionFile: string,
+  ): SessionViewToken {
+    const token: SessionViewToken = {
+      token: randomBytes(16).toString("hex"),
+      platform,
+      platformUserId,
+      conversationId,
+      sessionKey,
+      sessionFile,
+      expiresAt: Date.now() + TTL_MS,
+    };
+    this.tokens.set(token.token, token);
+    return token;
+  }
+
+  peek(rawToken: string): SessionViewToken | undefined {
+    const entry = this.tokens.get(rawToken);
+    if (!entry || Date.now() > entry.expiresAt) {
+      if (entry) this.tokens.delete(rawToken);
+      return undefined;
+    }
+    return entry;
+  }
+
+  purge(): void {
+    const now = Date.now();
+    for (const [key, value] of this.tokens) {
+      if (now > value.expiresAt) {
+        this.tokens.delete(key);
+      }
+    }
+  }
+}

--- a/src/tools/event.ts
+++ b/src/tools/event.ts
@@ -1,7 +1,8 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
+import * as log from "../log.js";
 
 const eventSchema = Type.Object({
   label: Type.String({
@@ -69,8 +70,6 @@ type EventPayload =
       userId: string;
       text: string;
       at: string;
-      sessionKey?: string;
-      threadTs?: string;
     }
   | {
       type: "periodic";
@@ -82,7 +81,6 @@ type EventPayload =
       schedule: string;
       timezone: string;
       sessionKey?: string;
-      threadTs?: string;
     };
 
 export function createEventTool(workspaceDir: string): {
@@ -113,7 +111,21 @@ export function createEventTool(workspaceDir: string): {
       const prefix = sanitizeFileSegment(params.filenamePrefix || payload.type || "event");
       const filename = `${prefix}-${Date.now()}.json`;
       const filePath = join(eventsDir, filename);
-      await writeFile(filePath, JSON.stringify(payload) + "\n", "utf-8");
+      const content = JSON.stringify(payload) + "\n";
+
+      log.logInfo(
+        `Writing event file: ${filePath} (type=${payload.type}, platform=${payload.platform}, conversation=${payload.conversationId})`,
+      );
+      await writeFile(filePath, content, "utf-8");
+
+      try {
+        const fileStat = await stat(filePath);
+        log.logInfo(
+          `Wrote event file: ${filePath} (${fileStat.size} bytes, mtime=${fileStat.mtime.toISOString()})`,
+        );
+      } catch (err) {
+        log.logWarning(`Event file missing immediately after write: ${filePath}`, String(err));
+      }
 
       return {
         content: [
@@ -147,18 +159,22 @@ function buildEventPayload(params: EventToolParams, context: EventToolContext): 
     conversationKind: context.conversationKind,
     userId: context.userId,
     text: params.text,
-    sessionKey: context.sessionKey,
-    ...(context.threadTs ? { threadTs: context.threadTs } : {}),
   };
 
   if (params.type === "immediate") {
-    return { ...base, type: "immediate" };
+    return {
+      ...base,
+      type: "immediate",
+      sessionKey: context.sessionKey,
+      ...(context.threadTs ? { threadTs: context.threadTs } : {}),
+    };
   }
 
   if (params.type === "one-shot") {
     if (!params.at) {
       throw new Error("`at` is required for one-shot events");
     }
+    // No sessionKey or threadTs: reminders should fire as top-level messages, not buried in old threads
     return { ...base, type: "one-shot", at: params.at };
   }
 
@@ -168,11 +184,13 @@ function buildEventPayload(params: EventToolParams, context: EventToolContext): 
   if (!params.timezone) {
     throw new Error("`timezone` is required for periodic events");
   }
+  // No threadTs: periodic events should always be top-level; keep sessionKey for task context
   return {
     ...base,
     type: "periodic",
     schedule: params.schedule,
     timezone: params.timezone,
+    sessionKey: context.sessionKey,
   };
 }
 

--- a/src/tools/event.ts
+++ b/src/tools/event.ts
@@ -36,6 +36,8 @@ interface EventToolContext {
   conversationId: string;
   conversationKind: "direct" | "shared";
   userId: string;
+  sessionKey: string;
+  threadTs?: string;
 }
 
 type EventToolParams = {
@@ -56,6 +58,8 @@ type EventPayload =
       conversationKind: "direct" | "shared";
       userId: string;
       text: string;
+      sessionKey?: string;
+      threadTs?: string;
     }
   | {
       type: "one-shot";
@@ -65,6 +69,8 @@ type EventPayload =
       userId: string;
       text: string;
       at: string;
+      sessionKey?: string;
+      threadTs?: string;
     }
   | {
       type: "periodic";
@@ -75,6 +81,8 @@ type EventPayload =
       text: string;
       schedule: string;
       timezone: string;
+      sessionKey?: string;
+      threadTs?: string;
     };
 
 export function createEventTool(workspaceDir: string): {
@@ -139,6 +147,8 @@ function buildEventPayload(params: EventToolParams, context: EventToolContext): 
     conversationKind: context.conversationKind,
     userId: context.userId,
     text: params.text,
+    sessionKey: context.sessionKey,
+    ...(context.threadTs ? { threadTs: context.threadTs } : {}),
   };
 
   if (params.type === "immediate") {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,8 @@ export function createMamaTools(
     conversationId: string;
     conversationKind: "direct" | "shared";
     userId: string;
+    sessionKey: string;
+    threadTs?: string;
   }) => void;
 } {
   const { tool: attachTool, setUploadFunction } = createAttachTool();

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -151,6 +151,86 @@ describe("syncLogToSessionManager", () => {
     ]);
   });
 
+  test("does not look ahead to newer queued messages", async () => {
+    writeLog([
+      {
+        date: "2026-04-01T10:00:00.000Z",
+        ts: "1000.0010",
+        user: "U001",
+        userName: "alice",
+        text: "first",
+        isBot: false,
+      },
+      {
+        date: "2026-04-01T10:00:05.000Z",
+        ts: "1000.0020",
+        user: "U001",
+        userName: "alice",
+        text: "second",
+        isBot: false,
+      },
+      {
+        date: "2026-04-01T10:00:10.000Z",
+        ts: "1000.0030",
+        user: "U001",
+        userName: "alice",
+        text: "third",
+        isBot: false,
+      },
+    ]);
+
+    const sessionManager = SessionManager.inMemory(testDir);
+    sessionManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "[2026-04-01 18:00:00+08:00] [alice]: first" }],
+      timestamp: new Date("2026-04-01T10:00:00.500Z").getTime(),
+    });
+
+    const synced = await syncLogToSessionManager(
+      sessionManager,
+      testDir,
+      "1000.0020",
+      { start: 0, end: Number.MAX_SAFE_INTEGER },
+      { scope: "top-level", rootTs: "C001" },
+    );
+
+    expect(synced).toBe(0);
+    expect(getMessageTexts(sessionManager)).toEqual(["[2026-04-01 18:00:00+08:00] [alice]: first"]);
+  });
+
+  test("does not re-import a live prompt that was already added to the session", async () => {
+    writeLog([
+      {
+        date: "2026-04-01T10:00:00.000Z",
+        ts: "1000.0010",
+        user: "U001",
+        userName: "alice",
+        text: "hello from slack",
+        isBot: false,
+      },
+    ]);
+
+    const sessionManager = SessionManager.inMemory(testDir);
+    sessionManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "[2026-04-01 18:01:10+08:00] [alice]: hello from slack" }],
+      timestamp: new Date("2026-04-01T10:01:10.000Z").getTime(),
+    });
+
+    const synced = await syncLogToSessionManager(
+      sessionManager,
+      testDir,
+      undefined,
+      { start: 0, end: Number.MAX_SAFE_INTEGER },
+      { scope: "top-level", rootTs: "C001" },
+    );
+
+    expect(synced).toBe(0);
+    expect(getMessageTexts(sessionManager)).toEqual([
+      "[2026-04-01 18:01:10+08:00] [alice]: hello from slack",
+    ]);
+  });
+
   test("thread scope only syncs the matching root message and thread replies", async () => {
     writeLog([
       {

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -89,6 +89,68 @@ describe("syncLogToSessionManager", () => {
     ]);
   });
 
+  test("does not duplicate messages when sync runs again after new activity", async () => {
+    writeLog([
+      {
+        date: "2026-04-01T10:00:00.000Z",
+        ts: "1000.0010",
+        user: "U001",
+        userName: "alice",
+        text: "first top-level message",
+        isBot: false,
+      },
+      {
+        date: "2026-04-01T10:02:00.000Z",
+        ts: "1000.0030",
+        user: "U003",
+        userName: "charlie",
+        text: "second top-level message",
+        isBot: false,
+      },
+    ]);
+
+    const sessionManager = SessionManager.inMemory(testDir);
+    const firstSynced = await syncLogToSessionManager(
+      sessionManager,
+      testDir,
+      undefined,
+      { start: 0, end: Number.MAX_SAFE_INTEGER },
+      { scope: "top-level", rootTs: "C001" },
+    );
+
+    expect(firstSynced).toBe(2);
+    expect(getMessageTexts(sessionManager)).toEqual([
+      "[alice]: first top-level message",
+      "[charlie]: second top-level message",
+    ]);
+
+    writeLog([
+      {
+        date: "2026-04-01T10:05:00.000Z",
+        ts: "1000.0050",
+        user: "U004",
+        userName: "dora",
+        text: "third top-level message",
+        isBot: false,
+      },
+    ]);
+
+    const secondSynced = await syncLogToSessionManager(
+      sessionManager,
+      testDir,
+      undefined,
+      { start: 0, end: Number.MAX_SAFE_INTEGER },
+      { scope: "top-level", rootTs: "C001" },
+    );
+
+    expect(secondSynced).toBe(1);
+    expect(getMessageTexts(sessionManager)).toEqual([
+      "[alice]: first top-level message",
+      "[charlie]: second top-level message",
+      "[dora]: third top-level message",
+    ]);
+  });
+
   test("thread scope only syncs the matching root message and thread replies", async () => {
     writeLog([
       {

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -231,6 +231,42 @@ describe("syncLogToSessionManager", () => {
     ]);
   });
 
+  test("does not re-import a live prompt when the session copy includes attachment markup", async () => {
+    writeLog([
+      {
+        date: "2026-04-01T10:00:00.000Z",
+        ts: "1000.0010",
+        user: "U001",
+        userName: "alice",
+        text: "hello from slack",
+        isBot: false,
+      },
+    ]);
+
+    const sessionManager = SessionManager.inMemory(testDir);
+    sessionManager.appendMessage({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "[2026-04-01 18:01:10+08:00] [alice]: hello from slack\n\n<slack_attachments>\n/workspace/C001/attachments/report.txt\n</slack_attachments>",
+        },
+      ],
+      timestamp: new Date("2026-04-01T10:01:10.000Z").getTime(),
+    });
+
+    const synced = await syncLogToSessionManager(
+      sessionManager,
+      testDir,
+      undefined,
+      { start: 0, end: Number.MAX_SAFE_INTEGER },
+      { scope: "top-level", rootTs: "C001" },
+    );
+
+    expect(synced).toBe(0);
+    expect(getMessageTexts(sessionManager)).toHaveLength(1);
+  });
+
   test("thread scope only syncs the matching root message and thread replies", async () => {
     writeLog([
       {

--- a/test/event-tool.test.ts
+++ b/test/event-tool.test.ts
@@ -23,7 +23,7 @@ describe("createEventTool", () => {
     return dir;
   }
 
-  test("writes immediate event payload with current context and sanitized filename", async () => {
+  test("writes top-level Slack event payload without threadTs", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1700000000000);
     const workspaceDir = makeWorkspace();
     const { tool, setEventContext } = createEventTool(workspaceDir);
@@ -33,7 +33,6 @@ describe("createEventTool", () => {
       conversationKind: "shared",
       userId: "U123",
       sessionKey: "C123",
-      threadTs: "1000.0001",
     });
 
     const result = await tool.execute("call-1", {
@@ -54,12 +53,45 @@ describe("createEventTool", () => {
       userId: "U123",
       text: "Check deployment status",
       sessionKey: "C123",
-      threadTs: "1000.0001",
     });
     expect(result.content[0]?.type).toBe("text");
     expect(result.content[0]?.text).toContain(
       "Queued immediate event deploy-prod-1700000000000.json",
     );
+  });
+
+  test("writes threaded Slack event payload with threadTs", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1700000000001);
+    const workspaceDir = makeWorkspace();
+    const { tool, setEventContext } = createEventTool(workspaceDir);
+    setEventContext({
+      platform: "slack",
+      conversationId: "C123",
+      conversationKind: "shared",
+      userId: "U123",
+      sessionKey: "C123:1000.0001",
+      threadTs: "1000.0001",
+    });
+
+    await tool.execute("call-1", {
+      label: "deploy",
+      type: "immediate",
+      text: "Check deployment status",
+    });
+
+    const eventsDir = join(workspaceDir, "events");
+    const files = readdirSync(eventsDir);
+    expect(files).toEqual(["immediate-1700000000001.json"]);
+    expect(JSON.parse(readFileSync(join(eventsDir, files[0]), "utf-8"))).toEqual({
+      type: "immediate",
+      platform: "slack",
+      conversationId: "C123",
+      conversationKind: "shared",
+      userId: "U123",
+      text: "Check deployment status",
+      sessionKey: "C123:1000.0001",
+      threadTs: "1000.0001",
+    });
   });
 
   test("requires event context before execution", async () => {
@@ -73,6 +105,75 @@ describe("createEventTool", () => {
         text: "Check deployment status",
       }),
     ).rejects.toThrow("Event context not configured");
+  });
+
+  test("one-shot event strips sessionKey and threadTs even when set in context", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1700000000200);
+    const workspaceDir = makeWorkspace();
+    const { tool, setEventContext } = createEventTool(workspaceDir);
+    setEventContext({
+      platform: "slack",
+      conversationId: "C123",
+      conversationKind: "shared",
+      userId: "U123",
+      sessionKey: "C123:1000.0001",
+      threadTs: "1000.0001",
+    });
+
+    await tool.execute("call-1", {
+      label: "dentist",
+      type: "one-shot",
+      text: "Dentist tomorrow",
+      at: "2025-12-15T09:00:00+01:00",
+    });
+
+    const eventsDir = join(workspaceDir, "events");
+    const files = readdirSync(eventsDir);
+    expect(JSON.parse(readFileSync(join(eventsDir, files[0]), "utf-8"))).toEqual({
+      type: "one-shot",
+      platform: "slack",
+      conversationId: "C123",
+      conversationKind: "shared",
+      userId: "U123",
+      text: "Dentist tomorrow",
+      at: "2025-12-15T09:00:00+01:00",
+    });
+  });
+
+  test("periodic event strips threadTs but keeps sessionKey when in a thread", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1700000000300);
+    const workspaceDir = makeWorkspace();
+    const { tool, setEventContext } = createEventTool(workspaceDir);
+    setEventContext({
+      platform: "slack",
+      conversationId: "C123",
+      conversationKind: "shared",
+      userId: "U123",
+      sessionKey: "C123:1000.0001",
+      threadTs: "1000.0001",
+    });
+
+    await tool.execute("call-1", {
+      label: "inbox",
+      type: "periodic",
+      text: "Check inbox",
+      schedule: "0 9 * * 1-5",
+      timezone: "Asia/Taipei",
+    });
+
+    const eventsDir = join(workspaceDir, "events");
+    const files = readdirSync(eventsDir);
+    expect(JSON.parse(readFileSync(join(eventsDir, files[0]), "utf-8"))).toEqual({
+      type: "periodic",
+      platform: "slack",
+      conversationId: "C123",
+      conversationKind: "shared",
+      userId: "U123",
+      text: "Check inbox",
+      schedule: "0 9 * * 1-5",
+      timezone: "Asia/Taipei",
+      sessionKey: "C123:1000.0001",
+    });
   });
 
   test("one-shot events require at", async () => {

--- a/test/event-tool.test.ts
+++ b/test/event-tool.test.ts
@@ -32,6 +32,8 @@ describe("createEventTool", () => {
       conversationId: "C123",
       conversationKind: "shared",
       userId: "U123",
+      sessionKey: "C123",
+      threadTs: "1000.0001",
     });
 
     const result = await tool.execute("call-1", {
@@ -51,6 +53,8 @@ describe("createEventTool", () => {
       conversationKind: "shared",
       userId: "U123",
       text: "Check deployment status",
+      sessionKey: "C123",
+      threadTs: "1000.0001",
     });
     expect(result.content[0]?.type).toBe("text");
     expect(result.content[0]?.text).toContain(
@@ -79,6 +83,8 @@ describe("createEventTool", () => {
       conversationId: "C123",
       conversationKind: "shared",
       userId: "U123",
+      sessionKey: "C123",
+      threadTs: "1000.0001",
     });
 
     await expect(
@@ -98,6 +104,7 @@ describe("createEventTool", () => {
       conversationId: "D123",
       conversationKind: "direct",
       userId: "U456",
+      sessionKey: "D123",
     });
 
     await expect(
@@ -128,6 +135,7 @@ describe("createEventTool", () => {
       conversationId: "999",
       conversationKind: "direct",
       userId: "U789",
+      sessionKey: "999",
     });
 
     const result = await tool.execute("call-1", {
@@ -150,6 +158,7 @@ describe("createEventTool", () => {
       text: "Check inbox",
       schedule: "0 9 * * 1-5",
       timezone: "Asia/Taipei",
+      sessionKey: "999",
     });
     expect(result.content[0]?.text).toContain(
       "Scheduled periodic event periodic-1700000000100.json",

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -148,6 +148,34 @@ describe("EventsWatcher platform routing", () => {
     expect(watcher.knownFiles.has(filename)).toBe(true);
   });
 
+  test("keeps a scheduled one-shot timer even if the file truly disappears", async () => {
+    const { bot } = makeBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+    const filename = "reminder.json";
+    const filePath = join(eventsDir, filename);
+
+    writeFileSync(
+      filePath,
+      JSON.stringify({
+        type: "one-shot",
+        platform: "slack",
+        conversationId: "D123",
+        conversationKind: "direct",
+        text: "wake up",
+        at: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+
+    await watcher.handleFile(filename);
+    expect(watcher.timers.has(filename)).toBe(true);
+
+    rmSync(filePath, { force: true });
+    await watcher.handleDelete(filename);
+
+    expect(watcher.timers.has(filename)).toBe(true);
+    expect(watcher.knownFiles.has(filename)).toBe(true);
+  });
+
   test("routes synthetic events to the explicitly requested platform", () => {
     const { bot: slackBot, enqueueEvent: enqueueSlack } = makeBot("slack");
     const { bot: discordBot, enqueueEvent: enqueueDiscord } = makeBot("discord");

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -102,6 +102,50 @@ describe("EventsWatcher platform routing", () => {
         "ambiguous.json",
       ),
     ).toThrow(/Missing required field 'platform'/);
+  });
+
+  test("ignores transient missing-file signals so scheduled events stay active", async () => {
+    const { bot } = makeBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+    const filename = "reminder.json";
+    const filePath = join(eventsDir, filename);
+
+    writeFileSync(
+      filePath,
+      JSON.stringify({
+        type: "one-shot",
+        platform: "slack",
+        conversationId: "D123",
+        conversationKind: "direct",
+        text: "wake up",
+        at: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+
+    await watcher.handleFile(filename);
+    expect(watcher.timers.has(filename)).toBe(true);
+
+    watcher.sleep = vi.fn(async () => {
+      if (!existsSync(filePath)) {
+        writeFileSync(
+          filePath,
+          JSON.stringify({
+            type: "one-shot",
+            platform: "slack",
+            conversationId: "D123",
+            conversationKind: "direct",
+            text: "wake up",
+            at: new Date(Date.now() + 60_000).toISOString(),
+          }),
+        );
+      }
+    });
+
+    rmSync(filePath, { force: true });
+    await watcher.handleDelete(filename);
+
+    expect(watcher.timers.has(filename)).toBe(true);
+    expect(watcher.knownFiles.has(filename)).toBe(true);
   });
 
   test("routes synthetic events to the explicitly requested platform", () => {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -191,6 +191,8 @@ describe("EventsWatcher platform routing", () => {
       conversationKind: "shared",
       text: "Deploy in 10 minutes",
       userId: "U123",
+      sessionKey: "CH-42:THREAD-1",
+      threadTs: "THREAD-1",
     });
 
     expect(enqueueSlack).not.toHaveBeenCalled();
@@ -202,7 +204,8 @@ describe("EventsWatcher platform routing", () => {
       user: "U123",
       text: "[EVENT:deploy-reminder.json:immediate:immediate] Deploy in 10 minutes",
       ts: "event:deploy-reminder.json",
-      sessionKey: "CH-42",
+      thread_ts: "THREAD-1",
+      sessionKey: "CH-42:THREAD-1",
     });
   });
 });

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -7,6 +7,7 @@ import {
   createManagedSessionFile,
   createManagedSessionFileAtPath,
   createNewSessionFile,
+  createThreadSessionFileFromRootMessage,
   forkThreadSessionFile,
   forkThreadSessionFileFromRootMessage,
   getChannelSessionDir,
@@ -15,6 +16,7 @@ import {
   resolveChannelSessionFile,
   resolveManagedSessionFile,
   resolveSessionFile,
+  ThreadRootNotFoundError,
   tryResolveCurrentSession,
   tryResolveThreadSession,
 } from "../src/session-store.js";
@@ -264,6 +266,63 @@ describe("thread fork", () => {
     expect(threadContent).toContain("first reply");
     expect(threadContent).toContain("second reply");
     expect(threadContent).not.toContain("third");
+  });
+
+  test("matches root messages even when the parent turn includes attachment markup", () => {
+    const sessionDir = getChannelSessionDir(channelDir);
+    const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
+    const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
+    channelSM.appendMessage(
+      makeUserMessage(
+        "[2026-04-28 18:18:59+08:00] [alice]: first\n\n<slack_attachments>\n/workspace/C123/attachments/a.txt\n</slack_attachments>",
+      ),
+    );
+    channelSM.appendMessage(makeAssistantMessage("first reply"));
+    channelSM.appendMessage(makeUserMessage("[2026-04-28 18:19:03+08:00] [alice]: second"));
+    channelSM.appendMessage(makeAssistantMessage("second reply"));
+
+    const threadFile = getThreadSessionFile(channelDir, "C123:1777371539.041289");
+    forkThreadSessionFileFromRootMessage(channelFile, threadFile, channelDir, {
+      userName: "alice",
+      text: "first",
+      loggedAt: 1,
+    });
+
+    const threadContent = readFileSync(threadFile, "utf-8");
+    expect(threadContent).toContain("first reply");
+    expect(threadContent).not.toContain("second");
+  });
+
+  test("falls back to a root-only thread session instead of copying the latest channel state", () => {
+    const sessionDir = getChannelSessionDir(channelDir);
+    const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
+    const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
+    channelSM.appendMessage(makeUserMessage("[2026-04-28 18:18:59+08:00] [alice]: second"));
+    channelSM.appendMessage(makeAssistantMessage("second reply"));
+
+    const threadFile = getThreadSessionFile(channelDir, "C123:1777371539.041289");
+    expect(() =>
+      forkThreadSessionFileFromRootMessage(channelFile, threadFile, channelDir, {
+        userName: "alice",
+        text: "first",
+      }),
+    ).toThrow(ThreadRootNotFoundError);
+
+    createThreadSessionFileFromRootMessage(
+      threadFile,
+      channelDir,
+      {
+        userName: "alice",
+        text: "first",
+        loggedAt: 123,
+      },
+      channelFile,
+    );
+
+    const threadContent = readFileSync(threadFile, "utf-8");
+    expect(threadContent).toContain(`"parentSession":"${channelFile}"`);
+    expect(threadContent).toContain("[alice]: first");
+    expect(threadContent).not.toContain("second reply");
   });
 
   test("different threads get independent session IDs", () => {

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -8,6 +8,7 @@ import {
   createManagedSessionFileAtPath,
   createNewSessionFile,
   forkThreadSessionFile,
+  forkThreadSessionFileFromRootMessage,
   getChannelSessionDir,
   getThreadSessionFile,
   openManagedSession,
@@ -239,6 +240,30 @@ describe("thread fork", () => {
     const reopened = openManagedSession(existing!, sessionDir, channelDir);
     expect(reopened.getSessionId()).toBe(threadSessionId);
     expect(readFileSync(existing!, "utf-8")).toContain("thread msg");
+  });
+
+  test("forks thread history from the root message turn instead of the latest channel state", () => {
+    const sessionDir = getChannelSessionDir(channelDir);
+    const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
+    const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
+    channelSM.appendMessage(makeUserMessage("[2026-04-28 18:18:59+08:00] [alice]: first"));
+    channelSM.appendMessage(makeAssistantMessage("first reply"));
+    channelSM.appendMessage(makeUserMessage("[2026-04-28 18:19:03+08:00] [alice]: second"));
+    channelSM.appendMessage(makeAssistantMessage("second reply"));
+    channelSM.appendMessage(makeUserMessage("[2026-04-28 18:19:08+08:00] [alice]: third"));
+    channelSM.appendMessage(makeAssistantMessage("third reply"));
+
+    const threadFile = getThreadSessionFile(channelDir, "C123:1777371539.041289");
+    forkThreadSessionFileFromRootMessage(channelFile, threadFile, channelDir, {
+      userName: "alice",
+      text: "second",
+      loggedAt: 3,
+    });
+
+    const threadContent = readFileSync(threadFile, "utf-8");
+    expect(threadContent).toContain("first reply");
+    expect(threadContent).toContain("second reply");
+    expect(threadContent).not.toContain("third");
   });
 
   test("different threads get independent session IDs", () => {

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -178,7 +178,7 @@ describe("managed session initialization", () => {
     const header = entries.find((entry) => entry.type === "session");
 
     expect(header?.cwd).toBe(channelDir);
-    expect(countSessionHeaders(sessionFile)).toBeGreaterThan(0);
+    expect(countSessionHeaders(sessionFile)).toBe(1);
   });
 
   test("creates a fixed-path thread session with the provided cwd", () => {
@@ -188,6 +188,7 @@ describe("managed session initialization", () => {
     const sessionManager = openManagedSession(threadFile, sessionDir, channelDir);
 
     sessionManager.appendMessage(makeUserMessage("hello thread"));
+    sessionManager.appendMessage(makeAssistantMessage("thread reply"));
 
     const entries = readFileSync(threadFile, "utf-8")
       .split("\n")

--- a/test/session-view.test.ts
+++ b/test/session-view.test.ts
@@ -1,0 +1,119 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { AssistantMessage, UserMessage } from "@mariozechner/pi-ai";
+import {
+  createManagedSessionFile,
+  createManagedSessionFileAtPath,
+  getChannelSessionDir,
+  getThreadSessionFile,
+  openManagedSession,
+} from "../src/session-store.js";
+import { parseSessionViewCommand } from "../src/session-view/command.js";
+import { loadSessionViewModel, resolveExistingSessionFile } from "../src/session-view/service.js";
+
+let workspaceDir: string;
+let conversationDir: string;
+let nextTimestamp = 1;
+
+beforeEach(() => {
+  nextTimestamp = 1;
+  workspaceDir = join(
+    tmpdir(),
+    `session-view-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  conversationDir = join(workspaceDir, "D123");
+  mkdirSync(conversationDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function makeUserMessage(text: string): UserMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp: nextTimestamp++,
+  };
+}
+
+function makeAssistantMessage(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-test",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: nextTimestamp++,
+  };
+}
+
+describe("parseSessionViewCommand", () => {
+  test("recognizes supported commands", () => {
+    expect(parseSessionViewCommand("session")).toEqual({ command: "session" });
+    expect(parseSessionViewCommand("/session")).toEqual({ command: "/session" });
+    expect(parseSessionViewCommand("/pi-session now")).toEqual({ command: "/pi-session" });
+  });
+
+  test("ignores unrelated text", () => {
+    expect(parseSessionViewCommand("hello there")).toBeNull();
+  });
+});
+
+describe("resolveExistingSessionFile", () => {
+  test("resolves the current channel session", () => {
+    const sessionDir = getChannelSessionDir(conversationDir);
+    const sessionFile = createManagedSessionFile(sessionDir, conversationDir);
+
+    expect(resolveExistingSessionFile(workspaceDir, "D123", "D123")).toBe(sessionFile);
+  });
+
+  test("resolves a fixed-path thread session when the conversation directory matches", () => {
+    const sharedConversationDir = join(workspaceDir, "C123");
+    mkdirSync(sharedConversationDir, { recursive: true });
+    const sessionFile = getThreadSessionFile(sharedConversationDir, "C123:1000.0001");
+    createManagedSessionFileAtPath(sessionFile, sharedConversationDir);
+
+    expect(resolveExistingSessionFile(workspaceDir, "C123", "C123:1000.0001")).toBe(sessionFile);
+  });
+});
+
+describe("loadSessionViewModel", () => {
+  test("maps session entries into a readable timeline", () => {
+    const sessionDir = getChannelSessionDir(conversationDir);
+    const sessionFile = createManagedSessionFile(sessionDir, conversationDir);
+    const sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
+
+    sessionManager.appendMessage(makeUserMessage("請幫我看一下測試結果"));
+    sessionManager.appendMessage(makeAssistantMessage("好的，我正在查看。"));
+    sessionManager.appendMessage({
+      role: "bashExecution",
+      command: "npm test",
+      output: "1 passed",
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      timestamp: nextTimestamp++,
+    } as any);
+
+    const model = loadSessionViewModel(sessionFile);
+
+    expect(model.title).toContain("Session");
+    expect(model.items.map((item) => item.title)).toEqual(["User", "Assistant", "Bash execution"]);
+    expect(model.items[0].body).toContain("請幫我看一下測試結果");
+    expect(model.items[1].body).toContain("好的，我正在查看");
+    expect(model.items[2].body).toContain("npm test");
+    expect(model.items[2].body).toContain("1 passed");
+  });
+});

--- a/test/session-view.test.ts
+++ b/test/session-view.test.ts
@@ -1,11 +1,12 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import type { AssistantMessage, UserMessage } from "@mariozechner/pi-ai";
 import {
   createManagedSessionFile,
   createManagedSessionFileAtPath,
+  forkThreadSessionFile,
   getChannelSessionDir,
   getThreadSessionFile,
   openManagedSession,
@@ -115,5 +116,31 @@ describe("loadSessionViewModel", () => {
     expect(model.items[1].body).toContain("好的，我正在查看");
     expect(model.items[2].body).toContain("npm test");
     expect(model.items[2].body).toContain("1 passed");
+    expect(model.forks).toEqual([]);
+  });
+
+  test("keeps channel and thread sessions on separate pages while linking them", () => {
+    const sessionDir = getChannelSessionDir(conversationDir);
+    const channelFile = createManagedSessionFile(sessionDir, conversationDir);
+    const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
+    channelSession.appendMessage(makeUserMessage("channel root"));
+    channelSession.appendMessage(makeAssistantMessage("channel reply"));
+
+    const threadFile = getThreadSessionFile(conversationDir, "D123:1000.0001");
+    forkThreadSessionFile(channelFile, threadFile, conversationDir);
+    const threadSession = openManagedSession(threadFile, sessionDir, conversationDir);
+    threadSession.appendMessage(makeUserMessage("thread only"));
+    threadSession.appendMessage(makeAssistantMessage("thread reply"));
+
+    const channelModel = loadSessionViewModel(channelFile);
+    expect(channelModel.items.some((item) => item.body?.includes("thread only"))).toBe(false);
+    expect(channelModel.forks).toHaveLength(1);
+    expect(channelModel.forks[0]?.fileName).toBe(basename(threadFile));
+    const anchoredItem = channelModel.items.find((item) => item.body?.includes("channel root"));
+    expect(anchoredItem?.forks?.[0]?.fileName).toBe(basename(threadFile));
+
+    const threadModel = loadSessionViewModel(threadFile);
+    expect(threadModel.parent?.fileName).toBe(basename(channelFile));
+    expect(threadModel.items.some((item) => item.body?.includes("thread only"))).toBe(true);
   });
 });

--- a/test/session-view.test.ts
+++ b/test/session-view.test.ts
@@ -11,6 +11,7 @@ import {
   getThreadSessionFile,
   openManagedSession,
 } from "../src/session-store.js";
+import { parseUserBody } from "../src/session-view/portal.js";
 import { parseSessionViewCommand } from "../src/session-view/command.js";
 import { loadSessionViewModel, resolveExistingSessionFile } from "../src/session-view/service.js";
 
@@ -142,5 +143,18 @@ describe("loadSessionViewModel", () => {
     const threadModel = loadSessionViewModel(threadFile);
     expect(threadModel.parent?.fileName).toBe(basename(channelFile));
     expect(threadModel.items.some((item) => item.body?.includes("thread only"))).toBe(true);
+  });
+});
+
+describe("parseUserBody", () => {
+  test("strips in-thread markers from timestamped user messages", () => {
+    expect(
+      parseUserBody(
+        "[2026-04-29 00:11:10+08:00] [geminixiang] [in-thread:1777386320.800769]: hello from thread",
+      ),
+    ).toEqual({
+      username: "geminixiang",
+      content: "hello from thread",
+    });
   });
 });

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -1,9 +1,10 @@
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { BotHandler } from "../src/adapter.js";
 import { SlackBot } from "../src/adapters/slack/bot.js";
+import { createManagedSessionFileAtPath, getThreadSessionFile } from "../src/session-store.js";
 
 function makeHandler(): BotHandler {
   return {
@@ -236,6 +237,61 @@ describe("SlackBot queues follow-up messages", () => {
     });
   });
 
+  test("first shared-channel thread reply waits behind the channel queue until the thread session exists", async () => {
+    const handler = makeHandler();
+
+    const bot = new SlackBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    let mentionHandler:
+      | ((payload: {
+          event: {
+            text: string;
+            channel: string;
+            user: string;
+            ts: string;
+            thread_ts?: string;
+          };
+          ack: () => void;
+        }) => void)
+      | undefined;
+
+    (bot as any).startupTs = "0";
+    (bot as any).botUserId = "B123";
+    (bot as any).logUserMessage = vi.fn().mockReturnValue([]);
+    (bot as any).postMessage = vi.fn().mockResolvedValue("2000.0001");
+    (bot as any).socketClient = {
+      on: vi.fn((event: string, fn: unknown) => {
+        if (event === "app_mention") mentionHandler = fn as typeof mentionHandler;
+      }),
+    };
+
+    (bot as any).setupEventHandlers();
+
+    const queue = (bot as any).getQueue("C123");
+    queue.processing = true;
+    const ack = vi.fn();
+
+    mentionHandler?.({
+      event: {
+        text: "<@B123> thread request",
+        channel: "C123",
+        user: "U123",
+        ts: "1001.0002",
+        thread_ts: "1000.0001",
+      },
+      ack,
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(queue.size()).toBe(1);
+    expect(handler.handleEvent).not.toHaveBeenCalled();
+  });
+
   test("DM follow-up messages are queued while the top-level DM session is running", async () => {
     const handler = makeHandler();
     vi.mocked(handler.isRunning).mockImplementation((sessionKey: string) => sessionKey === "D123");
@@ -303,7 +359,64 @@ describe("SlackBot queues follow-up messages", () => {
     });
   });
 
-  test("DM thread follow-up messages are queued on the thread session key", async () => {
+  test("first DM thread reply waits behind the top-level DM queue until the thread session exists", async () => {
+    const handler = makeHandler();
+
+    const bot = new SlackBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    let messageHandler:
+      | ((payload: {
+          event: {
+            text?: string;
+            channel: string;
+            user?: string;
+            ts: string;
+            thread_ts?: string;
+            channel_type?: string;
+          };
+          ack: () => void;
+        }) => void)
+      | undefined;
+
+    (bot as any).startupTs = "0";
+    (bot as any).botUserId = "B123";
+    (bot as any).logUserMessage = vi.fn().mockReturnValue([]);
+    (bot as any).postMessage = vi.fn().mockResolvedValue("3000.0001");
+    (bot as any).socketClient = {
+      on: vi.fn((event: string, fn: unknown) => {
+        if (event === "message") messageHandler = fn as typeof messageHandler;
+      }),
+    };
+
+    (bot as any).setupEventHandlers();
+
+    const queue = (bot as any).getQueue("D123");
+    queue.processing = true;
+    const ack = vi.fn();
+
+    messageHandler?.({
+      event: {
+        text: "thread request",
+        channel: "D123",
+        user: "U123",
+        ts: "2001.0001",
+        thread_ts: "2000.0001",
+        channel_type: "im",
+      },
+      ack,
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(queue.size()).toBe(1);
+    expect(handler.handleEvent).not.toHaveBeenCalled();
+  });
+
+  test("DM thread follow-up messages are queued on the thread session key once the thread session exists", async () => {
     const handler = makeHandler();
     vi.mocked(handler.isRunning).mockImplementation(
       (sessionKey: string) => sessionKey === "D123:2000.0001",
@@ -340,6 +453,11 @@ describe("SlackBot queues follow-up messages", () => {
       }),
     };
 
+    createManagedSessionFileAtPath(
+      getThreadSessionFile(join(workingDir, "D123"), "D123:2000.0001"),
+      join(workingDir, "D123"),
+    );
+
     (bot as any).setupEventHandlers();
 
     const queue = (bot as any).getQueue("D123:2000.0001");
@@ -372,6 +490,57 @@ describe("SlackBot queues follow-up messages", () => {
       text: "thread request",
       thread_ts: "2000.0001",
     });
+  });
+});
+
+describe("SlackBot backfill", () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = join(tmpdir(), `mama-slack-backfill-${Date.now()}`);
+    mkdirSync(workingDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  test("backfill preserves threadTs for thread replies", async () => {
+    const handler = makeHandler();
+    const bot = new SlackBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {
+        processAttachments: vi.fn().mockResolvedValue([]),
+      } as any,
+    });
+
+    (bot as any).botUserId = "B123";
+    (bot as any).users = new Map([
+      ["U123", { id: "U123", userName: "alice", displayName: "Alice" }],
+    ]);
+    (bot as any).webClient = {
+      conversations: {
+        history: vi.fn().mockResolvedValue({
+          messages: [
+            {
+              user: "U123",
+              text: "reply in thread",
+              ts: "1000.0002",
+              thread_ts: "1000.0001",
+            },
+          ],
+          response_metadata: {},
+        }),
+      },
+    };
+
+    const count = await (bot as any).backfillChannel("C123");
+
+    expect(count).toBe(1);
+    const logContent = readFileSync(join(workingDir, "C123", "log.jsonl"), "utf-8");
+    expect(logContent).toContain('"threadTs":"1000.0001"');
   });
 });
 

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -236,7 +236,7 @@ describe("SlackBot queues follow-up messages", () => {
     });
   });
 
-  test("DM follow-up messages are queued while the session is running", async () => {
+  test("DM follow-up messages are queued while the top-level DM session is running", async () => {
     const handler = makeHandler();
     vi.mocked(handler.isRunning).mockImplementation((sessionKey: string) => sessionKey === "D123");
 
@@ -300,6 +300,77 @@ describe("SlackBot queues follow-up messages", () => {
       conversationId: "D123",
       sessionKey: "D123",
       text: "second request",
+    });
+  });
+
+  test("DM thread follow-up messages are queued on the thread session key", async () => {
+    const handler = makeHandler();
+    vi.mocked(handler.isRunning).mockImplementation(
+      (sessionKey: string) => sessionKey === "D123:2000.0001",
+    );
+
+    const bot = new SlackBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    let messageHandler:
+      | ((payload: {
+          event: {
+            text?: string;
+            channel: string;
+            user?: string;
+            ts: string;
+            thread_ts?: string;
+            channel_type?: string;
+          };
+          ack: () => void;
+        }) => void)
+      | undefined;
+
+    (bot as any).startupTs = "0";
+    (bot as any).botUserId = "B123";
+    (bot as any).logUserMessage = vi.fn().mockReturnValue([]);
+    (bot as any).postMessage = vi.fn().mockResolvedValue("3000.0001");
+    (bot as any).socketClient = {
+      on: vi.fn((event: string, fn: unknown) => {
+        if (event === "message") messageHandler = fn as typeof messageHandler;
+      }),
+    };
+
+    (bot as any).setupEventHandlers();
+
+    const queue = (bot as any).getQueue("D123:2000.0001");
+    queue.processing = true;
+    const ack = vi.fn();
+
+    messageHandler?.({
+      event: {
+        text: "thread request",
+        channel: "D123",
+        user: "U123",
+        ts: "2001.0001",
+        thread_ts: "2000.0001",
+        channel_type: "im",
+      },
+      ack,
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(queue.size()).toBe(1);
+    expect(handler.handleEvent).not.toHaveBeenCalled();
+
+    queue.processing = false;
+    await queue.processNext();
+
+    expect(handler.handleEvent).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(handler.handleEvent).mock.calls[0]?.[0]).toMatchObject({
+      conversationId: "D123",
+      sessionKey: "D123:2000.0001",
+      text: "thread request",
+      thread_ts: "2000.0001",
     });
   });
 });

--- a/test/slack-branch-manager.test.ts
+++ b/test/slack-branch-manager.test.ts
@@ -1,0 +1,167 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  createManagedSessionFile,
+  getChannelSessionDir,
+  openManagedSession,
+} from "../src/session-store.js";
+import {
+  resolveSlackSessionScope,
+  waitForSlackBranchBootstrap,
+} from "../src/adapters/slack/branch-manager.js";
+
+let conversationDir: string;
+let nextTimestamp = 1;
+
+beforeEach(() => {
+  nextTimestamp = 1;
+  conversationDir = join(
+    tmpdir(),
+    `slack-branch-manager-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(conversationDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(conversationDir, { recursive: true, force: true });
+});
+
+function writeLog(entries: object[]): void {
+  writeFileSync(
+    join(conversationDir, "log.jsonl"),
+    entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function makeUserMessage(text: string) {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp: nextTimestamp++,
+  } as const;
+}
+
+function makeAssistantMessage(text: string) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-test",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: nextTimestamp++,
+  } as const;
+}
+
+describe("waitForSlackBranchBootstrap", () => {
+  test("waits for the parent Slack session to finish before first thread bootstrap", async () => {
+    let checks = 0;
+    const sleep = vi.fn(async () => {
+      checks += 1;
+    });
+
+    const waited = await waitForSlackBranchBootstrap({
+      parentSessionKey: "C123",
+      sessionKey: "C123:1000.0001",
+      hasThreadSession: () => false,
+      isParentRunning: () => checks < 3,
+      sleep,
+      pollMs: 1,
+    });
+
+    expect(waited).toBe(true);
+    expect(sleep).toHaveBeenCalledTimes(3);
+  });
+
+  test("stops waiting once the thread session already exists", async () => {
+    let checks = 0;
+    const sleep = vi.fn(async () => {
+      checks += 1;
+    });
+
+    const waited = await waitForSlackBranchBootstrap({
+      parentSessionKey: "C123",
+      sessionKey: "C123:1000.0001",
+      hasThreadSession: () => checks >= 1,
+      isParentRunning: () => true,
+      sleep,
+      pollMs: 1,
+    });
+
+    expect(waited).toBe(true);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  test("does nothing for top-level sessions", async () => {
+    const sleep = vi.fn(async () => {});
+
+    expect(
+      await waitForSlackBranchBootstrap({
+        parentSessionKey: "C123",
+        sessionKey: "C123",
+        hasThreadSession: () => false,
+        isParentRunning: () => true,
+        sleep,
+      }),
+    ).toBe(false);
+
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveSlackSessionScope", () => {
+  test("resolves the persistent top-level session", async () => {
+    const { sessionDir, contextFile, threadRootMessage } = await resolveSlackSessionScope({
+      conversationDir,
+      sessionKey: "C123",
+    });
+
+    expect(sessionDir).toBe(getChannelSessionDir(conversationDir));
+    expect(contextFile).toContain("/sessions/");
+    expect(threadRootMessage).toBeNull();
+  });
+
+  test("creates a root-only branch session when the parent root turn is not materialized yet", async () => {
+    const sessionDir = getChannelSessionDir(conversationDir);
+    const channelFile = createManagedSessionFile(sessionDir, conversationDir);
+    const channelSM = openManagedSession(channelFile, sessionDir, conversationDir);
+    channelSM.appendMessage(makeUserMessage("[2026-04-28 18:19:03+08:00] [alice]: second"));
+    channelSM.appendMessage(makeAssistantMessage("second reply"));
+
+    writeLog([
+      {
+        date: "2026-04-28T10:18:59.000Z",
+        ts: "1000.0001",
+        user: "U123",
+        userName: "alice",
+        text: "first",
+        isBot: false,
+      },
+    ]);
+
+    const { contextFile, threadRootMessage } = await resolveSlackSessionScope({
+      conversationDir,
+      sessionKey: "C123:1000.0001",
+      sleep: async () => {},
+      retryCount: 1,
+      retryDelayMs: 0,
+    });
+
+    expect(threadRootMessage?.text).toBe("first");
+    const content = readFileSync(contextFile, "utf-8");
+    expect(content).toContain(`"parentSession":"${channelFile}"`);
+    expect(content).toContain("[alice]: first");
+    expect(content).not.toContain("second reply");
+  });
+});

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -420,7 +420,7 @@ describe("thread_ts boundary values", () => {
     expect(createSlackAdapters(event, makeSlackBot()).message.sessionKey).toBe("C001");
   });
 
-  test("DM channel should share a single persistent session across messages", () => {
+  test("DM top-level messages share a single persistent session", () => {
     const event1 = makeEvent({ channel: "D001", ts: "1000.0001", thread_ts: undefined });
     const event2 = makeEvent({ channel: "D001", ts: "1000.0002", thread_ts: undefined });
     const bot = makeSlackBot();
@@ -428,6 +428,17 @@ describe("thread_ts boundary values", () => {
     const { message: msg2 } = createSlackAdapters(event2, bot);
     expect(msg1.sessionKey).toBe("D001");
     expect(msg2.sessionKey).toBe("D001");
+  });
+
+  test("DM thread replies use isolated per-thread sessions", () => {
+    const event = makeEvent({
+      channel: "D001",
+      ts: "1000.0003",
+      thread_ts: "1000.0001",
+    });
+    const bot = makeSlackBot();
+    const { message } = createSlackAdapters(event, bot);
+    expect(message.sessionKey).toBe("D001:1000.0001");
   });
 
   test("setTyping in thread should set assistant status with correct rootTs", async () => {

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -107,6 +107,23 @@ describe("respond() — non-threaded", () => {
     expect(bot.postInThread).not.toHaveBeenCalled();
   });
 
+  test("synthetic event in a Slack thread replies inside the original thread", async () => {
+    const bot = makeSlackBot();
+    const event = makeEvent({
+      ts: "event:deploy-reminder.json",
+      text: "[EVENT:deploy-reminder.json:immediate:immediate] Deploy now",
+      thread_ts: "1000.0001",
+      sessionKey: "C001:1000.0001",
+    });
+    const { responseCtx } = createSlackAdapters(event, bot, true);
+    await responseCtx.respond("done");
+    expect(bot.postInThread).toHaveBeenCalledWith(
+      "C001",
+      "1000.0001",
+      expect.stringContaining("done"),
+    );
+  });
+
   test("subsequent calls update the same message", async () => {
     const bot = makeSlackBot({ postInThread: vi.fn().mockResolvedValue("MSG1") });
     const event = makeEvent({ thread_ts: undefined });

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -94,6 +94,19 @@ describe("respond() — non-threaded", () => {
     expect(bot.postMessage).not.toHaveBeenCalled();
   });
 
+  test("synthetic event posts top-level instead of using an invalid thread root", async () => {
+    const bot = makeSlackBot();
+    const event = makeEvent({
+      ts: "event:deploy-reminder.json",
+      text: "[EVENT:deploy-reminder.json:immediate:immediate] Deploy now",
+      thread_ts: undefined,
+    });
+    const { responseCtx } = createSlackAdapters(event, bot, true);
+    await responseCtx.respond("done");
+    expect(bot.postMessage).toHaveBeenCalledWith("C001", expect.stringContaining("done"));
+    expect(bot.postInThread).not.toHaveBeenCalled();
+  });
+
   test("subsequent calls update the same message", async () => {
     const bot = makeSlackBot({ postInThread: vi.fn().mockResolvedValue("MSG1") });
     const event = makeEvent({ thread_ts: undefined });

--- a/test/slack-stop.test.ts
+++ b/test/slack-stop.test.ts
@@ -69,6 +69,27 @@ describe("stop command resolution in threads", () => {
     expect(target).toBe("C123");
   });
 
+  test("stop at top level falls back to the only running thread session", () => {
+    const handler = makeHandler(["C123:1000.0001"]);
+    vi.mocked(handler.getRunningSessions).mockReturnValue([
+      { sessionKey: "C123:1000.0001", startedAt: 1 },
+    ]);
+    const bot = makeBot(handler);
+    const target = (bot as any).resolveStopTarget("C123", undefined);
+    expect(target).toBe("C123:1000.0001");
+  });
+
+  test("stop at top level returns null when multiple thread sessions are running", () => {
+    const handler = makeHandler(["C123:1000.0001", "C123:1000.0002"]);
+    vi.mocked(handler.getRunningSessions).mockReturnValue([
+      { sessionKey: "C123:1000.0001", startedAt: 1 },
+      { sessionKey: "C123:1000.0002", startedAt: 2 },
+    ]);
+    const bot = makeBot(handler);
+    const target = (bot as any).resolveStopTarget("C123", undefined);
+    expect(target).toBeNull();
+  });
+
   test("stop at top level returns null when not running", () => {
     const handler = makeHandler([]);
     const bot = makeBot(handler);
@@ -95,5 +116,15 @@ describe("stop command resolution in threads", () => {
     const bot = makeBot(handler);
     const target = (bot as any).resolveStopTarget("D123", "1000.0001");
     expect(target).toBe("D123");
+  });
+
+  test("DM top-level stop can target the only running DM thread session", () => {
+    const handler = makeHandler(["D123:1000.0001"]);
+    vi.mocked(handler.getRunningSessions).mockReturnValue([
+      { sessionKey: "D123:1000.0001", startedAt: 1 },
+    ]);
+    const bot = makeBot(handler);
+    const target = (bot as any).resolveStopTarget("D123", undefined);
+    expect(target).toBe("D123:1000.0001");
   });
 });

--- a/test/slack-stop.test.ts
+++ b/test/slack-stop.test.ts
@@ -82,4 +82,18 @@ describe("stop command resolution in threads", () => {
     const target = (bot as any).resolveStopTarget("C123", "1000.0001");
     expect(target).toBe("C123:1000.0001");
   });
+
+  test("DM thread stop targets the DM thread session first", () => {
+    const handler = makeHandler(["D123", "D123:1000.0001"]);
+    const bot = makeBot(handler);
+    const target = (bot as any).resolveStopTarget("D123", "1000.0001");
+    expect(target).toBe("D123:1000.0001");
+  });
+
+  test("DM thread stop falls back to the top-level DM session", () => {
+    const handler = makeHandler(["D123"]);
+    const bot = makeBot(handler);
+    const target = (bot as any).resolveStopTarget("D123", "1000.0001");
+    expect(target).toBe("D123");
+  });
 });


### PR DESCRIPTION
## Summary
- restore Slack event notifications by posting synthetic event responses top-level instead of threading off a synthetic ts
- add coverage to ensure event-triggered Slack replies do not use invalid thread roots

## Testing
- npm test -- test/slack-context.test.ts test/events.test.ts
- npm run build