### PR TITLE
refactor: simplify command dispatch, token stores, and re-exports

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -49,10 +49,6 @@ export interface ChatAdapter {
   getPlatformInfo(): PlatformInfo;
 }
 
-// ============================================================================
-// Generic cross-platform event and bot interfaces
-// ============================================================================
-
 /**
  * A platform-agnostic event (message/mention) that triggers the agent.
  */

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -12,10 +12,6 @@ import { join } from "path";
 import type { BotHandler } from "../adapter.js";
 import * as log from "../log.js";
 
-// ============================================================================
-// Per-channel queue for sequential processing
-// ============================================================================
-
 export class ChannelQueue {
   private queue: Array<() => Promise<void>> = [];
   private processing = false;
@@ -47,10 +43,6 @@ export class ChannelQueue {
     this.processNext();
   }
 }
-
-// ============================================================================
-// Exponential backoff retry utility
-// ============================================================================
 
 export interface RetryOptions {
   /** Predicate that returns true when an error indicates a platform-side rate limit. */
@@ -118,10 +110,6 @@ export function splitText(
   return parts;
 }
 
-// ============================================================================
-// Per-conversation log.jsonl appender
-// ============================================================================
-
 /**
  * Append a JSON-serializable entry to `${workingDir}/${channel}/log.jsonl`,
  * creating the directory on first use. This is the single write path every
@@ -151,10 +139,6 @@ export function appendBotResponseLog(
     isBot: true,
   });
 }
-
-// ============================================================================
-// Stop-target resolution
-// ============================================================================
 
 export interface ResolveStopTargetInput {
   handler: BotHandler;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -33,7 +33,7 @@ import {
   type Executor,
   type RuntimePathContext,
   type SandboxConfig,
-} from "./sandbox.js";
+} from "./sandbox/index.js";
 import { createMountedRuntimePathContext } from "./sandbox/path-context.js";
 import { addLifecycleBreadcrumb, metricAttributes } from "./sentry.js";
 import type { VaultManager } from "./vault.js";
@@ -1293,10 +1293,6 @@ function extractToolResultText(result: unknown): string {
 
   return JSON.stringify(result);
 }
-
-// ============================================================================
-// Agent runner
-// ============================================================================
 
 /**
  * Create a new AgentRunner for a channel.

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,20 +2,20 @@ import { AutoReplyCommandHandler } from "./auto-reply.js";
 import { LoginCommandHandler } from "./login.js";
 import { ModelCommandHandler } from "./model.js";
 import { NewCommandHandler } from "./new.js";
-import { CommandRegistry } from "./registry.js";
 import { SandboxCommandHandler } from "./sandbox.js";
 import { SessionViewCommandHandler } from "./session-view.js";
+import type { CommandHandler } from "./types.js";
 
-export { CommandRegistry } from "./registry.js";
+export { dispatchCommand } from "./registry.js";
 export type { CommandContext, CommandHandler, CommandServices } from "./types.js";
 
-export function createDefaultCommandRegistry(): CommandRegistry {
-  return new CommandRegistry([
+export function defaultCommandHandlers(): CommandHandler[] {
+  return [
     new LoginCommandHandler(),
     new SessionViewCommandHandler(),
     new AutoReplyCommandHandler(),
     new ModelCommandHandler(),
     new SandboxCommandHandler(),
     new NewCommandHandler(),
-  ]);
+  ];
 }

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,14 +1,12 @@
 import type { CommandContext, CommandHandler } from "./types.js";
 
-export class CommandRegistry {
-  constructor(private readonly handlers: readonly CommandHandler[]) {}
-
-  async handle(context: CommandContext): Promise<boolean> {
-    for (const handler of this.handlers) {
-      if (await handler.tryHandle(context)) {
-        return true;
-      }
-    }
-    return false;
+/** Run handlers in order, returning true as soon as one accepts the command. */
+export async function dispatchCommand(
+  handlers: readonly CommandHandler[],
+  context: CommandContext,
+): Promise<boolean> {
+  for (const handler of handlers) {
+    if (await handler.tryHandle(context)) return true;
   }
+  return false;
 }

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,7 +1,7 @@
 import type { Bot, BotAdapters, PlatformName } from "../adapter.js";
 import type { DockerContainerManager } from "../provisioner.js";
 import type { SessionRuntime } from "../runtime/session-runtime.js";
-import type { SandboxConfig } from "../sandbox.js";
+import type { SandboxConfig } from "../sandbox/index.js";
 import type { VaultManager } from "../vault.js";
 
 export interface LinkTokenStoreLike {

--- a/src/events.ts
+++ b/src/events.ts
@@ -15,10 +15,6 @@ import { ensureDirExists, isRecord, parseJsonValue } from "./file-guards.js";
 import * as log from "./log.js";
 import { inferConversationKind } from "./session-policy.js";
 
-// ============================================================================
-// Event Types
-// ============================================================================
-
 export interface ImmediateEvent {
   type: "immediate";
   platform: string;
@@ -63,10 +59,6 @@ export interface PeriodicEventInfo {
   timezone: string;
   nextRun: string | null; // ISO 8601
 }
-
-// ============================================================================
-// EventsWatcher
-// ============================================================================
 
 const DEBOUNCE_MS = 100;
 const MAX_RETRIES = 3;

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { loadAgentConfig, loadAgentConfigForConversation } from "./config.js";
 import { ensureDirExists, isRecord, readJsonFileIfExists } from "./file-guards.js";
 import { DockerContainerManager, type ContainerMount } from "./provisioner.js";
-import { createExecutor, type Executor, type SandboxConfig } from "./sandbox.js";
+import { createExecutor, type Executor, type SandboxConfig } from "./sandbox/index.js";
 import type { ResolvedVault, VaultManager } from "./vault.js";
 import { resolveActorVaultKey } from "./vault-routing.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { createDefaultCommandRegistry, CommandRegistry } from "./commands/index.js";
+export { defaultCommandHandlers, dispatchCommand } from "./commands/index.js";
 export type { CommandContext, CommandHandler, CommandServices } from "./commands/index.js";
 export {
   createSessionRuntime,

--- a/src/login/session.ts
+++ b/src/login/session.ts
@@ -1,8 +1,6 @@
 import { randomBytes } from "crypto";
 import type { PlatformName } from "../adapter.js";
 
-// ── Types ──────────────────────────────────────────────────────────────────────
-
 export interface LinkToken {
   token: string;
   platform: PlatformName;
@@ -12,19 +10,16 @@ export interface LinkToken {
   /** Conversation to notify when binding completes */
   conversationId: string;
   expiresAt: number;
-  used: boolean;
 }
 
-const TTL_MS = 15 * 60 * 1000; // 15 minutes
-
-// ── InMemoryLinkTokenStore ─────────────────────────────────────────────────────
+const TTL_MS = 15 * 60 * 1000;
 
 export class InMemoryLinkTokenStore {
   private tokens = new Map<string, LinkToken>();
 
   /**
    * Create a link token for a platform user.
-   * Invalidates any existing unused token for the same user before creating a new one.
+   * Invalidates any existing token for the same user before creating a new one.
    */
   create(
     platform: PlatformName,
@@ -33,7 +28,6 @@ export class InMemoryLinkTokenStore {
     vaultId: string,
     providerId: string,
   ): LinkToken {
-    // Invalidate any existing token for this user so old links stop working
     for (const [key, t] of this.tokens) {
       if (t.platform === platform && t.platformUserId === platformUserId) {
         this.tokens.delete(key);
@@ -48,43 +42,32 @@ export class InMemoryLinkTokenStore {
       providerId,
       conversationId,
       expiresAt: Date.now() + TTL_MS,
-      used: false,
     };
     this.tokens.set(token.token, token);
     return token;
   }
 
-  /**
-   * Peek at a token without consuming it. Returns undefined if invalid or expired.
-   * Use this for read-only lookups (e.g. rendering the link page).
-   */
+  /** Look up a token without consuming it. Returns undefined if missing or expired. */
   peek(rawToken: string): LinkToken | undefined {
     const entry = this.tokens.get(rawToken);
-    if (!entry || entry.used || Date.now() > entry.expiresAt) return undefined;
+    if (!entry || Date.now() > entry.expiresAt) return undefined;
     return entry;
   }
 
-  /**
-   * Consume a token: validate, mark used, and return the token data.
-   * Returns undefined if the token is invalid, expired, or already used.
-   */
+  /** Consume a token (one-shot). Returns undefined if missing or expired. */
   consume(rawToken: string): LinkToken | undefined {
     const entry = this.tokens.get(rawToken);
     if (!entry) return undefined;
-    if (entry.used || Date.now() > entry.expiresAt) {
-      this.tokens.delete(rawToken);
-      return undefined;
-    }
-    entry.used = true;
     this.tokens.delete(rawToken);
+    if (Date.now() > entry.expiresAt) return undefined;
     return entry;
   }
 
-  /** Remove expired or used tokens. Call periodically to bound memory usage. */
+  /** Remove expired tokens. Call periodically to bound memory usage. */
   purge(): void {
     const now = Date.now();
     for (const [key, t] of this.tokens) {
-      if (t.used || now > t.expiresAt) {
+      if (now > t.expiresAt) {
         this.tokens.delete(key);
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,17 +20,17 @@ import { InMemorySessionViewTokenStore } from "./session-view/store.js";
 import { DockerContainerManager } from "./provisioner.js";
 import { createGlobalSettingsFile, loadAgentConfig, MissingGlobalSettingsError } from "./config.js";
 import { ensureDirExists, isRecord, readJsonFileIfExists } from "./file-guards.js";
-import { SandboxError, parseSandboxArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
+import {
+  SandboxError,
+  parseSandboxArg,
+  type SandboxConfig,
+  validateSandbox,
+} from "./sandbox/index.js";
 import { FileVaultManager } from "./vault.js";
 import { createSessionRuntime } from "./runtime/index.js";
 import { ChannelStore } from "./store.js";
 import * as Sentry from "@sentry/node";
 
-// ============================================================================
-// Config
-// ============================================================================
-
-// Get version from package.json
 function getVersion(): string {
   // Try to find package.json in the dist directory or parent
   const possiblePaths = [
@@ -324,10 +324,6 @@ const handler = createSessionRuntime({
   portalBaseUrl: portalBaseUrl(),
 });
 
-// ============================================================================
-// Start
-// ============================================================================
-
 const sandboxDesc =
   sandbox.type === "host"
     ? "host"
@@ -340,7 +336,6 @@ const sandboxDesc =
           : `cloudflare:${sandbox.sandboxId}`;
 log.logStartup(workingDir, sandboxDesc);
 
-// Create platform bots
 const bots: Bot[] = [];
 const botsByPlatform: Record<string, Bot> = {};
 

--- a/src/runtime/conversation-orchestrator.ts
+++ b/src/runtime/conversation-orchestrator.ts
@@ -4,8 +4,8 @@ import {
   waitForSlackBranchBootstrap,
 } from "../adapters/slack/branch-manager.js";
 import type { AgentRunner } from "../agent.js";
-import type { CommandRegistry } from "../commands/index.js";
-import type { CommandServices } from "../commands/index.js";
+import { dispatchCommand } from "../commands/index.js";
+import type { CommandHandler, CommandServices } from "../commands/index.js";
 import { isPrivateConversation } from "../commands/utils.js";
 import * as log from "../log.js";
 import { addLifecycleBreadcrumb, applyRunScope } from "../sentry.js";
@@ -32,7 +32,7 @@ export interface RunConversationOptions {
 
 interface ConversationOrchestratorOptions {
   workingDir: string;
-  commandRegistry: CommandRegistry;
+  commandHandlers: readonly CommandHandler[];
   commandServices: CommandServices;
   isShuttingDown: () => boolean;
   getState: (sessionKey: string) => ConversationRuntimeState | undefined;
@@ -65,7 +65,7 @@ export class ConversationOrchestrator {
 
     const sessionKey = event.sessionKey ?? `${conversationId}:${event.thread_ts ?? event.ts}`;
     const privateConversation = isPrivateConversation(event);
-    const handledCommand = await this.options.commandRegistry.handle({
+    const handledCommand = await dispatchCommand(this.options.commandHandlers, {
       bot,
       responseCtx: adapters.responseCtx,
       platform: adapters.platform.name as PlatformName,

--- a/src/runtime/session-runtime.ts
+++ b/src/runtime/session-runtime.ts
@@ -1,8 +1,8 @@
 import type { Bot, BotAdapters, BotEvent, BotHandler, RunningSession } from "../adapter.js";
 import { resolveSlackSessionScope } from "../adapters/slack/branch-manager.js";
 import { type AgentRunner, createRunner } from "../agent.js";
-import { CommandRegistry, createDefaultCommandRegistry } from "../commands/index.js";
-import type { CommandServices } from "../commands/index.js";
+import { defaultCommandHandlers } from "../commands/index.js";
+import type { CommandHandler, CommandServices } from "../commands/index.js";
 import * as log from "../log.js";
 import {
   createManagedSessionFile,
@@ -36,9 +36,9 @@ export interface CreateSessionSandboxOptions {
   sessionKey: string;
 }
 
-export interface SessionRuntimeOptions extends CommandServices {
-  /** Override the default command registry (e.g., to add /help, /status). */
-  commandRegistry?: CommandRegistry;
+export interface SessionRuntimeOptions extends Omit<CommandServices, "runtime"> {
+  /** Override the default command handlers (e.g., to add /help, /status). */
+  commandHandlers?: readonly CommandHandler[];
 }
 
 export interface SessionRuntime extends BotHandler {
@@ -71,17 +71,16 @@ class MamaSessionRuntime implements SessionRuntime {
   private readonly conversationStates = new Map<string, ConversationState>();
   private readonly sessionQueues = new Map<string, Promise<void>>();
   private readonly inFlightRuns = new Set<Promise<void>>();
-  private readonly commandRegistry: CommandRegistry;
   private readonly orchestrator: ConversationOrchestrator;
   private isShuttingDown = false;
 
   constructor(private readonly options: SessionRuntimeOptions) {
-    this.options.runtime = this;
-    this.commandRegistry = options.commandRegistry ?? createDefaultCommandRegistry();
+    const commandServices: CommandServices = { ...options, runtime: this };
+    const commandHandlers = options.commandHandlers ?? defaultCommandHandlers();
     this.orchestrator = new ConversationOrchestrator({
       workingDir: options.workingDir,
-      commandRegistry: this.commandRegistry,
-      commandServices: this.options,
+      commandHandlers,
+      commandServices,
       isShuttingDown: () => this.isShuttingDown,
       getState: (sessionKey) => this.conversationStates.get(sessionKey),
       getOrCreateState: (createOptions) => this.getOrCreateState(createOptions),

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -1,1 +1,0 @@
-export * from "./sandbox/index.js";

--- a/src/session-view/store.ts
+++ b/src/session-view/store.ts
@@ -41,10 +41,7 @@ export class InMemorySessionViewTokenStore {
 
   peek(rawToken: string): SessionViewToken | undefined {
     const entry = this.tokens.get(rawToken);
-    if (!entry || Date.now() > entry.expiresAt) {
-      if (entry) this.tokens.delete(rawToken);
-      return undefined;
-    }
+    if (!entry || Date.now() > entry.expiresAt) return undefined;
     return entry;
   }
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@sinclair/typebox";
-import type { Executor } from "../sandbox.js";
+import type { Executor } from "../sandbox/index.js";
 import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -1,7 +1,7 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import * as Diff from "diff";
-import type { Executor } from "../sandbox.js";
+import type { Executor } from "../sandbox/index.js";
 
 /**
  * Generate a unified diff string with line numbers and context

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,6 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { createAttachTool } from "../adapters/slack/tools/attach.js";
-import type { Executor } from "../sandbox.js";
+import type { Executor } from "../sandbox/index.js";
 import { createBashTool } from "./bash.js";
 import { createEditTool } from "./edit.js";
 import { createEventTool, HostEventStore } from "./event.js";

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -2,7 +2,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { Type } from "@sinclair/typebox";
 import { extname } from "path";
-import type { Executor } from "../sandbox.js";
+import type { Executor } from "../sandbox/index.js";
 import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -1,6 +1,6 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@sinclair/typebox";
-import type { Executor } from "../sandbox.js";
+import type { Executor } from "../sandbox/index.js";
 
 const writeSchema = Type.Object({
   label: Type.String({ description: "Brief description of what you're writing (shown to user)" }),

--- a/src/vault-routing.ts
+++ b/src/vault-routing.ts
@@ -1,5 +1,5 @@
 import { DockerContainerManager } from "./provisioner.js";
-import type { SandboxConfig } from "./sandbox.js";
+import type { SandboxConfig } from "./sandbox/index.js";
 export function resolveActorVaultKey(
   baseConfig: SandboxConfig,
   userId: string,

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -9,7 +9,7 @@ import {
 } from "fs";
 import { dirname, isAbsolute, join, normalize, sep } from "path";
 import { readTextFileIfExists } from "./file-guards.js";
-import type { SandboxConfig } from "./sandbox.js";
+import type { SandboxConfig } from "./sandbox/index.js";
 import { atomicWritePrivateFile } from "./fs-atomic.js";
 
 const PRIVATE_DIR_MODE = 0o700;

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -4,14 +4,14 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { Bot, ChatResponseContext } from "../src/adapter.js";
 import { AutoReplyCommandHandler } from "../src/commands/auto-reply.js";
-import { CommandRegistry } from "../src/commands/registry.js";
+import { dispatchCommand } from "../src/commands/registry.js";
 import { LoginCommandHandler } from "../src/commands/login.js";
 import { NewCommandHandler } from "../src/commands/new.js";
 import { SandboxCommandHandler } from "../src/commands/sandbox.js";
 import { SessionViewCommandHandler } from "../src/commands/session-view.js";
 import type { CommandContext, CommandHandler, CommandServices } from "../src/commands/types.js";
 import { createManagedSessionFile, getChannelSessionDir } from "../src/session-store.js";
-import type { SandboxConfig } from "../src/sandbox.js";
+import type { SandboxConfig } from "../src/sandbox/index.js";
 import type { VaultManager } from "../src/vault.js";
 
 // ── Fakes ────────────────────────────────────────────────────────────────────
@@ -167,16 +167,13 @@ function buildContext(args: BuildContextArgs): CommandContext & {
   };
 }
 
-// ── CommandRegistry ──────────────────────────────────────────────────────────
-
-describe("CommandRegistry", () => {
+describe("dispatchCommand", () => {
   test("returns false when no handler accepts the command", async () => {
     const a: CommandHandler = { tryHandle: vi.fn(async () => false) };
     const b: CommandHandler = { tryHandle: vi.fn(async () => false) };
-    const registry = new CommandRegistry([a, b]);
     const ctx = buildContext({ commandText: "hello" });
 
-    const handled = await registry.handle(ctx);
+    const handled = await dispatchCommand([a, b], ctx);
 
     expect(handled).toBe(false);
     expect(a.tryHandle).toHaveBeenCalledOnce();
@@ -186,10 +183,9 @@ describe("CommandRegistry", () => {
   test("short-circuits on the first handler that accepts", async () => {
     const a: CommandHandler = { tryHandle: vi.fn(async () => true) };
     const b: CommandHandler = { tryHandle: vi.fn(async () => true) };
-    const registry = new CommandRegistry([a, b]);
     const ctx = buildContext({ commandText: "/login" });
 
-    const handled = await registry.handle(ctx);
+    const handled = await dispatchCommand([a, b], ctx);
 
     expect(handled).toBe(true);
     expect(a.tryHandle).toHaveBeenCalledOnce();
@@ -199,10 +195,9 @@ describe("CommandRegistry", () => {
   test("falls through to the next handler when the first declines", async () => {
     const a: CommandHandler = { tryHandle: vi.fn(async () => false) };
     const b: CommandHandler = { tryHandle: vi.fn(async () => true) };
-    const registry = new CommandRegistry([a, b]);
     const ctx = buildContext({ commandText: "/session" });
 
-    const handled = await registry.handle(ctx);
+    const handled = await dispatchCommand([a, b], ctx);
 
     expect(handled).toBe(true);
     expect(a.tryHandle).toHaveBeenCalledOnce();

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -7,7 +7,7 @@ import {
   SandboxError,
   createExecutor,
   parseSandboxArg,
-} from "../src/sandbox.js";
+} from "../src/sandbox/index.js";
 
 describe("parseSandboxArg", () => {
   afterEach(() => {

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -4,11 +4,11 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { BotHandler } from "../src/adapter.js";
 import { SlackBot } from "../src/adapters/slack/bot.js";
-import { createDefaultCommandRegistry } from "../src/commands/index.js";
+import { defaultCommandHandlers } from "../src/commands/index.js";
 import type { CommandServices } from "../src/commands/types.js";
 import { ConversationOrchestrator } from "../src/runtime/conversation-orchestrator.js";
 import { createManagedSessionFileAtPath, getThreadSessionFile } from "../src/session-store.js";
-import type { SandboxConfig } from "../src/sandbox.js";
+import type { SandboxConfig } from "../src/sandbox/index.js";
 import type { VaultManager } from "../src/vault.js";
 
 function makeHandler(): BotHandler {
@@ -298,7 +298,7 @@ describe("SlackBot slash commands", () => {
 
     const orchestrator = new ConversationOrchestrator({
       workingDir,
-      commandRegistry: createDefaultCommandRegistry(),
+      commandHandlers: defaultCommandHandlers(),
       commandServices: makeCommandServices(workingDir),
       isShuttingDown: () => false,
       getState: () => undefined,

--- a/test/vault.test.ts
+++ b/test/vault.test.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ActorExecutionResolver } from "../src/execution-resolver.js";
 import { DockerContainerManager } from "../src/provisioner.js";
-import { HostExecutor } from "../src/sandbox.js";
+import { HostExecutor } from "../src/sandbox/index.js";
 import { resolveActorVaultKey } from "../src/vault-routing.js";
 import { FileVaultManager, parseEnvFile, sharedVaultKey } from "../src/vault.js";
 


### PR DESCRIPTION
- Drop CommandRegistry class in favor of a plain `dispatchCommand`
  function; the class wrapped a one-line for-loop and added nothing.
- Delete src/sandbox.ts (a one-line `export *` proxy); callers now
  import from src/sandbox/index.js directly.
- Build CommandServices explicitly inside the runtime constructor
  instead of mutating the caller's options object with `runtime = this`.
- Remove the redundant `LinkToken.used` flag — consume/purge already
  delete the entry, so a separate flag is just another invariant
  to keep in sync.
- Stop mutating state from `peek()` in the session-view token store;
  expired entries are now handled by `purge()` only.
- Strip pure-noise banner comments from main/adapter/agent/events/
  adapters-shared.