### PR TITLE
feat(streaming): stream response deltas across adapters

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -29,6 +29,8 @@ export interface ChatResponseBlockKit {
 
 export interface ChatResponseContext {
   respond(text: string): Promise<void>;
+  appendResponseDelta?(delta: string): Promise<void>;
+  finishResponse?(finalText?: string): Promise<void>;
   replaceResponse(text: string, options?: { createOverflowLink?: () => string }): Promise<void>;
   respondDiagnostic(text: string, options?: { style?: "muted" | "error" }): Promise<void>;
   respondToolResult(result: ChatToolResult): Promise<void>;

--- a/src/adapters/discord/context.ts
+++ b/src/adapters/discord/context.ts
@@ -12,6 +12,7 @@ import {
   splitText,
   type ChatResponseErrorOperation,
 } from "../shared.js";
+import { BufferedResponseStream } from "../streaming.js";
 import type { DiscordBot, DiscordEvent } from "./bot.js";
 
 const DISCORD_FORMATTING_GUIDE = `## Discord Formatting (Markdown)
@@ -145,6 +146,17 @@ export function createDiscordAdapters(
     }
   }
 
+  const stream = new BufferedResponseStream({
+    flush: async (text) => {
+      await postSplitResponse(isWorking ? text + workingIndicator : text);
+    },
+    finish: async (text) => {
+      isWorking = false;
+      stopTyping();
+      await postSplitResponse(text);
+    },
+  });
+
   async function queueDiscordResponse(
     label: string,
     operation: ChatResponseErrorOperation,
@@ -169,6 +181,7 @@ export function createDiscordAdapters(
         "respond",
         async () => {
           accumulatedText = accumulatedText ? `${accumulatedText}\n${text}` : text;
+          stream.setText(accumulatedText);
           await postSplitResponse(isWorking ? accumulatedText + workingIndicator : accumulatedText);
           if (messageId !== null) {
             bot.logBotResponse(channelId, text, messageId);
@@ -182,12 +195,40 @@ export function createDiscordAdapters(
       );
     },
 
+    appendResponseDelta: async (delta: string) => {
+      await queueDiscordResponse(
+        "appendResponseDelta",
+        "respond",
+        async () => {
+          await stream.append(delta);
+          accumulatedText = stream.getText();
+          if (messageId !== null) {
+            bot.logBotResponse(channelId, delta, messageId);
+          }
+        },
+        () => ({ textLength: delta.length, accumulatedLength: stream.getText().length }),
+      );
+    },
+
+    finishResponse: async (finalText?: string) => {
+      await queueDiscordResponse(
+        "finishResponse",
+        "set_working",
+        async () => {
+          await stream.finish(finalText);
+          accumulatedText = stream.getText();
+        },
+        () => ({ finalTextLength: finalText?.length }),
+      );
+    },
+
     replaceResponse: async (text: string) => {
       await queueDiscordResponse(
         "replaceResponse",
         "replace_response",
         async () => {
           accumulatedText = text;
+          stream.setText(accumulatedText);
           await postSplitResponse(accumulatedText);
         },
         () => ({

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -309,6 +309,35 @@ export class SlackBot implements Bot {
     });
   }
 
+  async startMessageStream(channel: string, text: string, threadTs?: string): Promise<string> {
+    return slackRetry(async () => {
+      const result = await this.webClient.apiCall("chat.startStream", {
+        channel,
+        markdown_text: text,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      });
+      const ts = (result as { ts?: string }).ts;
+      if (!ts) throw new Error("Slack chat.startStream did not return ts");
+      return ts;
+    });
+  }
+
+  async appendMessageStream(channel: string, ts: string, text: string): Promise<void> {
+    return slackRetry(async () => {
+      await this.webClient.apiCall("chat.appendStream", {
+        channel,
+        ts,
+        markdown_text: text,
+      });
+    });
+  }
+
+  async stopMessageStream(channel: string, ts: string): Promise<void> {
+    return slackRetry(async () => {
+      await this.webClient.apiCall("chat.stopStream", { channel, ts });
+    });
+  }
+
   async deleteMessage(channel: string, ts: string): Promise<void> {
     return slackRetry(async () => {
       await this.webClient.chat.delete({ channel, ts });

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -110,6 +110,8 @@ export function createSlackAdapters(
   let accumulatedText = "";
   let isWorking = true;
   let blockKitFinalized = false;
+  let streamActive = false;
+  let streamUnavailable = false;
   let updatePromise = Promise.resolve();
 
   const channelId = event.channel;
@@ -209,6 +211,34 @@ export function createSlackAdapters(
     messageTs = await postFirstMessage(body);
   };
 
+  const startOrAppendStream = async (chunk: string, displayText: string): Promise<void> => {
+    if (streamUnavailable) {
+      await postOrUpdateMain(displayText);
+      return;
+    }
+
+    try {
+      if (messageTs && streamActive) {
+        await slack.appendMessageStream(channelId, messageTs, chunk);
+        return;
+      }
+      messageTs = await slack.startMessageStream(
+        channelId,
+        displayText,
+        isThreaded ? rootTs : undefined,
+      );
+      streamActive = true;
+    } catch (err) {
+      streamUnavailable = true;
+      streamActive = false;
+      log.logWarning(
+        "Slack streaming unavailable; falling back to chat.update",
+        err instanceof Error ? err.message : String(err),
+      );
+      await postOrUpdateMain(displayText);
+    }
+  };
+
   const queueResponseOperation = async (
     label: string,
     operation: ChatResponseErrorOperation,
@@ -244,7 +274,7 @@ export function createSlackAdapters(
           }
 
           const displayText = isWorking ? accumulatedText + WORKING_INDICATOR : accumulatedText;
-          await postOrUpdateMain(displayText);
+          await startOrAppendStream(text, displayText);
 
           if (messageTs) {
             slack.logBotResponse(channelId, text, messageTs, isThreaded ? rootTs : undefined);
@@ -276,6 +306,10 @@ export function createSlackAdapters(
           const displayText = isWorking ? accumulatedText + WORKING_INDICATOR : accumulatedText;
 
           try {
+            if (streamActive && messageTs) {
+              await slack.stopMessageStream(channelId, messageTs);
+              streamActive = false;
+            }
             await postOrUpdateMain(displayText);
           } catch (err) {
             if (!isSlackMsgTooLong(err)) throw err;
@@ -377,9 +411,14 @@ export function createSlackAdapters(
           }
           if (messageTs) {
             const displayText = isWorking ? accumulatedText + WORKING_INDICATOR : accumulatedText;
-            const updates: Promise<void>[] = [
-              slack.updateMessage(channelId, messageTs, displayText),
-            ];
+            const updates: Promise<void>[] =
+              streamActive && !isWorking
+                ? [
+                    slack.stopMessageStream(channelId, messageTs).then(() => {
+                      streamActive = false;
+                    }),
+                  ]
+                : [slack.updateMessage(channelId, messageTs, displayText)];
             if (!working && rootTs) {
               updates.push(
                 slack

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -12,6 +12,7 @@ import {
   splitText,
   type ChatResponseErrorOperation,
 } from "../shared.js";
+import { BufferedResponseStream } from "../streaming.js";
 import type { SlackBot, SlackEvent } from "./bot.js";
 import { planSlackAdapterSession } from "./session.js";
 
@@ -222,11 +223,12 @@ export function createSlackAdapters(
         await slack.appendMessageStream(channelId, messageTs, chunk);
         return;
       }
-      messageTs = await slack.startMessageStream(
-        channelId,
-        displayText,
-        isThreaded ? rootTs : undefined,
-      );
+      if (!rootTs) {
+        streamUnavailable = true;
+        await postOrUpdateMain(displayText);
+        return;
+      }
+      messageTs = await slack.startMessageStream(channelId, displayText, rootTs);
       streamActive = true;
     } catch (err) {
       streamUnavailable = true;
@@ -238,6 +240,34 @@ export function createSlackAdapters(
       await postOrUpdateMain(displayText);
     }
   };
+
+  const stream = new BufferedResponseStream({
+    flush: async (text) => {
+      accumulatedText = text;
+      const mainLimit = isWorking ? MAX_MAIN_LENGTH - WORKING_INDICATOR.length : MAX_MAIN_LENGTH;
+      if (accumulatedText.length > mainLimit) {
+        accumulatedText =
+          accumulatedText.substring(0, mainLimit - TRUNCATION_NOTE_INCREMENTAL.length) +
+          TRUNCATION_NOTE_INCREMENTAL;
+        stream.setText(accumulatedText);
+      }
+      const displayText = isWorking ? accumulatedText + WORKING_INDICATOR : accumulatedText;
+      await startOrAppendStream(text, displayText);
+    },
+    finish: async (text) => {
+      accumulatedText = text;
+      isWorking = false;
+      if (streamActive && messageTs) {
+        await slack.appendMessageStream(channelId, messageTs, accumulatedText);
+        await slack.stopMessageStream(channelId, messageTs);
+        streamActive = false;
+        return;
+      }
+      if (messageTs) {
+        await slack.updateMessage(channelId, messageTs, accumulatedText);
+      }
+    },
+  });
 
   const queueResponseOperation = async (
     label: string,
@@ -273,6 +303,7 @@ export function createSlackAdapters(
               TRUNCATION_NOTE_INCREMENTAL;
           }
 
+          stream.setText(accumulatedText);
           const displayText = isWorking ? accumulatedText + WORKING_INDICATOR : accumulatedText;
           await startOrAppendStream(text, displayText);
 
@@ -285,6 +316,36 @@ export function createSlackAdapters(
           textLength: text.length,
           accumulatedLength: accumulatedText.length,
         }),
+      );
+    },
+
+    appendResponseDelta: async (delta: string) => {
+      await queueResponseOperation(
+        "appendResponseDelta",
+        "respond",
+        async () => {
+          await stream.append(delta);
+          if (messageTs) {
+            slack.logBotResponse(channelId, delta, messageTs, isThreaded ? rootTs : undefined);
+          }
+        },
+        () => ({ textLength: delta.length, accumulatedLength: stream.getText().length }),
+      );
+    },
+
+    finishResponse: async (finalText?: string) => {
+      await queueResponseOperation(
+        "finishResponse",
+        "set_working",
+        async () => {
+          await stream.finish(finalText);
+          accumulatedText = stream.getText();
+          if (!rootTs) return;
+          await slack
+            .setAssistantStatus(channelId, rootTs, "")
+            .catch((err) => onAssistantStatusError("clear-on-idle", err));
+        },
+        () => ({ finalTextLength: finalText?.length }),
       );
     },
 
@@ -303,6 +364,7 @@ export function createSlackAdapters(
           };
 
           accumulatedText = text;
+          stream.setText(accumulatedText);
           const displayText = isWorking ? accumulatedText + WORKING_INDICATOR : accumulatedText;
 
           try {

--- a/src/adapters/streaming.ts
+++ b/src/adapters/streaming.ts
@@ -1,0 +1,66 @@
+export interface BufferedResponseStreamOptions {
+  minFlushIntervalMs?: number;
+  minFlushChars?: number;
+  now?: () => number;
+}
+
+export interface BufferedResponseStreamSink {
+  flush(text: string): Promise<void>;
+  finish(text: string): Promise<void>;
+}
+
+export class BufferedResponseStream {
+  private readonly minFlushIntervalMs: number;
+  private readonly minFlushChars: number;
+  private readonly now: () => number;
+  private readonly sink: BufferedResponseStreamSink;
+  private text = "";
+  private pendingChars = 0;
+  private lastFlushAt = 0;
+
+  constructor(sink: BufferedResponseStreamSink, options: BufferedResponseStreamOptions = {}) {
+    this.sink = sink;
+    this.minFlushIntervalMs = options.minFlushIntervalMs ?? 750;
+    this.minFlushChars = options.minFlushChars ?? 80;
+    this.now = options.now ?? Date.now;
+  }
+
+  getText(): string {
+    return this.text;
+  }
+
+  setText(text: string): void {
+    this.text = text;
+    this.pendingChars = 0;
+  }
+
+  async append(delta: string): Promise<void> {
+    if (!delta) return;
+    this.text += delta;
+    this.pendingChars += delta.length;
+
+    const elapsed = this.now() - this.lastFlushAt;
+    if (
+      this.lastFlushAt === 0 ||
+      this.pendingChars >= this.minFlushChars ||
+      elapsed >= this.minFlushIntervalMs
+    ) {
+      await this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    this.pendingChars = 0;
+    this.lastFlushAt = this.now();
+    await this.sink.flush(this.text);
+  }
+
+  async finish(finalText?: string): Promise<void> {
+    if (finalText !== undefined) {
+      this.text = finalText;
+    }
+    this.pendingChars = 0;
+    this.lastFlushAt = this.now();
+    await this.sink.finish(this.text);
+  }
+}

--- a/src/adapters/telegram/context.ts
+++ b/src/adapters/telegram/context.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../adapter.js";
 import * as log from "../../log.js";
 import { createChatResponseErrorReporter, formatToolArgs, splitText } from "../shared.js";
+import { BufferedResponseStream } from "../streaming.js";
 import { sanitizeTelegramHtml } from "./html.js";
 import type { TelegramBot, TelegramEvent } from "./bot.js";
 
@@ -123,6 +124,16 @@ export function createTelegramAdapters(
     }
   };
 
+  const stream = new BufferedResponseStream({
+    flush: async (text) => {
+      await sendSplitText(text, sendOrUpdate);
+    },
+    finish: async (text) => {
+      stopTyping();
+      await sendSplitText(text, sendOrUpdate);
+    },
+  });
+
   const queueTelegramSend = async (
     label: string,
     work: () => Promise<void>,
@@ -145,6 +156,7 @@ export function createTelegramAdapters(
         async () => {
           const sanitized = sanitizeTelegramHtml(text);
           accumulatedText = accumulatedText ? `${accumulatedText}\n${sanitized}` : sanitized;
+          stream.setText(accumulatedText);
           await sendSplitText(accumulatedText, sendOrUpdate);
           if (messageId !== null) {
             bot.logBotResponse(conversationId, text, String(messageId));
@@ -159,11 +171,47 @@ export function createTelegramAdapters(
       );
     },
 
+    appendResponseDelta: async (delta: string) => {
+      await queueTelegramSend(
+        "appendResponseDelta",
+        async () => {
+          const sanitized = sanitizeTelegramHtml(delta);
+          await stream.append(sanitized);
+          accumulatedText = stream.getText();
+          if (messageId !== null) {
+            bot.logBotResponse(conversationId, delta, String(messageId));
+          }
+        },
+        (err) =>
+          reportResponseError(err, "respond", {
+            textLength: delta.length,
+            accumulatedLength: stream.getText().length,
+          }),
+      );
+    },
+
+    finishResponse: async (finalText?: string) => {
+      await queueTelegramSend(
+        "finishResponse",
+        async () => {
+          await stream.finish(
+            finalText === undefined ? undefined : sanitizeTelegramHtml(finalText),
+          );
+          accumulatedText = stream.getText();
+        },
+        (err) =>
+          reportResponseError(err, "set_working", {
+            finalTextLength: finalText?.length,
+          }),
+      );
+    },
+
     replaceResponse: async (text: string) => {
       await queueTelegramSend(
         "replaceResponse",
         async () => {
           accumulatedText = sanitizeTelegramHtml(text);
+          stream.setText(accumulatedText);
           await sendSplitText(accumulatedText, sendOrUpdate);
         },
         (err) =>

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1234,6 +1234,24 @@ function attachSessionEventHandlers(params: {
       return;
     }
 
+    if (event.type === "message_update") {
+      const assistantMessageEvent = (
+        event as {
+          assistantMessageEvent?: { type?: string; delta?: string };
+        }
+      ).assistantMessageEvent;
+      if (
+        assistantMessageEvent?.type === "text_delta" &&
+        assistantMessageEvent.delta &&
+        responseCtx.appendResponseDelta
+      ) {
+        queue.enqueue(async () => {
+          await responseCtx.appendResponseDelta?.(assistantMessageEvent.delta ?? "");
+        }, "response delta");
+      }
+      return;
+    }
+
     if (event.type === "message_end") {
       if (event.message.role === "assistant") {
         const assistantMsg = event.message;
@@ -1321,11 +1339,15 @@ function attachSessionEventHandlers(params: {
 
         if (text.trim() && !hasToolCall) {
           if (runState.finalResponseHandledByTool) return;
+          const finalText = appendTriggerAttribution(text, runState.triggerAttribution);
           log.logResponse(logCtx, text);
-          queue.enqueue(
-            () => responseCtx.respond(appendTriggerAttribution(text, runState.triggerAttribution)),
-            "response main",
-          );
+          if (responseCtx.finishResponse) {
+            queue.enqueue(async () => {
+              await responseCtx.finishResponse?.(finalText);
+            }, "response finish");
+          } else {
+            queue.enqueue(() => responseCtx.respond(finalText), "response main");
+          }
         }
       }
       return;

--- a/test/discord-context.test.ts
+++ b/test/discord-context.test.ts
@@ -490,6 +490,30 @@ describe("uploadFile()", () => {
 });
 
 // ============================================================================
+// Streaming lifecycle
+// ============================================================================
+
+describe("streaming lifecycle", () => {
+  test("delta streaming posts then updates the same message", async () => {
+    const bot = makeDiscordBot();
+    const event = makeEvent({ thread_ts: undefined });
+    const { responseCtx } = createDiscordAdapters(event, bot);
+
+    await responseCtx.appendResponseDelta?.("hello");
+    await responseCtx.appendResponseDelta?.(" world".repeat(20));
+    await responseCtx.finishResponse?.("hello final");
+
+    expect(bot.postReply).toHaveBeenCalledWith("CH001", "MSG001", expect.stringContaining("hello"));
+    expect(bot.updateMessageRaw).toHaveBeenCalledWith(
+      "CH001",
+      "MSG002",
+      expect.stringContaining("world"),
+    );
+    expect(bot.updateMessageRaw).toHaveBeenLastCalledWith("CH001", "MSG002", "hello final");
+  });
+});
+
+// ============================================================================
 // ChatMessage fields
 // ============================================================================
 

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -14,6 +14,9 @@ function makeSlackBot(overrides: Partial<SlackBot> = {}): SlackBot {
     postMessage: vi.fn().mockResolvedValue("T001"),
     postInThread: vi.fn().mockResolvedValue("T002"),
     updateMessage: vi.fn().mockResolvedValue(undefined),
+    startMessageStream: vi.fn().mockRejectedValue(new Error("streaming unsupported in mock")),
+    appendMessageStream: vi.fn().mockResolvedValue(undefined),
+    stopMessageStream: vi.fn().mockResolvedValue(undefined),
     deleteMessage: vi.fn().mockResolvedValue(undefined),
     logBotResponse: vi.fn(),
     uploadFile: vi.fn().mockResolvedValue(undefined),
@@ -148,6 +151,30 @@ describe("respond() — non-threaded", () => {
     await responseCtx.respond("hello");
     expect(bot.postMessage).toHaveBeenCalledWith("C001", expect.stringContaining("hello"));
     expect(bot.postInThread).not.toHaveBeenCalled();
+  });
+
+  test("uses Slack stream APIs when available", async () => {
+    const bot = makeSlackBot({
+      startMessageStream: vi.fn().mockResolvedValue("STREAM1"),
+      appendMessageStream: vi.fn().mockResolvedValue(undefined),
+      stopMessageStream: vi.fn().mockResolvedValue(undefined),
+    });
+    const event = makeEvent({ thread_ts: undefined });
+    const { responseCtx } = createSlackAdapters(event, bot);
+
+    await responseCtx.respond("first");
+    await responseCtx.respond("second");
+    await responseCtx.setWorking(false);
+
+    expect(bot.startMessageStream).toHaveBeenCalledWith(
+      "C001",
+      expect.stringContaining("first"),
+      undefined,
+    );
+    expect(bot.appendMessageStream).toHaveBeenCalledWith("C001", "STREAM1", "second");
+    expect(bot.stopMessageStream).toHaveBeenCalledWith("C001", "STREAM1");
+    expect(bot.postMessage).not.toHaveBeenCalled();
+    expect(bot.updateMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -169,7 +169,7 @@ describe("respond() — non-threaded", () => {
     expect(bot.startMessageStream).toHaveBeenCalledWith(
       "C001",
       expect.stringContaining("first"),
-      undefined,
+      "1000.0001",
     );
     expect(bot.appendMessageStream).toHaveBeenCalledWith("C001", "STREAM1", "second");
     expect(bot.stopMessageStream).toHaveBeenCalledWith("C001", "STREAM1");
@@ -609,5 +609,29 @@ describe("thread_ts boundary values", () => {
     const { responseCtx } = createSlackAdapters(event, bot);
     await responseCtx.uploadFile("/path/to/file.txt", "test");
     expect(bot.uploadFile).toHaveBeenCalledWith("C001", "/path/to/file.txt", "test", "1000.0001");
+  });
+});
+
+describe("streaming lifecycle", () => {
+  test("native stream failure falls back to incremental chat.update for later deltas", async () => {
+    const bot = makeSlackBot({
+      startMessageStream: vi.fn().mockRejectedValue(new Error("missing required field: thread_ts")),
+      postMessage: vi.fn().mockResolvedValue("T001"),
+      updateMessage: vi.fn().mockResolvedValue(undefined),
+    });
+    const event = makeEvent({ thread_ts: undefined });
+    const { responseCtx } = createSlackAdapters(event, bot);
+
+    await responseCtx.appendResponseDelta?.("hello");
+    await responseCtx.appendResponseDelta?.(" world".repeat(20));
+    await responseCtx.finishResponse?.("hello final");
+
+    expect(bot.postMessage).toHaveBeenCalledWith("C001", expect.stringContaining("hello"));
+    expect(bot.updateMessage).toHaveBeenCalledWith(
+      "C001",
+      "T001",
+      expect.stringContaining("world"),
+    );
+    expect(bot.updateMessage).toHaveBeenLastCalledWith("C001", "T001", "hello final");
   });
 });

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from "vitest";
+import { BufferedResponseStream } from "../src/adapters/streaming.js";
+
+describe("BufferedResponseStream", () => {
+  test("flushes immediately on first delta and buffers small subsequent deltas", async () => {
+    let now = 1000;
+    const flush = vi.fn().mockResolvedValue(undefined);
+    const finish = vi.fn().mockResolvedValue(undefined);
+    const stream = new BufferedResponseStream(
+      { flush, finish },
+      { now: () => now, minFlushIntervalMs: 750, minFlushChars: 80 },
+    );
+
+    await stream.append("hello");
+    await stream.append(" world");
+
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(flush).toHaveBeenCalledWith("hello");
+    expect(stream.getText()).toBe("hello world");
+  });
+
+  test("flushes buffered deltas after interval", async () => {
+    let now = 1000;
+    const flush = vi.fn().mockResolvedValue(undefined);
+    const finish = vi.fn().mockResolvedValue(undefined);
+    const stream = new BufferedResponseStream(
+      { flush, finish },
+      { now: () => now, minFlushIntervalMs: 750, minFlushChars: 80 },
+    );
+
+    await stream.append("hello");
+    now += 800;
+    await stream.append(" world");
+
+    expect(flush).toHaveBeenCalledTimes(2);
+    expect(flush).toHaveBeenLastCalledWith("hello world");
+  });
+
+  test("finish always emits final text", async () => {
+    const flush = vi.fn().mockResolvedValue(undefined);
+    const finish = vi.fn().mockResolvedValue(undefined);
+    const stream = new BufferedResponseStream({ flush, finish });
+
+    await stream.append("draft");
+    await stream.finish("final");
+
+    expect(finish).toHaveBeenCalledWith("final");
+    expect(stream.getText()).toBe("final");
+  });
+});

--- a/test/telegram-context.test.ts
+++ b/test/telegram-context.test.ts
@@ -452,6 +452,30 @@ describe("uploadFile()", () => {
 });
 
 // ============================================================================
+// Streaming lifecycle
+// ============================================================================
+
+describe("streaming lifecycle", () => {
+  test("delta streaming posts then updates the same message", async () => {
+    const bot = makeTelegramBot();
+    const event = makeEvent({ thread_ts: undefined });
+    const { responseCtx } = createTelegramAdapters(event, bot);
+
+    await responseCtx.appendResponseDelta?.("hello");
+    await responseCtx.appendResponseDelta?.(" world".repeat(20));
+    await responseCtx.finishResponse?.("hello final");
+
+    expect(bot.postMessageRaw).toHaveBeenCalledWith(123456, expect.stringContaining("hello"));
+    expect(bot.updateMessage).toHaveBeenCalledWith(
+      "123456",
+      "1001",
+      expect.stringContaining("world"),
+    );
+    expect(bot.updateMessage).toHaveBeenLastCalledWith("123456", "1001", "hello final");
+  });
+});
+
+// ============================================================================
 // ChatMessage fields
 // ============================================================================
 


### PR DESCRIPTION
Closes #69

## Summary

- Add first-class response delta streaming hooks to chat adapters
- Route agent `message_update` text deltas through buffered platform streams
- Support streaming responses across Slack, Discord, and Telegram
- Add buffered stream tests and adapter lifecycle coverage

## Verification

- npm test
- npm run build
- pre-commit: lint, fmt:check, knip, build, test

## Follow-up

- Slack reply mode policy is tracked separately in #70