### PR TITLE
fix(slack): anchor event fork sessions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,7 @@ flowchart LR
   Executor -. host / container / image / firecracker .-> ConversationDir
   Provisioner -. managed conversation sandbox .-> Executor
   VaultManager -. env + mount routing .-> Executor
-  EventsWatcher -. enqueue synthetic BotEvent .-> Main
+  EventsWatcher -. enqueue BotEvent .-> Main
 ```
 
 ## 2. 主要分層
@@ -241,6 +241,8 @@ sequenceDiagram
 - `sessions/*.jsonl` 給 `SessionManager` 保留完整結構化上下文與 tool 結果
 - top-level session 用 `current` 指標
 - thread / reply session 用固定檔名，讓分支可被單獨追蹤
+- Slack top-level messages share the channel session; Slack thread replies fork to `conversationId:threadTs`
+- Slack events first materialize a top-level anchor message, then run in `conversationId:anchorTs`
 
 ## 5. Login / Vault / Sandbox 關係
 
@@ -269,7 +271,7 @@ flowchart TD
 
 ## 6. Events 與一般對話的差異
 
-`events/*.json` 會被 `EventsWatcher` 監看，之後轉成 synthetic `BotEvent` 再走一次正常流程。  
+`events/*.json` 會被 `EventsWatcher` 監看，之後轉成 `BotEvent` 再走一次正常流程。
 也就是說 events 不是獨立執行器，而是「另一個訊息入口」。
 
 這讓下列能力共用同一套機制:

--- a/docs/events.md
+++ b/docs/events.md
@@ -64,40 +64,32 @@ Common schedules:
 
 ## Routing Fields
 
-| Field              | Description                                                                                                                                                                                                                            |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `platform`         | Target bot platform (e.g. `slack`)                                                                                                                                                                                                     |
-| `conversationId`   | Channel or DM ID to post into                                                                                                                                                                                                          |
-| `conversationKind` | `"shared"` (channel) or `"direct"` (DM)                                                                                                                                                                                                |
-| `userId`           | Platform user ID of whoever requested the event; used for vault/credential routing in per-user modes                                                                                                                                   |
-| `sessionKey`       | Determines which AgentRunner (and its LLM context) handles the event                                                                                                                                                                   |
-| `threadTs`         | Sub-conversation target; when present, the response is posted inside that thread rather than as a top-level message. Semantics are platform-specific: Slack thread timestamp, Discord thread channel ID, Telegram reply-to message ID. |
+| Field              | Description                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| `platform`         | Target bot platform (e.g. `slack`)                                                                   |
+| `conversationId`   | Channel or DM ID to post into                                                                        |
+| `conversationKind` | `"shared"` (channel) or `"direct"` (DM)                                                              |
+| `userId`           | Platform user ID of whoever requested the event; used for vault/credential routing in per-user modes |
 
 ## Session Binding
 
-`sessionKey` determines which AgentRunner (and its LLM context) handles an event when it fires. Whether it is included depends on the event type:
+Event files do not carry `sessionKey` or thread targeting. The event text must be self-contained because a scheduled/background event is not a continuation of the live chat turn that created it.
 
-- **Immediate** — included. The event is an extension of the current turn, so the same session context applies.
-- **One-shot** — omitted. A reminder firing hours or days later has no meaningful connection to the session it was created in; it simply delivers a message to the conversation.
-- **Periodic** — included. Recurring tasks often need the context from the session where they were configured.
+| Platform/event source   | Visible delivery          | Session key                            | Thread targeting |
+| ----------------------- | ------------------------- | -------------------------------------- | ---------------- |
+| Slack event file/tool   | New top-level anchor      | `<conversationId>:<anchor message ts>` | None             |
+| Slack direct `BotEvent` | Provided `thread_ts` wins | `<conversationId>:<thread_ts>` if set  | Optional         |
+| Other platform event    | Platform adapter default  | Platform adapter default event session | Adapter-specific |
+
+For Slack event files, firing an event actively creates a top-level Slack message first. That message timestamp becomes the fork point and the run uses the fixed session key `<conversationId>:<anchor message ts>`.
+
+This keeps event runs visible in the channel and isolates them from the persistent top-level session. The top-level channel history remains available in `log.jsonl` for explicit lookup, but it is not implicitly copied into the event session.
 
 ## Thread Targeting
 
-`threadTs` controls whether a response is posted as a top-level message or as a reply inside a sub-conversation (Slack thread, Discord thread, Telegram reply chain). The same per-type reasoning applies:
+Events are delivered as top-level messages. They should not be buried in a historical thread or reply chain.
 
-- **Immediate** — preserved. The reply belongs in the same sub-conversation as the current exchange.
-- **One-shot** — omitted. A reminder should be a prominent top-level message, not buried in a sub-conversation that may be days old.
-- **Periodic** — omitted. Recurring replies into an old sub-conversation create noise and reduce visibility.
-
-Summary:
-
-| Type        | `sessionKey` |    `threadTs`    |
-| ----------- | :----------: | :--------------: |
-| `immediate` |      ✓       | ✓ (if in thread) |
-| `one-shot`  |      —       |        —         |
-| `periodic`  |      ✓       |        —         |
-
-The `event` tool (available to the agent) fills all routing fields automatically and applies these rules. Use it instead of writing JSON by hand.
+The `event` tool (available to the agent) fills the routing fields automatically. Use it instead of writing JSON by hand.
 
 ## Lifecycle
 

--- a/e2e/slack/event-thread-fork.e2e.ts
+++ b/e2e/slack/event-thread-fork.e2e.ts
@@ -1,0 +1,99 @@
+import { mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { loadContextOrSkip } from "./helpers/client.js";
+import {
+  nowSeconds,
+  postMessage,
+  sleep,
+  summarizeMessage,
+  waitForRecentBotReply,
+  waitForThreadBotReply,
+} from "./helpers/slack.js";
+
+const ctx = loadContextOrSkip();
+
+describe.skipIf(!ctx || !ctx.env.mamaBotUserId)("Slack event thread fork", () => {
+  if (!ctx || !ctx.env.mamaBotUserId) return;
+  const { client, env } = ctx;
+  const botUserId = ctx.env.mamaBotUserId;
+
+  it("event creates a top-level anchor whose thread continues the fork session", async () => {
+    const eventToken = `QA_EVENT_FORK_${Date.now()}`;
+    const followupToken = `QA_EVENT_THREAD_${Date.now()}`;
+    const filename = `slack-e2e-event-thread-fork-${eventToken}.json`;
+    const at = new Date(Date.now() + 5_000).toISOString();
+    const startedAt = nowSeconds();
+
+    await mkdir(env.eventsDir, { recursive: true });
+    await writeFile(
+      join(env.eventsDir, filename),
+      JSON.stringify(
+        {
+          type: "one-shot",
+          platform: "slack",
+          conversationId: env.channel,
+          conversationKind: "shared",
+          text: `Event fork E2E. Reply with exactly this token: ${eventToken}`,
+          at,
+        },
+        null,
+        2,
+      ),
+    );
+
+    const eventReply = await waitForRecentBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      startedAt,
+      timeoutMs: Math.max(env.timeoutMs, 60_000),
+      pollMs: env.pollMs,
+      textIncludes: eventToken,
+    });
+    expect(eventReply, `no top-level event reply containing ${eventToken}`).not.toBeNull();
+
+    const anchorTs = String(eventReply!.ts);
+    expect(anchorTs).toMatch(/^\d+\.\d+$/);
+    expect(
+      !eventReply!.thread_ts || eventReply!.thread_ts === anchorTs,
+      `event reply should be top-level, got thread_ts=${eventReply!.thread_ts}`,
+    ).toBe(true);
+
+    await sleep(Math.max(env.pollMs, 3_000));
+
+    const threadStartedAt = nowSeconds();
+    // CI may post QA messages from a bot token. Use an explicit mention so this
+    // exercises the "mama needs to reply" thread-fork path without weakening
+    // bot-to-bot loop protection for bare bot messages.
+    const userThreadTs = await postMessage(
+      client,
+      env.channel,
+      `<@${botUserId}> Thread follow-up for event fork. Reply with exactly this token: ${followupToken}`,
+      anchorTs,
+    );
+
+    const threadReply = await waitForThreadBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      rootTs: anchorTs,
+      startedAt: threadStartedAt,
+      excludeTs: new Set([anchorTs, userThreadTs]),
+      timeoutMs: Math.max(env.timeoutMs, 60_000),
+      pollMs: env.pollMs,
+      textIncludes: followupToken,
+    });
+
+    expect(threadReply, `no event thread reply containing ${followupToken}`).not.toBeNull();
+    expect(String(threadReply!.thread_ts ?? anchorTs), "reply not anchored to event thread").toBe(
+      anchorTs,
+    );
+    expect(String(threadReply!.ts), "thread reply should not be the top-level anchor").not.toBe(
+      anchorTs,
+    );
+
+    console.log(`event anchor ts=${anchorTs}: ${summarizeMessage(eventReply!)}`);
+    console.log(`event thread reply ts=${threadReply!.ts}: ${summarizeMessage(threadReply!)}`);
+  });
+});

--- a/e2e/slack/helpers/slack.ts
+++ b/e2e/slack/helpers/slack.ts
@@ -148,12 +148,25 @@ export interface WaitForThreadBotReplyOptions {
   excludeTs: Set<string>;
   timeoutMs: number;
   pollMs: number;
+  textIncludes?: string;
+  textMatches?: RegExp;
 }
 
 export async function waitForThreadBotReply(
   opts: WaitForThreadBotReplyOptions,
 ): Promise<SlackMessage | null> {
-  const { client, channel, botUserId, rootTs, startedAt, excludeTs, timeoutMs, pollMs } = opts;
+  const {
+    client,
+    channel,
+    botUserId,
+    rootTs,
+    startedAt,
+    excludeTs,
+    timeoutMs,
+    pollMs,
+    textIncludes,
+    textMatches,
+  } = opts;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const threadMessages = await fetchThreadMessages(client, channel, rootTs).catch(
@@ -163,7 +176,13 @@ export async function waitForThreadBotReply(
       .filter((message) => String(message.ts) !== rootTs)
       .filter((message) => !excludeTs.has(String(message.ts)))
       .filter((message) => Number(message.ts) >= startedAt)
-      .find((message) => isTargetBotMessage(message, botUserId));
+      .filter((message) => isTargetBotMessage(message, botUserId))
+      .find((message) => {
+        const text = messageText(message);
+        if (textIncludes && !text.includes(textIncludes)) return false;
+        if (textMatches && !textMatches.test(text)) return false;
+        return true;
+      });
 
     if (reply) return reply;
     await sleep(pollMs);

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -121,12 +121,7 @@ export interface RunningSession {
 export interface BotHandler {
   isRunning(sessionKey: string): boolean;
   getRunningSessions(): RunningSession[];
-  handleEvent(
-    event: BotEvent,
-    bot: Bot,
-    adapters: BotAdapters,
-    isSyntheticEvent?: boolean,
-  ): Promise<void>;
+  handleEvent(event: BotEvent, bot: Bot, adapters: BotAdapters): Promise<void>;
   handleStop(sessionKey: string, conversationId: string, bot: Bot): Promise<void>;
   /** Force stop a running session (bypass normal stop mechanism) */
   forceStop(sessionKey: string): void;

--- a/src/adapters/discord/bot.ts
+++ b/src/adapters/discord/bot.ts
@@ -183,8 +183,8 @@ export class DiscordBot implements Bot {
     }
     log.logInfo(`Enqueueing event for ${conversationId}: ${event.text.substring(0, 50)}`);
     queue.enqueue(() => {
-      const adapters = createDiscordAdapters(event as DiscordEvent, this, true);
-      return this.handler.handleEvent(event, this, adapters, true);
+      const adapters = createDiscordAdapters(event as DiscordEvent, this);
+      return this.handler.handleEvent(event, this, adapters);
     });
     return true;
   }
@@ -583,7 +583,7 @@ export class DiscordBot implements Bot {
           attachments: [],
         };
 
-        await this.handler.handleEvent(event, this, adapters, false);
+        await this.handler.handleEvent(event, this, adapters);
       } catch (err) {
         log.logWarning(
           "Discord slash command error",
@@ -697,8 +697,8 @@ export class DiscordBot implements Bot {
       this.logToFile(conversationId, { ...logEntryBase, attachments: processedAttachments });
 
       this.getQueue(sessionKey).enqueue(() => {
-        const adapters = createDiscordAdapters(event, this, false);
-        return this.handler.handleEvent(event, this, adapters, false);
+        const adapters = createDiscordAdapters(event, this);
+        return this.handler.handleEvent(event, this, adapters);
       });
     });
   }

--- a/src/adapters/discord/context.ts
+++ b/src/adapters/discord/context.ts
@@ -37,7 +37,6 @@ function formatToolResult(result: ChatToolResult): string {
 export function createDiscordAdapters(
   event: DiscordEvent,
   bot: DiscordBot,
-  _isSyntheticEvent?: boolean,
 ): {
   message: ChatMessage;
   responseCtx: ChatResponseContext;

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -32,7 +32,6 @@ export interface ChatResponseErrorContext {
   threadTs?: string;
   replyTargetId?: string;
   replyToId?: number | null;
-  isSyntheticEvent?: boolean;
   isThreaded?: boolean;
   extra?: Record<string, unknown>;
 }
@@ -69,7 +68,6 @@ export function reportChatResponseError(err: unknown, context: ChatResponseError
       replyTargetId: context.replyTargetId,
       replyToId: context.replyToId,
       conversationKind: context.conversationKind,
-      isSyntheticEvent: context.isSyntheticEvent,
       isThreaded: context.isThreaded,
       ...context.extra,
     },

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -1,6 +1,6 @@
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
-import { existsSync, linkSync, readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { basename, join } from "path";
 import type {
@@ -26,11 +26,18 @@ import {
   resolveStopTarget,
   withRetry,
 } from "../shared.js";
-import { getThreadSessionFile } from "../../session-store.js";
 import { evaluateAutoReplyPolicy } from "../../trigger.js";
 import { createSlackAdapters } from "./context.js";
-import { hasMaterializedSlackBranchSession } from "./branch-manager.js";
-import { resolveSlackSessionKey } from "./session.js";
+import { hasMaterializedSlackBranchSession, registerSlackForkSession } from "./branch-manager.js";
+import {
+  isSlackForkSessionKey,
+  planSlackAdapterSession,
+  planSlackEventForkRun,
+  resolveSlackSessionKey,
+} from "./session.js";
+import { reportUserFacingError } from "../../sentry.js";
+
+const SLACK_EVENT_ANCHOR_TEXT = "Working on it...";
 
 // Slack WebClient errors carry either `code: "rate_limited"` (retry-after) or
 // the legacy `data.error === "rate_limited"` / 429 status shape.
@@ -419,29 +426,6 @@ export class SlackBot implements Bot {
     appendBotResponseLog(this.workingDir, channel, text, ts, threadTs);
   }
 
-  aliasSyntheticEventThread(channel: string, threadTs: string, eventTs: string): void {
-    const conversationDir = join(this.workingDir, channel);
-    const source = getThreadSessionFile(conversationDir, `${channel}:${eventTs}`);
-    const target = getThreadSessionFile(conversationDir, `${channel}:${threadTs}`);
-    if (source === target) return;
-
-    try {
-      linkSync(source, target);
-      log.logInfo(`Aliased synthetic event session ${source} -> ${target}`);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "EEXIST") return;
-      if (code === "ENOENT") {
-        log.logWarning(`Cannot alias synthetic event session; source missing: ${source}`);
-        return;
-      }
-      log.logWarning(
-        `Failed to alias synthetic event session ${source} -> ${target}`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-  }
-
   getPlatformInfo(): PlatformInfo {
     return {
       name: "slack",
@@ -477,24 +461,65 @@ export class SlackBot implements Bot {
       return false;
     }
     log.logInfo(`Enqueueing event for ${conversationId}: ${event.text.substring(0, 50)}`);
-    queue.enqueue(() => {
-      const slackEvent: SlackEvent = {
-        type: event.type as SlackEvent["type"],
-        conversationId,
-        conversationKind: event.conversationKind,
-        channel: conversationId,
-        ts: event.ts,
-        thread_ts: event.thread_ts,
-        user: event.user,
-        text: event.text,
-        attachments: event.attachments?.map((attachment) => ({
-          original: attachment.name,
-          localPath: attachment.localPath,
-        })),
-        sessionKey: event.sessionKey,
-      };
-      const adapters = createSlackAdapters(slackEvent, this, true);
-      return this.handler.handleEvent(event, this, adapters, true);
+    queue.enqueue(async () => {
+      let anchorTs: string | undefined;
+      if (!event.thread_ts) {
+        try {
+          anchorTs = await this.postMessage(conversationId, SLACK_EVENT_ANCHOR_TEXT);
+        } catch (err) {
+          log.logWarning(
+            `Failed to post Slack event anchor for ${conversationId}`,
+            err instanceof Error ? err.message : String(err),
+          );
+          reportUserFacingError(err, {
+            domain: "events",
+            surface: "event_delivery",
+            operation: "slack_anchor_post",
+            severity: "error",
+            platform: "slack",
+            context: {
+              conversationId,
+              conversationKind: event.conversationKind,
+              eventTs: event.ts,
+              textLength: event.text.length,
+            },
+          });
+          throw err;
+        }
+      }
+      const eventPlan = planSlackEventForkRun(event, anchorTs);
+      const eventForRun = eventPlan.event;
+      if (eventPlan.initialMessageTs && eventForRun.sessionKey) {
+        registerSlackForkSession({
+          conversationDir: join(this.workingDir, conversationId),
+          sessionKey: eventForRun.sessionKey,
+        });
+      }
+
+      const runQueueKey = planSlackAdapterSession(eventForRun, {
+        initialMessageTs: eventPlan.initialMessageTs,
+      }).sessionKey;
+      this.getQueue(runQueueKey).enqueue(async () => {
+        const slackEvent: SlackEvent = {
+          type: eventForRun.type as SlackEvent["type"],
+          conversationId,
+          conversationKind: eventForRun.conversationKind,
+          channel: conversationId,
+          ts: eventForRun.ts,
+          thread_ts: eventForRun.thread_ts,
+          user: eventForRun.user,
+          text: eventForRun.text,
+          attachments: eventForRun.attachments?.map((attachment) => ({
+            original: attachment.name,
+            localPath: attachment.localPath,
+          })),
+          sessionKey: eventForRun.sessionKey,
+        };
+        const adapters = createSlackAdapters(slackEvent, this, {
+          initialMessageTs: eventPlan.initialMessageTs,
+        });
+        return this.handler.handleEvent(eventForRun, this, adapters);
+      });
     });
     return true;
   }
@@ -513,11 +538,13 @@ export class SlackBot implements Bot {
   }
 
   private resolveQueueKey(conversationId: string, sessionKey: string): string {
-    if (!sessionKey.includes(":")) return sessionKey;
-    if (sessionKey.includes(":event:")) return sessionKey;
-    return hasMaterializedSlackBranchSession(join(this.workingDir, conversationId), sessionKey)
-      ? sessionKey
-      : conversationId;
+    if (!isSlackForkSessionKey(sessionKey)) return sessionKey;
+    if (this.handler.isRunning(sessionKey)) return sessionKey;
+    return this.hasKnownForkSession(conversationId, sessionKey) ? sessionKey : conversationId;
+  }
+
+  private hasKnownForkSession(conversationId: string, sessionKey: string): boolean {
+    return hasMaterializedSlackBranchSession(join(this.workingDir, conversationId), sessionKey);
   }
 
   private shouldTriggerSharedThreadReply(channelId: string, threadTs?: string): boolean {
@@ -526,7 +553,7 @@ export class SlackBot implements Bot {
     const sessionKey = resolveSlackSessionKey(channelId, threadTs);
     if (this.handler.isRunning(sessionKey)) return true;
 
-    return hasMaterializedSlackBranchSession(join(this.workingDir, channelId), sessionKey);
+    return this.hasKnownForkSession(channelId, sessionKey);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -852,7 +879,7 @@ export class SlackBot implements Bot {
       isDirectMessage ? {} : { ephemeralChannelId: sourceChannelId },
     );
 
-    await this.handler.handleEvent(event, this, adapters, false);
+    await this.handler.handleEvent(event, this, adapters);
   }
 
   private async routeSlashNewCommand(payload: {
@@ -935,7 +962,7 @@ export class SlackBot implements Bot {
       isDirectMessage ? {} : { ephemeralChannelId: conversationId },
     );
 
-    await this.handler.handleEvent(event, this, adapters, false);
+    await this.handler.handleEvent(event, this, adapters);
   }
 
   private async routeSlashSandboxCommand(payload: {
@@ -1007,7 +1034,7 @@ export class SlackBot implements Bot {
         : { ephemeralChannelId: conversationId, threadTs: payload.thread_ts },
     );
 
-    await this.handler.handleEvent(event, this, adapters, false);
+    await this.handler.handleEvent(event, this, adapters);
   }
 
   private setupEventHandlers(): void {
@@ -1086,12 +1113,11 @@ export class SlackBot implements Bot {
 
       this.getQueue(this.resolveQueueKey(e.channel, sessionKey)).enqueue(async () => {
         slackEvent.attachments = await attachmentsPromise;
-        const adapters = createSlackAdapters(slackEvent, this, false);
+        const adapters = createSlackAdapters(slackEvent, this);
         return this.handler.handleEvent(
           slackEvent as unknown as import("../../adapter.js").BotEvent,
           this,
           adapters,
-          false,
         );
       });
 
@@ -1224,12 +1250,11 @@ export class SlackBot implements Bot {
         slackEvent.sessionKey = activeSessionKey;
         this.getQueue(this.resolveQueueKey(e.channel, activeSessionKey)).enqueue(async () => {
           slackEvent.attachments = await attachmentsPromise;
-          const adapters = createSlackAdapters(slackEvent, this, false);
+          const adapters = createSlackAdapters(slackEvent, this);
           return this.handler.handleEvent(
             slackEvent as unknown as import("../../adapter.js").BotEvent,
             this,
             adapters,
-            false,
           );
         });
       };

--- a/src/adapters/slack/branch-manager.ts
+++ b/src/adapters/slack/branch-manager.ts
@@ -1,7 +1,6 @@
 import {
   createManagedSessionFileAtPath,
   createThreadSessionFileFromRootMessage,
-  extractSessionSuffix,
   forkThreadSessionFile,
   forkThreadSessionFileFromRootMessage,
   getChannelSessionDir,
@@ -14,6 +13,7 @@ import {
   type ThreadRootMessage,
 } from "../../session-store.js";
 import { findLogMessageById, type ConversationLogMessage } from "../../context.js";
+import { parseSlackSessionKey } from "./session.js";
 
 export interface SlackBranchBootstrapWaitOptions {
   parentSessionKey: string;
@@ -33,6 +33,12 @@ export interface ResolveSlackSessionScopeOptions {
   sleep?: (ms: number) => Promise<void>;
   retryCount?: number;
   retryDelayMs?: number;
+}
+
+export interface RegisterSlackForkSessionOptions {
+  conversationDir: string;
+  sessionKey: string;
+  cwd?: string;
 }
 
 function defaultSleep(ms: number): Promise<void> {
@@ -93,8 +99,19 @@ export function hasMaterializedSlackBranchSession(
   conversationDir: string,
   sessionKey: string,
 ): boolean {
-  if (!sessionKey.includes(":")) return false;
+  if (parseSlackSessionKey(sessionKey).kind !== "fork") return false;
   return tryResolveThreadSession(getThreadSessionFile(conversationDir, sessionKey)) !== null;
+}
+
+export function registerSlackForkSession(options: RegisterSlackForkSessionOptions): string | null {
+  const { conversationDir, sessionKey } = options;
+  if (parseSlackSessionKey(sessionKey).kind !== "fork") return null;
+
+  const threadFile = getThreadSessionFile(conversationDir, sessionKey);
+  return (
+    tryResolveThreadSession(threadFile) ??
+    createManagedSessionFileAtPath(threadFile, options.cwd ?? conversationDir)
+  );
 }
 
 export async function waitForSlackBranchBootstrap(
@@ -109,7 +126,7 @@ export async function waitForSlackBranchBootstrap(
     pollMs = 100,
   } = options;
 
-  if (!sessionKey.includes(":")) return false;
+  if (parseSlackSessionKey(sessionKey).kind !== "fork") return false;
   if (sessionKey === parentSessionKey) return false;
   if (hasThreadSession()) return false;
 
@@ -135,7 +152,8 @@ export async function resolveSlackSessionScope(
   const cwd = options.cwd ?? conversationDir;
 
   const sessionDir = getChannelSessionDir(conversationDir);
-  if (!sessionKey.includes(":")) {
+  const sessionRef = parseSlackSessionKey(sessionKey);
+  if (sessionRef.kind === "channel") {
     return {
       sessionDir,
       contextFile: resolveManagedSessionFile(sessionDir, cwd),
@@ -143,7 +161,7 @@ export async function resolveSlackSessionScope(
     };
   }
 
-  const rootTs = extractSessionSuffix(sessionKey);
+  const rootTs = sessionRef.anchorTs;
   const threadRootLogMessage = await findLogMessageById(conversationDir, rootTs);
   const threadRootMessage = threadRootLogMessage ? buildThreadRootSeed(threadRootLogMessage) : null;
   const threadFile = getThreadSessionFile(conversationDir, sessionKey);

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -7,11 +7,15 @@ import type {
 import * as log from "../../log.js";
 import { createChatResponseErrorReporter, formatToolArgs, splitText } from "../shared.js";
 import type { SlackBot, SlackEvent } from "./bot.js";
-import { resolveSlackRootTs, resolveSlackSessionKey } from "./session.js";
+import { planSlackAdapterSession } from "./session.js";
 
 export const SLACK_FORMATTING_GUIDE = `## Slack Formatting (mrkdwn, NOT Markdown)
 Bold: *text*, Italic: _text_, Code: \`code\`, Block: \`\`\`code\`\`\`, Links: <url|text>
 Do NOT use **double asterisks** or [markdown](links).`;
+
+export interface SlackAdapterOptions {
+  initialMessageTs?: string;
+}
 
 const MAX_MAIN_LENGTH = 35000; // Best-effort streaming cap; final responses use Slack error-driven fallback.
 const MAX_THREAD_LENGTH = 20000;
@@ -21,10 +25,6 @@ const TRUNCATION_NOTE_INCREMENTAL =
   "\n\n_(message truncated, ask me to elaborate on specific parts)_";
 
 const formatSlackContinuation = (partNum: number): string => `_(continued ${partNum})_`;
-
-function isSlackMessageTs(ts: string | undefined): ts is string {
-  return typeof ts === "string" && /^\d+\.\d+$/.test(ts);
-}
 
 function isSlackMsgTooLong(err: unknown): boolean {
   const data = (err as { data?: { error?: string } } | undefined)?.data;
@@ -81,13 +81,16 @@ function formatSlackToolResult(result: ChatToolResult): string {
 export function createSlackAdapters(
   event: SlackEvent,
   slack: SlackBot,
-  isSyntheticEvent?: boolean,
+  adapterOptions: SlackAdapterOptions = {},
 ): {
   message: ChatMessage;
   responseCtx: ChatResponseContext;
   platform: PlatformInfo;
 } {
-  let messageTs: string | null = null;
+  const sessionPlan = planSlackAdapterSession(event, {
+    initialMessageTs: adapterOptions.initialMessageTs,
+  });
+  let messageTs: string | null = sessionPlan.initialMessageTs ?? null;
   let assistantStatusFailureWarned = false;
   const onAssistantStatusError = (label: string, err: unknown): void => {
     if (assistantStatusFailureWarned) return;
@@ -106,28 +109,17 @@ export function createSlackAdapters(
   const conversationId = event.conversationId;
   const user = slack.getUser(event.user);
 
-  // Synthetic event ts format: `event:<filename>`.
-  const eventFilename = isSyntheticEvent
-    ? event.ts.match(/^event:([^:]+(?:\.json)?)/)?.[1]
-    : undefined;
+  // Slack message timestamps are numeric; event-file triggers use `event:<filename>`.
+  const eventFilename = event.ts.match(/^event:([^:]+(?:\.json)?)/)?.[1];
 
-  const rootTs =
-    event.thread_ts ?? (isSlackMessageTs(event.ts) ? resolveSlackRootTs(event.ts) : undefined);
-  const isThreaded = !!event.thread_ts;
+  const { rootTs, isThreaded } = sessionPlan;
 
   /**
    * Post the first visible reply.
    * Default Slack behavior is now top-level channel replies.
    * If the triggering message is already inside a thread, stay in that thread.
-   * Synthetic event messages have no real Slack root ts, so they must post top-level.
    */
   const postFirstMessage = async (text: string): Promise<string> => {
-    if (isSyntheticEvent) {
-      if (event.thread_ts) {
-        return slack.postInThread(channelId, event.thread_ts, text);
-      }
-      return slack.postMessage(channelId, text);
-    }
     if (isThreaded && rootTs) {
       return slack.postInThread(channelId, rootTs, text);
     }
@@ -162,9 +154,7 @@ export function createSlackAdapters(
 
   const message: ChatMessage = {
     id: event.ts,
-    sessionKey: isSyntheticEvent
-      ? `${conversationId}:${event.ts}`
-      : (event.sessionKey ?? resolveSlackSessionKey(conversationId, event.thread_ts)),
+    sessionKey: sessionPlan.sessionKey,
     conversationKind: event.conversationKind,
     userId: event.user,
     userName: user?.userName,
@@ -197,7 +187,6 @@ export function createSlackAdapters(
     responseMessageId: messageTs,
     threadTs: rootTs,
     conversationKind: message.conversationKind,
-    isSyntheticEvent: Boolean(isSyntheticEvent),
     isThreaded,
   }));
 
@@ -225,9 +214,6 @@ export function createSlackAdapters(
             messageTs = await slack.postInThread(channelId, rootTs, displayText);
           } else {
             messageTs = await postFirstMessage(displayText);
-            if (isSyntheticEvent && !event.thread_ts && messageTs) {
-              slack.aliasSyntheticEventThread(channelId, messageTs, event.ts);
-            }
           }
 
           if (messageTs) {
@@ -267,9 +253,6 @@ export function createSlackAdapters(
               return;
             }
             messageTs = await postFirstMessage(body);
-            if (isSyntheticEvent && !event.thread_ts && messageTs) {
-              slack.aliasSyntheticEventThread(channelId, messageTs, event.ts);
-            }
           };
 
           accumulatedText = text;

--- a/src/adapters/slack/session.ts
+++ b/src/adapters/slack/session.ts
@@ -1,9 +1,58 @@
 import type { ConversationKind } from "../../adapter.js";
 import { resolveChatSessionKey } from "../../session-policy.js";
 
+interface SlackSessionEventLike {
+  conversationId: string;
+  ts: string;
+  thread_ts?: string;
+  sessionKey?: string;
+}
+
+export type SlackSessionRef =
+  | { kind: "channel"; channelId: string }
+  | { kind: "fork"; channelId: string; anchorTs: string };
+
+export interface SlackAdapterSessionPlan {
+  sessionKey: string;
+  rootTs?: string;
+  initialMessageTs?: string;
+  isThreaded: boolean;
+}
+
+export interface SlackEventForkRunPlan<T extends SlackSessionEventLike> {
+  event: T;
+  initialMessageTs?: string;
+}
+
+export function formatSlackSessionKey(ref: SlackSessionRef): string {
+  return ref.kind === "channel" ? ref.channelId : `${ref.channelId}:${ref.anchorTs}`;
+}
+
+export function parseSlackSessionKey(sessionKey: string): SlackSessionRef {
+  const separator = sessionKey.indexOf(":");
+  if (separator === -1) {
+    return { kind: "channel", channelId: sessionKey };
+  }
+  return {
+    kind: "fork",
+    channelId: sessionKey.slice(0, separator),
+    anchorTs: sessionKey.slice(separator + 1),
+  };
+}
+
+export function isSlackForkSessionKey(sessionKey: string): boolean {
+  return parseSlackSessionKey(sessionKey).kind === "fork";
+}
+
+export function resolveSlackSessionRef(channelId: string, threadTs?: string): SlackSessionRef {
+  return threadTs
+    ? { kind: "fork", channelId, anchorTs: threadTs }
+    : { kind: "channel", channelId };
+}
+
 export function resolveSlackSessionKey(channelId: string, threadTs?: string): string {
   const conversationKind: ConversationKind = channelId.startsWith("D") ? "direct" : "shared";
-  return resolveChatSessionKey({
+  const sessionKey = resolveChatSessionKey({
     conversationId: channelId,
     conversationKind,
     messageId: channelId,
@@ -11,8 +60,51 @@ export function resolveSlackSessionKey(channelId: string, threadTs?: string): st
     persistentTopLevel: true,
     scopeDirectThreads: true,
   });
+  return formatSlackSessionKey(parseSlackSessionKey(sessionKey));
 }
 
 export function resolveSlackRootTs(messageTs: string, threadTs?: string): string {
   return threadTs || messageTs;
+}
+
+export function isSlackMessageTs(ts: string | undefined): ts is string {
+  return typeof ts === "string" && /^\d+\.\d+$/.test(ts);
+}
+
+export function resolveSlackResponseRootTs(
+  event: Pick<SlackSessionEventLike, "ts" | "thread_ts">,
+): string | undefined {
+  return event.thread_ts ?? (isSlackMessageTs(event.ts) ? resolveSlackRootTs(event.ts) : undefined);
+}
+
+export function planSlackAdapterSession(
+  event: SlackSessionEventLike,
+  options: { initialMessageTs?: string } = {},
+): SlackAdapterSessionPlan {
+  const sessionKey =
+    event.sessionKey ?? resolveSlackSessionKey(event.conversationId, event.thread_ts);
+
+  return {
+    sessionKey,
+    rootTs: options.initialMessageTs ?? resolveSlackResponseRootTs(event),
+    initialMessageTs: options.initialMessageTs,
+    isThreaded: !!event.thread_ts,
+  };
+}
+
+export function planSlackEventForkRun<T extends SlackSessionEventLike>(
+  event: T,
+  anchorTs?: string,
+): SlackEventForkRunPlan<T> {
+  if (!anchorTs || event.thread_ts) {
+    return { event };
+  }
+
+  return {
+    event: {
+      ...event,
+      sessionKey: resolveSlackSessionKey(event.conversationId, anchorTs),
+    },
+    initialMessageTs: anchorTs,
+  };
 }

--- a/src/adapters/telegram/bot.ts
+++ b/src/adapters/telegram/bot.ts
@@ -149,8 +149,8 @@ export class TelegramBot implements Bot {
     }
     log.logInfo(`Enqueueing event for ${conversationId}: ${event.text.substring(0, 50)}`);
     queue.enqueue(() => {
-      const adapters = createTelegramAdapters(event as TelegramEvent, this, true);
-      return this.handler.handleEvent(event, this, adapters, true);
+      const adapters = createTelegramAdapters(event as TelegramEvent, this);
+      return this.handler.handleEvent(event, this, adapters);
     });
     return true;
   }
@@ -443,8 +443,8 @@ export class TelegramBot implements Bot {
         attachments: [],
         isBot: false,
       });
-      const adapters = createTelegramAdapters(event, this, false);
-      await this.handler.handleEvent(event, this, adapters, false);
+      const adapters = createTelegramAdapters(event, this);
+      await this.handler.handleEvent(event, this, adapters);
     });
 
     // --- Catch-all for regular (non-command) messages ---
@@ -518,8 +518,8 @@ export class TelegramBot implements Bot {
         await this.postMessage(mc.chatId, formatAlreadyWorking("telegram", "/stop"));
       } else {
         this.getQueue(mc.sessionKey).enqueue(() => {
-          const adapters = createTelegramAdapters(event, this, false);
-          return this.handler.handleEvent(event, this, adapters, false);
+          const adapters = createTelegramAdapters(event, this);
+          return this.handler.handleEvent(event, this, adapters);
         });
       }
     });

--- a/src/adapters/telegram/context.ts
+++ b/src/adapters/telegram/context.ts
@@ -47,7 +47,6 @@ function formatToolResult(result: ChatToolResult): string {
 export function createTelegramAdapters(
   event: TelegramEvent,
   bot: TelegramBot,
-  _isEvent?: boolean,
 ): {
   message: ChatMessage;
   responseCtx: ChatResponseContext;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -246,7 +246,7 @@ function buildSystemPrompt(
   sandboxConfig: SandboxConfig,
   platform: PlatformInfo,
   skills: Skill[],
-  isSyntheticEvent = false,
+  isEventTrigger = false,
   triggerAttribution?: string,
 ): string {
   const { workspaceRoot, conversationPath, scratchPath } = buildRuntimePaths(
@@ -271,9 +271,9 @@ function buildSystemPrompt(
 
   const envDescription = buildEnvDescription(sandboxType, workspaceRoot);
   const eventFilesystemInstructions = buildEventFilesystemInstructions(sandboxType, workspaceRoot);
-  const syntheticEventInstructions = isSyntheticEvent
+  const eventTriggerInstructions = isEventTrigger
     ? `
-## Synthetic Event Mode
+## Event Trigger Mode
 - You are handling a scheduled/background event, not opening a brand new chat with a stranger.
 - Treat the incoming user message as a self-contained task prepared by an earlier run.
 - Complete the task directly. Avoid generic greetings, self-introductions, or boilerplate offers to help.
@@ -301,7 +301,7 @@ Do not add this to \`[SILENT]\` responses.
 - The active top-level session is selected by \`${conversationPath}/sessions/current\`, which points to a timestamped \`.jsonl\` file in the same directory.
 - Scoped/thread sessions use fixed files at \`${conversationPath}/sessions/<scope_id>.jsonl\` (for example \`${conversationPath}/sessions/1777386320.800769.jsonl\`).
 - User messages include a \`[in-thread:TS]\` marker when sent from within a platform thread/reply (TS is the thread or parent message identifier). Without this marker, the message is a top-level conversation message.
-${syntheticEventInstructions}
+${eventTriggerInstructions}
 ${platform.formattingGuide}
 
 ## Platform IDs

--- a/src/events.ts
+++ b/src/events.ts
@@ -522,7 +522,7 @@ export class EventsWatcher {
           conversationId: event.conversationId,
           conversationKind: event.conversationKind,
           deleteAfter,
-          isSyntheticEvent: true,
+          triggeredByEventFile: true,
           textLength: event.text.length,
         },
       });
@@ -533,7 +533,7 @@ export class EventsWatcher {
     }
 
     const eventId = filename.replace(/\.json$/i, "");
-    const syntheticEvent: BotEvent = {
+    const botEvent: BotEvent = {
       type: "mention",
       conversationId: event.conversationId,
       conversationKind: event.conversationKind,
@@ -543,7 +543,7 @@ export class EventsWatcher {
     };
 
     // Enqueue for processing
-    const enqueued = bot.enqueueEvent(syntheticEvent);
+    const enqueued = bot.enqueueEvent(botEvent);
 
     if (enqueued && deleteAfter) {
       // Delete file after successful enqueue (immediate and one-shot)
@@ -563,7 +563,7 @@ export class EventsWatcher {
           conversationId: event.conversationId,
           conversationKind: event.conversationKind,
           deleteAfter,
-          isSyntheticEvent: true,
+          triggeredByEventFile: true,
           textLength: event.text.length,
         },
       });

--- a/src/runtime/conversation-orchestrator.ts
+++ b/src/runtime/conversation-orchestrator.ts
@@ -27,7 +27,6 @@ export interface RunConversationOptions {
   event: BotEvent;
   bot: Bot;
   adapters: BotAdapters;
-  isSyntheticEvent?: boolean;
 }
 
 interface ConversationOrchestratorOptions {
@@ -49,12 +48,7 @@ interface ConversationOrchestratorOptions {
 export class ConversationOrchestrator {
   constructor(private readonly options: ConversationOrchestratorOptions) {}
 
-  async runSession({
-    event,
-    bot,
-    adapters,
-    isSyntheticEvent,
-  }: RunConversationOptions): Promise<void> {
+  async runSession({ event, bot, adapters }: RunConversationOptions): Promise<void> {
     const conversationId = event.conversationId;
     if (this.options.isShuttingDown()) {
       log.logInfo(
@@ -81,7 +75,7 @@ export class ConversationOrchestrator {
 
     const conversationDir = join(this.options.workingDir, conversationId);
     const waitedForParent =
-      adapters.platform.name === "slack" && !isSyntheticEvent
+      adapters.platform.name === "slack"
         ? await waitForSlackBranchBootstrap({
             parentSessionKey: conversationId,
             sessionKey,
@@ -114,7 +108,6 @@ export class ConversationOrchestrator {
           sessionKey,
           messageId: adapters.message.id,
           threadTs: adapters.message.threadTs,
-          isSyntheticEvent: Boolean(isSyntheticEvent),
           attachmentCount: adapters.message.attachments?.length ?? 0,
         },
       });
@@ -132,7 +125,7 @@ export class ConversationOrchestrator {
       try {
         const result = await this.runWithInstrumentation(
           adapters,
-          { conversationId, sessionKey, isSyntheticEvent, startedAt: state.startedAt! },
+          { conversationId, sessionKey, startedAt: state.startedAt! },
           async () => {
             await adapters.responseCtx.setTyping(true);
             await adapters.responseCtx.setWorking(true);
@@ -174,12 +167,11 @@ export class ConversationOrchestrator {
     meta: {
       conversationId: string;
       sessionKey: string;
-      isSyntheticEvent?: boolean;
       startedAt: number;
     },
     body: () => Promise<{ stopReason: string; errorMessage?: string }>,
   ): Promise<{ stopReason: string; errorMessage?: string } | undefined> {
-    const { conversationId, sessionKey, isSyntheticEvent, startedAt } = meta;
+    const { conversationId, sessionKey, startedAt } = meta;
     const { message, platform } = adapters;
 
     Sentry.metrics.count("agent.run.started", 1, {
@@ -198,7 +190,6 @@ export class ConversationOrchestrator {
             userId: message.userId,
             userName: message.userName,
             threadTs: message.threadTs,
-            isSyntheticEvent,
           });
           addLifecycleBreadcrumb("agent.run.started", {
             channel_id: conversationId,
@@ -245,7 +236,6 @@ export class ConversationOrchestrator {
                 sessionKey,
                 messageId: message.id,
                 threadTs: message.threadTs,
-                isSyntheticEvent: Boolean(isSyntheticEvent),
                 attachmentCount: message.attachments?.length ?? 0,
               },
             });

--- a/src/runtime/session-runtime.ts
+++ b/src/runtime/session-runtime.ts
@@ -28,7 +28,6 @@ export interface RunSessionOptions {
   event: BotEvent;
   bot: Bot;
   adapters: BotAdapters;
-  isSyntheticEvent?: boolean;
 }
 
 export interface CreateSessionSandboxOptions {
@@ -168,17 +167,10 @@ class MamaSessionRuntime implements SessionRuntime {
     await bot.postMessage(conversationId, "Conversation reset. Send a new message to start fresh.");
   }
 
-  async handleEvent(
-    event: BotEvent,
-    bot: Bot,
-    adapters: BotAdapters,
-    isSyntheticEvent?: boolean,
-  ): Promise<void> {
+  async handleEvent(event: BotEvent, bot: Bot, adapters: BotAdapters): Promise<void> {
     const sessionKey = event.sessionKey ?? `${event.conversationId}:${event.thread_ts ?? event.ts}`;
     const previous = this.sessionQueues.get(sessionKey) ?? Promise.resolve();
-    const next = previous
-      .catch(() => {})
-      .then(() => this.runSession({ event, bot, adapters, isSyntheticEvent }));
+    const next = previous.catch(() => {}).then(() => this.runSession({ event, bot, adapters }));
     this.sessionQueues.set(sessionKey, next);
     try {
       await next;
@@ -189,8 +181,8 @@ class MamaSessionRuntime implements SessionRuntime {
     }
   }
 
-  async runSession({ event, bot, adapters, isSyntheticEvent }: RunSessionOptions): Promise<void> {
-    await this.orchestrator.runSession({ event, bot, adapters, isSyntheticEvent });
+  async runSession({ event, bot, adapters }: RunSessionOptions): Promise<void> {
+    await this.orchestrator.runSession({ event, bot, adapters });
   }
 
   async createSessionSandbox(options: CreateSessionSandboxOptions): Promise<AgentRunner> {
@@ -306,15 +298,6 @@ class MamaSessionRuntime implements SessionRuntime {
     sessionKey: string,
     cwd: string,
   ): Promise<ResolvedSessionScope> {
-    if (sessionKey.includes(":event:")) {
-      const sessionDir = getChannelSessionDir(conversationDir);
-      const contextFile = createManagedSessionFileAtPath(
-        getThreadSessionFile(conversationDir, sessionKey),
-        cwd,
-      );
-      return { sessionDir, contextFile, threadRootMessage: null };
-    }
-
     if (platformName === "slack") {
       return resolveSlackSessionScope({ conversationDir, sessionKey, cwd });
     }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -66,7 +66,6 @@ export interface SentryRunScopeContext {
   threadTs?: string;
   provider?: string;
   model?: string;
-  isSyntheticEvent?: boolean;
 }
 
 export type UserFacingErrorDomain =
@@ -162,7 +161,6 @@ export function applyRunScope(scope: Scope, context: SentryRunScopeContext): voi
   scope.setTag("channel_id", context.conversationId);
   scope.setTag("session_key", context.sessionKey);
   scope.setTag("platform", context.platform);
-  scope.setTag("is_synthetic_event", String(Boolean(context.isSyntheticEvent)));
   if (context.threadTs) scope.setTag("thread_ts", context.threadTs);
   if (context.provider) scope.setTag("provider", context.provider);
   if (context.model) scope.setTag("model", context.model);
@@ -180,7 +178,6 @@ export function applyRunScope(scope: Scope, context: SentryRunScopeContext): voi
     platform: context.platform,
     provider: context.provider,
     model: context.model,
-    isSyntheticEvent: Boolean(context.isSyntheticEvent),
   });
 }
 

--- a/src/session-view/portal.ts
+++ b/src/session-view/portal.ts
@@ -682,7 +682,7 @@ async function handleSessionMessageRequest(
   });
 
   void interactive.handler
-    .handleEvent(event, bot, adapters, false)
+    .handleEvent(event, bot, adapters)
     .then(() => {
       if (!targetSessionFile) {
         sessionViewStreamHub.publish(streamKey, { type: "status", running: false });

--- a/test/session-runtime.test.ts
+++ b/test/session-runtime.test.ts
@@ -1,0 +1,91 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { registerSlackForkSession } from "../src/adapters/slack/branch-manager.js";
+import { createSessionRuntime } from "../src/runtime/session-runtime.js";
+import {
+  createManagedSessionFile,
+  getChannelSessionDir,
+  getThreadSessionFile,
+  openManagedSession,
+} from "../src/session-store.js";
+import type { SandboxConfig } from "../src/sandbox/index.js";
+import type { VaultManager } from "../src/vault.js";
+
+let workingDir: string;
+let conversationDir: string;
+
+beforeEach(() => {
+  workingDir = join(
+    tmpdir(),
+    `mama-session-runtime-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  conversationDir = join(workingDir, "C123");
+  mkdirSync(conversationDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
+});
+
+function makeRuntime() {
+  const sandbox: SandboxConfig = { type: "host" };
+  return createSessionRuntime({
+    workingDir,
+    sandbox,
+    vaultManager: {
+      hasEntry: () => false,
+      resolve: () => undefined,
+      getSandboxConfig: (_uid, base) => base,
+      list: () => [],
+      isEnabled: () => true,
+      upsertEnv: () => {},
+      upsertFile: () => {},
+      listSharedVaults: () => [],
+      deleteSharedVault: () => false,
+      copySharedVaultTo: () => ({ filesCopied: 0, envKeysCopied: 0 }),
+    } as VaultManager,
+    linkTokenStore: { create: () => ({ token: "link" }) },
+    sessionViewTokenStore: { create: () => ({ token: "session" }) },
+  } as any);
+}
+
+function makeUserMessage(text: string) {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp: 1,
+  } as const;
+}
+
+describe("SessionRuntime Slack fork scope", () => {
+  test("uses a pre-registered empty fork session for Slack event anchors", async () => {
+    const sessionDir = getChannelSessionDir(conversationDir);
+    const channelFile = createManagedSessionFile(sessionDir, conversationDir);
+    const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
+    channelSession.appendMessage(makeUserMessage("channel history should not leak"));
+
+    const runtime = makeRuntime();
+    registerSlackForkSession({
+      conversationDir,
+      sessionKey: "C123:2000.0001",
+      cwd: conversationDir,
+    });
+
+    // This intentionally reaches the private scope resolver: the bug was in
+    // pre-run session materialization, before a public run can observe it.
+    const sessionScope = await (runtime as any).resolveSessionScope(
+      "slack",
+      conversationDir,
+      "C123:2000.0001",
+      conversationDir,
+    );
+
+    expect(sessionScope.contextFile).toBe(getThreadSessionFile(conversationDir, "C123:2000.0001"));
+    expect(sessionScope.threadRootMessage).toBeNull();
+    expect(readFileSync(sessionScope.contextFile, "utf-8")).not.toContain(
+      "channel history should not leak",
+    );
+  });
+});

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -308,7 +308,7 @@ describe("SlackBot slash commands", () => {
       onRunFinished: vi.fn(),
     });
     (handler.handleEvent as any).mockImplementation((event: any, eventBot: any, adapters: any) =>
-      orchestrator.runSession({ event, bot: eventBot, adapters, isSyntheticEvent: false }),
+      orchestrator.runSession({ event, bot: eventBot, adapters }),
     );
 
     const postEphemeral = vi.fn().mockResolvedValue(undefined);
@@ -712,6 +712,217 @@ describe("SlackBot queues follow-up messages", () => {
     });
   });
 
+  test("Slack events create a top-level anchor and run under that fork session", async () => {
+    const handler = makeHandler();
+    const handled = new Promise<void>((resolve, reject) => {
+      handler.handleEvent = vi.fn(async (event, _calledBot, adapters) => {
+        try {
+          expect(event).toMatchObject({
+            conversationId: "C123",
+            sessionKey: "C123:2000.0001",
+            ts: "event:deploy-reminder",
+          });
+          expect(adapters.message.sessionKey).toBe("C123:2000.0001");
+          await adapters.responseCtx.respond("event done");
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+
+    const bot = new SlackBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    (bot as any).postMessage = vi.fn().mockResolvedValue("2000.0001");
+    (bot as any).updateMessage = vi.fn().mockResolvedValue(undefined);
+
+    expect(
+      bot.enqueueEvent({
+        type: "mention",
+        conversationId: "C123",
+        conversationKind: "shared",
+        ts: "event:deploy-reminder",
+        user: "EVENT",
+        text: "Deploy in 10 minutes",
+      }),
+    ).toBe(true);
+
+    await Promise.race([
+      handled,
+      new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error("Slack event was not handled")), 1000);
+      }),
+    ]);
+
+    expect((bot as any).postMessage).toHaveBeenCalledTimes(1);
+    expect((bot as any).postMessage).toHaveBeenCalledWith("C123", "Working on it...");
+    expect((bot as any).updateMessage).toHaveBeenCalledWith(
+      "C123",
+      "2000.0001",
+      expect.stringContaining("event done"),
+    );
+    expect(existsSync(getThreadSessionFile(join(workingDir, "C123"), "C123:2000.0001"))).toBe(true);
+  });
+
+  test("Slack events report anchor failures instead of creating legacy event sessions", async () => {
+    const handler = makeHandler();
+    const bot = new SlackBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    const postMessage = vi.fn().mockRejectedValueOnce(new Error("anchor failed"));
+    (bot as any).postMessage = postMessage;
+    (bot as any).updateMessage = vi.fn().mockResolvedValue(undefined);
+
+    expect(
+      bot.enqueueEvent({
+        type: "mention",
+        conversationId: "C123",
+        conversationKind: "shared",
+        ts: "event:deploy-reminder",
+        user: "EVENT",
+        text: "Deploy in 10 minutes",
+      }),
+    ).toBe(true);
+
+    for (let i = 0; i < 10 && postMessage.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(postMessage).toHaveBeenNthCalledWith(1, "C123", "Working on it...");
+    expect(handler.handleEvent).not.toHaveBeenCalled();
+    expect((bot as any).updateMessage).not.toHaveBeenCalled();
+    expect(existsSync(join(workingDir, "C123", "sessions"))).toBe(false);
+  });
+
+  test("Slack event anchor thread replies queue behind the event fork run", async () => {
+    const handler = makeHandler();
+    let releaseEventRun!: () => void;
+    const eventRunCanFinish = new Promise<void>((resolve) => {
+      releaseEventRun = resolve;
+    });
+    let resolveEventHandled!: () => void;
+    let rejectEventHandled!: (err: unknown) => void;
+    const eventHandled = new Promise<void>((resolve, reject) => {
+      resolveEventHandled = resolve;
+      rejectEventHandled = reject;
+    });
+    const replyHandled = new Promise<void>((resolve, reject) => {
+      handler.handleEvent = vi.fn(async (event, _calledBot, adapters) => {
+        try {
+          if (event.ts === "event:deploy-reminder") {
+            expect(event).toMatchObject({
+              conversationId: "C123",
+              sessionKey: "C123:2000.0001",
+            });
+            expect(adapters.message.sessionKey).toBe("C123:2000.0001");
+            resolveEventHandled();
+            await eventRunCanFinish;
+            return;
+          }
+          expect(event).toMatchObject({
+            conversationId: "C123",
+            sessionKey: "C123:2000.0001",
+            text: "thread follow-up",
+            thread_ts: "2000.0001",
+          });
+          resolve();
+        } catch (err) {
+          if (event.ts === "event:deploy-reminder") rejectEventHandled(err);
+          else reject(err);
+        }
+      });
+    });
+
+    const bot = new SlackBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    (bot as any).postMessage = vi.fn().mockResolvedValue("2000.0001");
+    (bot as any).updateMessage = vi.fn().mockResolvedValue(undefined);
+
+    expect(
+      bot.enqueueEvent({
+        type: "mention",
+        conversationId: "C123",
+        conversationKind: "shared",
+        ts: "event:deploy-reminder",
+        user: "EVENT",
+        text: "Deploy in 10 minutes",
+      }),
+    ).toBe(true);
+
+    await Promise.race([
+      eventHandled,
+      new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error("Slack event was not handled")), 1000);
+      }),
+    ]);
+
+    expect((bot as any).shouldTriggerSharedThreadReply("C123", "2000.0001")).toBe(true);
+    expect((bot as any).resolveQueueKey("C123", "C123:2000.0001")).toBe("C123:2000.0001");
+
+    let messageHandler:
+      | ((payload: {
+          event: {
+            text?: string;
+            channel: string;
+            user?: string;
+            ts: string;
+            thread_ts?: string;
+            channel_type?: string;
+          };
+          ack: () => void;
+        }) => void)
+      | undefined;
+
+    (bot as any).startupTs = "0";
+    (bot as any).botUserId = "B123";
+    (bot as any).logUserMessage = vi.fn().mockResolvedValue([]);
+    (bot as any).socketClient = {
+      on: vi.fn((event: string, fn: unknown) => {
+        if (event === "message") messageHandler = fn as typeof messageHandler;
+      }),
+    };
+    (bot as any).setupEventHandlers();
+
+    const queue = (bot as any).getQueue("C123:2000.0001");
+    expect(queue.processing).toBe(true);
+    const ack = vi.fn();
+
+    messageHandler?.({
+      event: {
+        text: "thread follow-up",
+        channel: "C123",
+        user: "U123",
+        ts: "2001.0001",
+        thread_ts: "2000.0001",
+        channel_type: "channel",
+      },
+      ack,
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(queue.size()).toBe(1);
+    expect(handler.handleEvent).toHaveBeenCalledTimes(1);
+
+    releaseEventRun();
+    await replyHandled;
+
+    expect(handler.handleEvent).toHaveBeenCalledTimes(2);
+  });
+
   test("external Slack app bot messages are logged but do not trigger mama", async () => {
     const handler = makeHandler();
 
@@ -865,7 +1076,7 @@ describe("SlackBot queues follow-up messages", () => {
 
     (bot as any).setupEventHandlers();
 
-    const queue = (bot as any).getQueue("C123");
+    const queue = (bot as any).getQueue("C123:1000.0001");
     queue.processing = true;
     const ack = vi.fn();
 

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -16,7 +16,6 @@ function makeSlackBot(overrides: Partial<SlackBot> = {}): SlackBot {
     updateMessage: vi.fn().mockResolvedValue(undefined),
     deleteMessage: vi.fn().mockResolvedValue(undefined),
     logBotResponse: vi.fn(),
-    aliasSyntheticEventThread: vi.fn(),
     uploadFile: vi.fn().mockResolvedValue(undefined),
     start: vi.fn(),
     getChannel: vi.fn().mockReturnValue(undefined),
@@ -91,32 +90,35 @@ describe("respond() — non-threaded", () => {
     expect(bot.postInThread).not.toHaveBeenCalled();
   });
 
-  test("synthetic event posts top-level instead of using an invalid thread root", async () => {
-    const bot = makeSlackBot();
+  test("event anchor session updates that top-level message", async () => {
+    const bot = makeSlackBot({ updateMessage: vi.fn().mockResolvedValue(undefined) });
     const event = makeEvent({
       ts: "event:deploy-reminder.json",
       text: "Deploy now",
       thread_ts: undefined,
+      sessionKey: "C001:T001",
     });
-    const { responseCtx } = createSlackAdapters(event, bot, true);
+    const { message, responseCtx } = createSlackAdapters(event, bot, {
+      initialMessageTs: "T001",
+    });
+
+    expect(message.sessionKey).toBe("C001:T001");
+
     await responseCtx.respond("done");
-    expect(bot.postMessage).toHaveBeenCalledWith("C001", expect.stringContaining("done"));
+
+    expect(bot.updateMessage).toHaveBeenCalledWith("C001", "T001", expect.stringContaining("done"));
+    expect(bot.postMessage).not.toHaveBeenCalled();
     expect(bot.postInThread).not.toHaveBeenCalled();
-    expect((bot as any).aliasSyntheticEventThread).toHaveBeenCalledWith(
-      "C001",
-      "T001",
-      "event:deploy-reminder.json",
-    );
   });
 
-  test("synthetic event in a Slack thread replies inside the original thread", async () => {
+  test("event-file-shaped ts in a Slack thread replies inside the original thread", async () => {
     const bot = makeSlackBot();
     const event = makeEvent({
       ts: "event:deploy-reminder.json",
       text: "Deploy now",
       thread_ts: "1000.0001",
     });
-    const { responseCtx } = createSlackAdapters(event, bot, true);
+    const { responseCtx } = createSlackAdapters(event, bot);
     await responseCtx.respond("done");
     expect(bot.postInThread).toHaveBeenCalledWith(
       "C001",
@@ -139,10 +141,10 @@ describe("respond() — non-threaded", () => {
     );
   });
 
-  test("synthetic events without a Slack ts post a normal channel message first", async () => {
+  test("event-file-shaped ts without a Slack ts posts a normal channel message first", async () => {
     const bot = makeSlackBot({ postMessage: vi.fn().mockResolvedValue("BOT_MSG") });
     const event = makeEvent({ ts: "event:reminder.json" });
-    const { responseCtx } = createSlackAdapters(event, bot, true);
+    const { responseCtx } = createSlackAdapters(event, bot);
     await responseCtx.respond("hello");
     expect(bot.postMessage).toHaveBeenCalledWith("C001", expect.stringContaining("hello"));
     expect(bot.postInThread).not.toHaveBeenCalled();
@@ -245,23 +247,23 @@ describe("respondDiagnostic()", () => {
     );
   });
 
-  test("synthetic event diagnostics anchor to the bot message after respond", async () => {
+  test("event-file-shaped ts diagnostics anchor to the bot message after respond", async () => {
     const postInThread = vi.fn().mockResolvedValue("THREAD_MSG");
     const bot = makeSlackBot({
       postMessage: vi.fn().mockResolvedValue("BOT_MSG"),
       postInThread,
     });
     const event = makeEvent({ ts: "event:reminder.json" });
-    const { responseCtx } = createSlackAdapters(event, bot, true);
+    const { responseCtx } = createSlackAdapters(event, bot);
     await responseCtx.respond("main");
     await responseCtx.respondDiagnostic("detail");
     expect(postInThread).toHaveBeenCalledWith("C001", "BOT_MSG", expect.stringContaining("detail"));
   });
 
-  test("synthetic event diagnostics before a main response are dropped instead of using invalid thread_ts", async () => {
+  test("event-file-shaped ts diagnostics before a main response are dropped instead of using invalid thread_ts", async () => {
     const bot = makeSlackBot();
     const event = makeEvent({ ts: "event:reminder.json" });
-    const { responseCtx } = createSlackAdapters(event, bot, true);
+    const { responseCtx } = createSlackAdapters(event, bot);
     await responseCtx.respondDiagnostic("detail");
     expect(bot.postInThread).not.toHaveBeenCalled();
     expect(bot.postMessage).not.toHaveBeenCalled();
@@ -283,10 +285,10 @@ describe("setTyping()", () => {
     expect(bot.postInThread).not.toHaveBeenCalled();
   });
 
-  test("synthetic events do not call assistant status with invalid ts", async () => {
+  test("event-file-shaped ts does not call assistant status with invalid ts", async () => {
     const bot = makeSlackBot({ setAssistantStatus: vi.fn().mockResolvedValue(undefined) });
     const event = makeEvent({ ts: "event:reminder.json" });
-    const { responseCtx } = createSlackAdapters(event, bot, true);
+    const { responseCtx } = createSlackAdapters(event, bot);
     await responseCtx.setTyping(true);
     expect(bot.setAssistantStatus).not.toHaveBeenCalled();
   });

--- a/test/slack-session.test.ts
+++ b/test/slack-session.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+import {
+  formatSlackSessionKey,
+  parseSlackSessionKey,
+  planSlackAdapterSession,
+  planSlackEventForkRun,
+  resolveSlackResponseRootTs,
+} from "../src/adapters/slack/session.js";
+
+describe("Slack session planning", () => {
+  test("top-level user turns use the persistent channel session", () => {
+    expect(
+      planSlackAdapterSession({
+        conversationId: "C123",
+        ts: "1000.0001",
+      }),
+    ).toMatchObject({
+      sessionKey: "C123",
+      rootTs: "1000.0001",
+      isThreaded: false,
+    });
+  });
+
+  test("thread turns use the thread root as the fork session key", () => {
+    expect(
+      planSlackAdapterSession({
+        conversationId: "C123",
+        ts: "1000.0002",
+        thread_ts: "1000.0001",
+      }),
+    ).toMatchObject({
+      sessionKey: "C123:1000.0001",
+      rootTs: "1000.0001",
+      isThreaded: true,
+    });
+  });
+
+  test("anchored events use the anchor session", () => {
+    expect(
+      planSlackAdapterSession(
+        {
+          conversationId: "C123",
+          ts: "event:deploy-reminder",
+          sessionKey: "C123:2000.0001",
+        },
+        { initialMessageTs: "2000.0001" },
+      ),
+    ).toMatchObject({
+      sessionKey: "C123:2000.0001",
+      rootTs: "2000.0001",
+      initialMessageTs: "2000.0001",
+    });
+  });
+
+  test("session refs make channel and fork keys explicit", () => {
+    expect(parseSlackSessionKey("C123")).toEqual({ kind: "channel", channelId: "C123" });
+    expect(parseSlackSessionKey("C123:2000.0001")).toEqual({
+      kind: "fork",
+      channelId: "C123",
+      anchorTs: "2000.0001",
+    });
+    expect(formatSlackSessionKey({ kind: "fork", channelId: "C123", anchorTs: "2000.0001" })).toBe(
+      "C123:2000.0001",
+    );
+  });
+
+  test("event fork planning binds top-level events to the Slack anchor", () => {
+    const planned = planSlackEventForkRun(
+      {
+        conversationId: "C123",
+        ts: "event:deploy-reminder",
+      },
+      "2000.0001",
+    );
+
+    expect(planned.initialMessageTs).toBe("2000.0001");
+    expect(planned.event.sessionKey).toBe("C123:2000.0001");
+  });
+
+  test("event fork planning leaves explicit thread events alone", () => {
+    const event = {
+      conversationId: "C123",
+      ts: "event:deploy-reminder",
+      thread_ts: "1000.0001",
+    };
+
+    expect(planSlackEventForkRun(event, "2000.0001")).toEqual({ event });
+  });
+
+  test("non-Slack timestamps do not produce response roots", () => {
+    expect(resolveSlackResponseRootTs({ ts: "event:deploy-reminder" })).toBeUndefined();
+  });
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: ["e2e/**/*.e2e.ts"],
     testTimeout: 120_000,
     hookTimeout: 30_000,
+    fileParallelism: false,
     pool: "forks",
     forks: { singleFork: true },
     reporters: ["verbose"],


### PR DESCRIPTION
## Summary

- Make Slack event files create a visible top-level anchor message, then run as a normal fork session under `conversationId:anchorTs`.
- Remove the runtime `isSyntheticEvent` flag and the Slack legacy `:event:` session path; after planning, runtime only sees channel sessions and fork sessions.
- Add explicit Slack session refs plus `registerSlackForkSession` so thread trigger and queue routing share the same materialized-fork predicate.
- Queue anchored event runs on the fork queue, so replies in the anchor thread serialize behind the event run instead of racing in a separate queue.
- Add unit coverage plus a real Slack E2E test for event-anchor thread continuation.

## Root Cause

Slack events and Slack thread replies were modeled as separate special cases even though both should be fork sessions. That left routing, queueing, and session-scope resolution with different predicates for the same question: whether `conversationId:ts` is a live fork.

## Design

Slack now has two session shapes: channel and fork. Event delivery posts the anchor first, materializes the anchor fork session, and hands runtime a normal fork `sessionKey`. Runtime no longer needs to know whether a run came from an event file.

`log.jsonl` remains the complete channel history. The fork session is the LLM window; currently it starts with the fork point only, with the session ref and registration path leaving room for later `includeRecentTopLevel` behavior without adding another event-specific code path.

Behavior change: Slack thread replies now serialize behind the corresponding fork session run, not behind the channel session. This lets unrelated top-level channel work and thread work stop blocking each other while preserving ordering inside the fork.

## Validation

- `npm run lint` -> passed
- `npm run fmt:check` -> passed
- `npm test` -> 456 passed
- `npm run build` -> passed
- Local `npm run test:e2e:slack -- e2e/slack/event-thread-fork.e2e.ts` -> skipped without Slack QA env
- GitHub Actions Slack E2E -> passed: https://github.com/geminixiang/mama/actions/runs/26217215278
