### PR TITLE
refactor: eliminate duplication across adapters, vault, and Slack command factories

### DIFF
--- a/src/adapters/discord/bot.ts
+++ b/src/adapters/discord/bot.ts
@@ -28,6 +28,7 @@ import type {
 import * as log from "../../log.js";
 import { resolveChatSessionKey } from "../../session-policy.js";
 import { formatNothingRunning } from "../../ui-copy.js";
+import { ChannelQueue } from "../shared.js";
 import { createDiscordAdapters } from "./context.js";
 
 // ============================================================================
@@ -37,39 +38,6 @@ import { createDiscordAdapters } from "./context.js";
 export interface DiscordEvent extends BotEvent {
   type: "mention" | "dm";
   userName?: string;
-}
-
-// ============================================================================
-// Per-channel queue for sequential processing
-// ============================================================================
-
-type QueuedWork = () => Promise<void>;
-
-class ChannelQueue {
-  private queue: QueuedWork[] = [];
-  private processing = false;
-
-  enqueue(work: QueuedWork): void {
-    this.queue.push(work);
-    this.processNext();
-  }
-
-  size(): number {
-    return this.queue.length;
-  }
-
-  private async processNext(): Promise<void> {
-    if (this.processing || this.queue.length === 0) return;
-    this.processing = true;
-    const work = this.queue.shift()!;
-    try {
-      await work();
-    } catch (err) {
-      log.logWarning("Discord queue error", err instanceof Error ? err.message : String(err));
-    }
-    this.processing = false;
-    this.processNext();
-  }
 }
 
 // ============================================================================
@@ -331,7 +299,7 @@ export class DiscordBot implements Bot {
   private getQueue(channelId: string): ChannelQueue {
     let queue = this.queues.get(channelId);
     if (!queue) {
-      queue = new ChannelQueue();
+      queue = new ChannelQueue("Discord");
       this.queues.set(channelId, queue);
     }
     return queue;

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -7,6 +7,87 @@
  * markup wrappers — so it lives here once.
  */
 
+import * as log from "../log.js";
+
+// ============================================================================
+// Per-channel queue for sequential processing
+// ============================================================================
+
+export class ChannelQueue {
+  private queue: Array<() => Promise<void>> = [];
+  private processing = false;
+
+  constructor(private readonly name: string = "") {}
+
+  enqueue(work: () => Promise<void>): void {
+    this.queue.push(work);
+    this.processNext();
+  }
+
+  size(): number {
+    return this.queue.length;
+  }
+
+  private async processNext(): Promise<void> {
+    if (this.processing || this.queue.length === 0) return;
+    this.processing = true;
+    const work = this.queue.shift()!;
+    try {
+      await work();
+    } catch (err) {
+      log.logWarning(
+        `${this.name ? this.name + " " : ""}queue error`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    this.processing = false;
+    this.processNext();
+  }
+}
+
+// ============================================================================
+// Exponential backoff retry utility
+// ============================================================================
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxRetries: number = 3,
+  baseDelayMs: number = 1000,
+): Promise<T> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+
+      let isRateLimited = false;
+      if ("code" in lastError && lastError.code === "rate_limited") {
+        isRateLimited = true;
+      }
+      if ("data" in lastError) {
+        const data = (lastError as { data?: { error?: string; response?: { status?: number } } })
+          .data;
+        if (data?.error === "rate_limited" || data?.response?.status === 429) {
+          isRateLimited = true;
+        }
+      }
+
+      if (isRateLimited) {
+        const delay = baseDelayMs * Math.pow(2, attempt);
+        log.logWarning(
+          `Rate limited, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+
+      throw lastError;
+    }
+  }
+  throw lastError;
+}
+
 /**
  * Split `text` into chunks no larger than `limit`, appending a continuation
  * marker (e.g. `_(continued 1)_`) at the end of every part except the last.

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -18,61 +18,10 @@ import type { EventsWatcher } from "../../events.js";
 import * as log from "../../log.js";
 import type { Attachment, ChannelStore } from "../../store.js";
 import { PRODUCT_NAME, formatForceStopped, formatNothingRunning } from "../../ui-copy.js";
+import { ChannelQueue, withRetry } from "../shared.js";
 import { createSlackAdapters } from "./context.js";
 import { hasMaterializedSlackBranchSession } from "./branch-manager.js";
 import { resolveSlackSessionKey } from "./session.js";
-
-// ============================================================================
-// Exponential backoff utility for Slack API calls
-// ============================================================================
-
-/**
- * Retry a function with exponential backoff on rate limit errors.
- */
-async function withRetry<T>(
-  fn: () => Promise<T>,
-  maxRetries: number = 3,
-  baseDelayMs: number = 1000,
-): Promise<T> {
-  let lastError: Error | undefined;
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastError = err instanceof Error ? err : new Error(String(err));
-
-      // Check for rate limit errors
-      let isRateLimited = false;
-
-      // Check for rate_limited error code (Slack SDK)
-      if ("code" in lastError && lastError.code === "rate_limited") {
-        isRateLimited = true;
-      }
-
-      // Check for rate_limited in error response
-      if ("data" in lastError) {
-        const data = (lastError as { data?: { error?: string; response?: { status?: number } } })
-          .data;
-        if (data?.error === "rate_limited" || data?.response?.status === 429) {
-          isRateLimited = true;
-        }
-      }
-
-      if (isRateLimited) {
-        const delay = baseDelayMs * Math.pow(2, attempt);
-        log.logWarning(
-          `Rate limited, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
-        );
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        continue;
-      }
-
-      // Non-retryable error
-      throw lastError;
-    }
-  }
-  throw lastError;
-}
 
 // ============================================================================
 // Types
@@ -137,39 +86,6 @@ export interface SlackContext {
   uploadFile: (filePath: string, title?: string) => Promise<void>;
   setWorking: (working: boolean) => Promise<void>;
   deleteMessage: () => Promise<void>;
-}
-
-// ============================================================================
-// Per-channel queue for sequential processing
-// ============================================================================
-
-type QueuedWork = () => Promise<void>;
-
-class ChannelQueue {
-  private queue: QueuedWork[] = [];
-  private processing = false;
-
-  enqueue(work: QueuedWork): void {
-    this.queue.push(work);
-    this.processNext();
-  }
-
-  size(): number {
-    return this.queue.length;
-  }
-
-  private async processNext(): Promise<void> {
-    if (this.processing || this.queue.length === 0) return;
-    this.processing = true;
-    const work = this.queue.shift()!;
-    try {
-      await work();
-    } catch (err) {
-      log.logWarning("Queue error", err instanceof Error ? err.message : String(err));
-    }
-    this.processing = false;
-    this.processNext();
-  }
 }
 
 // ============================================================================
@@ -441,7 +357,7 @@ export class SlackBot implements Bot {
   private getQueue(channelId: string): ChannelQueue {
     let queue = this.queues.get(channelId);
     if (!queue) {
-      queue = new ChannelQueue();
+      queue = new ChannelQueue("Slack");
       this.queues.set(channelId, queue);
     }
     return queue;
@@ -641,64 +557,13 @@ export class SlackBot implements Bot {
     return runningInConversation.length === 1 ? runningInConversation[0] : null;
   }
 
-  private createDirectCommandAdapters(
+  private createCommandAdapters(
     conversationId: string,
     userId: string,
     userName: string | undefined,
     text: string,
     ts: string,
-  ): BotAdapters {
-    const message: ChatMessage = {
-      id: ts,
-      sessionKey: conversationId,
-      conversationKind: "direct",
-      userId,
-      userName,
-      text,
-      attachments: [],
-    };
-
-    const responseCtx: ChatResponseContext = {
-      respond: async (responseText: string) => {
-        const messageTs = await this.postMessage(conversationId, responseText);
-        this.logBotResponse(conversationId, responseText, messageTs);
-      },
-      replaceResponse: async (responseText: string) => {
-        const messageTs = await this.postMessage(conversationId, responseText);
-        this.logBotResponse(conversationId, responseText, messageTs);
-      },
-      respondDiagnostic: async (responseText: string) => {
-        const messageTs = await this.postMessage(conversationId, responseText);
-        this.logBotResponse(conversationId, responseText, messageTs);
-      },
-      respondToolResult: async (result: ChatToolResult) => {
-        const duration = (result.durationMs / 1000).toFixed(1);
-        const text = `${result.isError ? "Error" : "Done"} ${result.toolName} (${duration}s)\n${result.result}`;
-        const messageTs = await this.postMessage(conversationId, text);
-        this.logBotResponse(conversationId, text, messageTs);
-      },
-      setTyping: async () => {},
-      setWorking: async () => {},
-      uploadFile: async (filePath: string, title?: string) => {
-        await this.uploadFile(conversationId, filePath, title);
-      },
-      deleteResponse: async () => {},
-    };
-
-    return {
-      message,
-      responseCtx,
-      platform: this.getPlatformInfo(),
-    };
-  }
-
-  private createPrivateSessionCommandAdapters(
-    conversationId: string,
-    userId: string,
-    userName: string | undefined,
-    text: string,
-    ts: string,
-    options: { ephemeralChannelId?: string },
+    options: { ephemeralChannelId?: string } = {},
   ): BotAdapters {
     const message: ChatMessage = {
       id: ts,
@@ -710,36 +575,24 @@ export class SlackBot implements Bot {
       attachments: [],
     };
 
-    let hasResponded = false;
-
-    const respondPrivately = async (responseText: string) => {
+    const respond = async (responseText: string) => {
       if (options.ephemeralChannelId) {
         await this.postEphemeral(options.ephemeralChannelId, userId, responseText);
         return;
       }
-
       const messageTs = await this.postMessage(conversationId, responseText);
       this.logBotResponse(conversationId, responseText, messageTs);
     };
 
     const responseCtx: ChatResponseContext = {
-      respond: async (responseText: string) => {
-        hasResponded = true;
-        await respondPrivately(responseText);
-      },
-      replaceResponse: async (responseText: string) => {
-        if (!hasResponded) {
-          hasResponded = true;
-        }
-        await respondPrivately(responseText);
-      },
-      respondDiagnostic: async (responseText: string) => {
-        await respondPrivately(responseText);
-      },
+      respond,
+      replaceResponse: respond,
+      respondDiagnostic: respond,
       respondToolResult: async (result: ChatToolResult) => {
         const duration = (result.durationMs / 1000).toFixed(1);
-        const formatted = `${result.isError ? "Error" : "Done"} ${result.toolName} (${duration}s)\n${result.result}`;
-        await respondPrivately(formatted);
+        await respond(
+          `${result.isError ? "Error" : "Done"} ${result.toolName} (${duration}s)\n${result.result}`,
+        );
       },
       setTyping: async () => {},
       setWorking: async () => {},
@@ -820,7 +673,7 @@ export class SlackBot implements Bot {
       sessionKey: targetChannelId,
     };
 
-    const adapters = this.createDirectCommandAdapters(
+    const adapters = this.createCommandAdapters(
       targetChannelId,
       payload.user_id,
       userName,
@@ -900,7 +753,7 @@ export class SlackBot implements Bot {
       sessionKey,
     };
 
-    const adapters = this.createPrivateSessionCommandAdapters(
+    const adapters = this.createCommandAdapters(
       conversationId,
       payload.user_id,
       userName,

--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -5,6 +5,7 @@ import type { Bot, BotEvent, BotHandler, PlatformInfo } from "../../adapter.js";
 import * as log from "../../log.js";
 import { resolveChatSessionKey } from "../../session-policy.js";
 import { formatAlreadyWorking, formatNothingRunning } from "../../ui-copy.js";
+import { ChannelQueue } from "../shared.js";
 import { createTelegramAdapters } from "./context.js";
 import { escapeTelegramHtml } from "./html.js";
 
@@ -28,39 +29,6 @@ interface MessageContext {
   msgId: string;
   threadTs: string | undefined;
   sessionKey: string;
-}
-
-// ============================================================================
-// Per-channel queue for sequential processing
-// ============================================================================
-
-type QueuedWork = () => Promise<void>;
-
-class ChannelQueue {
-  private queue: QueuedWork[] = [];
-  private processing = false;
-
-  enqueue(work: QueuedWork): void {
-    this.queue.push(work);
-    this.processNext();
-  }
-
-  size(): number {
-    return this.queue.length;
-  }
-
-  private async processNext(): Promise<void> {
-    if (this.processing || this.queue.length === 0) return;
-    this.processing = true;
-    const work = this.queue.shift()!;
-    try {
-      await work();
-    } catch (err) {
-      log.logWarning("Telegram queue error", err instanceof Error ? err.message : String(err));
-    }
-    this.processing = false;
-    this.processNext();
-  }
 }
 
 // ============================================================================
@@ -341,7 +309,7 @@ export class TelegramBot implements Bot {
   private getQueue(channelId: string): ChannelQueue {
     let queue = this.queues.get(channelId);
     if (!queue) {
-      queue = new ChannelQueue();
+      queue = new ChannelQueue("Telegram");
       this.queues.set(channelId, queue);
     }
     return queue;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -447,6 +447,8 @@ export async function createRunner(
       sandboxConfig.type === "image")
       ? new ActorExecutionResolver(sandboxConfig, vaultManager, bindingStore, provisioner)
       : undefined;
+  // activeExecutor is replaced at the start of each run() call when executionResolver
+  // is present, so the stable `executor` wrapper always delegates to the latest resolved value.
   let activeExecutor: Executor =
     executionResolver !== undefined
       ? createExecutor({ type: "host" })

--- a/src/main.ts
+++ b/src/main.ts
@@ -276,13 +276,9 @@ const sessionViewTokenStore = new InMemorySessionViewTokenStore();
 setInterval(() => linkTokenStore.purge(), 5 * 60 * 1000).unref();
 setInterval(() => sessionViewTokenStore.purge(), 5 * 60 * 1000).unref();
 
-function normalizePortalBaseUrl(): string | undefined {
-  if (MOM_LINK_URL) {
-    return MOM_LINK_URL.replace(/\/+$/, "");
-  }
-  if (MOM_LINK_PORT) {
-    return `http://localhost:${MOM_LINK_PORT}`;
-  }
+function portalBaseUrl(): string | undefined {
+  if (MOM_LINK_URL) return MOM_LINK_URL.replace(/\/+$/, "");
+  if (MOM_LINK_PORT) return `http://localhost:${MOM_LINK_PORT}`;
   return undefined;
 }
 
@@ -335,7 +331,7 @@ async function handleLoginCommand(
     return true;
   }
 
-  const baseUrl = normalizePortalBaseUrl();
+  const baseUrl = portalBaseUrl();
   if (!baseUrl) {
     await replyWithContext(
       responseCtx,
@@ -413,7 +409,7 @@ async function handleSessionViewCommand(
     return true;
   }
 
-  const baseUrl = normalizePortalBaseUrl();
+  const baseUrl = portalBaseUrl();
   if (!baseUrl) {
     await sendSessionViewReply(
       "Session viewer is not configured. Set `MOM_LINK_URL` or `MOM_LINK_PORT` on the server.",

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -274,12 +274,10 @@ export class FileVaultManager implements VaultManager {
   }
 
   addEntry(key: string, entry: VaultEntry): void {
-    if (!this.config) {
-      this.config = { vaults: {} };
-    }
+    const cfg = (this.config ??= { vaults: {} });
     // Idempotent: skip if already exists
-    if (this.config.vaults[key]) return;
-    this.config.vaults[key] = entry;
+    if (cfg.vaults[key]) return;
+    cfg.vaults[key] = entry;
     this.persistConfig();
   }
 
@@ -288,13 +286,10 @@ export class FileVaultManager implements VaultManager {
       throw new Error(`vault: ensureImageSandboxEntry requires sandbox.type=image for "${key}"`);
     }
 
-    if (!this.config) {
-      this.config = { vaults: {} };
-    }
-
-    const existing = this.config.vaults[key];
+    const cfg = (this.config ??= { vaults: {} });
+    const existing = cfg.vaults[key];
     if (!existing) {
-      this.config.vaults[key] = entry;
+      cfg.vaults[key] = entry;
       this.persistConfig();
       return;
     }
@@ -323,11 +318,9 @@ export class FileVaultManager implements VaultManager {
       changed = true;
     }
 
-    if (!changed) {
-      return;
-    }
+    if (!changed) return;
 
-    this.config.vaults[key] = nextEntry;
+    cfg.vaults[key] = nextEntry;
     this.persistConfig();
   }
 


### PR DESCRIPTION
- Extract ChannelQueue and withRetry to adapters/shared.ts — removes 3 identical copies
- Merge createDirectCommandAdapters + createPrivateSessionCommandAdapters into one
  createCommandAdapters(options = {}) in slack/bot.ts
- Use `const cfg = (this.config ??= { vaults: {} })` in vault.ts addEntry and
  ensureImageSandboxEntry to share config init without a separate helper
- Rename normalizePortalBaseUrl → portalBaseUrl in main.ts (shorter, no redundancy)
- Add comment on activeExecutor mutation pattern in agent.ts

Net: -139 lines

https://claude.ai/code/session_012rxMpExdQF7iRjzUKoW8JT