### PR TITLE
feat(slack): configure reply mode in admin

### DIFF
--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -15,7 +15,7 @@ import type {
   ConversationKind,
   PlatformInfo,
 } from "../../adapter.js";
-import { loadAgentConfigForConversation } from "../../config.js";
+import { loadAgentConfigForConversation, MissingGlobalSettingsError } from "../../config.js";
 import type { EventsWatcher } from "../../events.js";
 import * as log from "../../log.js";
 import type { Attachment, ChannelStore } from "../../store.js";
@@ -43,6 +43,20 @@ import {
 import { reportUserFacingError } from "../../sentry.js";
 
 const SLACK_EVENT_ANCHOR_TEXT = "Working on it...";
+
+type SlackReplyMode = "top-level" | "thread";
+
+function loadSlackReplyMode(workingDir: string, conversationId: string): SlackReplyMode {
+  try {
+    return (
+      loadAgentConfigForConversation(join(workingDir, conversationId)).slack?.replyMode ??
+      "top-level"
+    );
+  } catch (err) {
+    if (err instanceof MissingGlobalSettingsError) return "top-level";
+    throw err;
+  }
+}
 
 // Slack WebClient errors carry either `code: "rate_limited"` (retry-after) or
 // the legacy `data.error === "rate_limited"` / 429 status shape.
@@ -143,9 +157,7 @@ export class SlackBot implements Bot {
 
   private createAdapters(event: SlackEvent): BotAdapters {
     return createSlackAdapters(event, this, {
-      replyMode:
-        loadAgentConfigForConversation(join(this.workingDir, event.conversationId)).slack
-          ?.replyMode ?? "top-level",
+      replyMode: loadSlackReplyMode(this.workingDir, event.conversationId),
     });
   }
 
@@ -545,9 +557,7 @@ export class SlackBot implements Bot {
         };
         const adapters = createSlackAdapters(slackEvent, this, {
           initialMessageTs: eventPlan.initialMessageTs,
-          replyMode:
-            loadAgentConfigForConversation(join(this.workingDir, eventForRun.conversationId)).slack
-              ?.replyMode ?? "top-level",
+          replyMode: loadSlackReplyMode(this.workingDir, eventForRun.conversationId),
         });
         return this.handler.handleEvent(eventForRun, this, adapters);
       });

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -15,7 +15,7 @@ import type {
   ConversationKind,
   PlatformInfo,
 } from "../../adapter.js";
-import { loadAgentConfigForConversation, MissingGlobalSettingsError } from "../../config.js";
+import { loadAgentConfigForConversation } from "../../config.js";
 import type { EventsWatcher } from "../../events.js";
 import * as log from "../../log.js";
 import type { Attachment, ChannelStore } from "../../store.js";
@@ -43,20 +43,6 @@ import {
 import { reportUserFacingError } from "../../sentry.js";
 
 const SLACK_EVENT_ANCHOR_TEXT = "Working on it...";
-
-type SlackReplyMode = "top-level" | "thread";
-
-function loadSlackReplyMode(workingDir: string, conversationId: string): SlackReplyMode {
-  try {
-    return (
-      loadAgentConfigForConversation(join(workingDir, conversationId)).slack?.replyMode ??
-      "top-level"
-    );
-  } catch (err) {
-    if (err instanceof MissingGlobalSettingsError) return "top-level";
-    throw err;
-  }
-}
 
 // Slack WebClient errors carry either `code: "rate_limited"` (retry-after) or
 // the legacy `data.error === "rate_limited"` / 429 status shape.
@@ -157,7 +143,9 @@ export class SlackBot implements Bot {
 
   private createAdapters(event: SlackEvent): BotAdapters {
     return createSlackAdapters(event, this, {
-      replyMode: loadSlackReplyMode(this.workingDir, event.conversationId),
+      replyMode:
+        loadAgentConfigForConversation(join(this.workingDir, event.conversationId)).slack
+          ?.replyMode ?? "top-level",
     });
   }
 
@@ -557,7 +545,9 @@ export class SlackBot implements Bot {
         };
         const adapters = createSlackAdapters(slackEvent, this, {
           initialMessageTs: eventPlan.initialMessageTs,
-          replyMode: loadSlackReplyMode(this.workingDir, eventForRun.conversationId),
+          replyMode:
+            loadAgentConfigForConversation(join(this.workingDir, eventForRun.conversationId)).slack
+              ?.replyMode ?? "top-level",
         });
         return this.handler.handleEvent(eventForRun, this, adapters);
       });

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -15,6 +15,7 @@ import type {
   ConversationKind,
   PlatformInfo,
 } from "../../adapter.js";
+import { loadAgentConfigForConversation } from "../../config.js";
 import type { EventsWatcher } from "../../events.js";
 import * as log from "../../log.js";
 import type { Attachment, ChannelStore } from "../../store.js";
@@ -139,6 +140,14 @@ export class SlackBot implements Bot {
   private channels = new Map<string, SlackChannel>();
   private queues = new Map<string, ChannelQueue>();
   private eventsWatcher: EventsWatcher | null = null;
+
+  private createAdapters(event: SlackEvent): BotAdapters {
+    return createSlackAdapters(event, this, {
+      replyMode:
+        loadAgentConfigForConversation(join(this.workingDir, event.conversationId)).slack
+          ?.replyMode ?? "top-level",
+    });
+  }
 
   constructor(
     handler: BotHandler,
@@ -536,6 +545,9 @@ export class SlackBot implements Bot {
         };
         const adapters = createSlackAdapters(slackEvent, this, {
           initialMessageTs: eventPlan.initialMessageTs,
+          replyMode:
+            loadAgentConfigForConversation(join(this.workingDir, eventForRun.conversationId)).slack
+              ?.replyMode ?? "top-level",
         });
         return this.handler.handleEvent(eventForRun, this, adapters);
       });
@@ -1091,7 +1103,7 @@ export class SlackBot implements Bot {
 
     this.getQueue(this.resolveQueueKey(e.channel, sessionKey)).enqueue(async () => {
       slackEvent.attachments = await attachmentsPromise;
-      const adapters = createSlackAdapters(slackEvent, this);
+      const adapters = this.createAdapters(slackEvent);
       return this.handler.handleEvent(
         slackEvent as unknown as import("../../adapter.js").BotEvent,
         this,
@@ -1225,7 +1237,7 @@ export class SlackBot implements Bot {
       slackEvent.sessionKey = activeSessionKey;
       this.getQueue(this.resolveQueueKey(e.channel, activeSessionKey)).enqueue(async () => {
         slackEvent.attachments = await attachmentsPromise;
-        const adapters = createSlackAdapters(slackEvent, this);
+        const adapters = this.createAdapters(slackEvent);
         return this.handler.handleEvent(
           slackEvent as unknown as import("../../adapter.js").BotEvent,
           this,
@@ -1482,7 +1494,7 @@ export class SlackBot implements Bot {
         attachments: [],
         sessionKey,
       };
-      return this.handler.handleEvent(event, this, createSlackAdapters(slackEvent, this));
+      return this.handler.handleEvent(event, this, this.createAdapters(slackEvent));
     });
   }
 

--- a/src/adapters/slack/context.ts
+++ b/src/adapters/slack/context.ts
@@ -20,8 +20,11 @@ const SLACK_FORMATTING_GUIDE = `## Slack Formatting (mrkdwn, NOT Markdown)
 Bold: *text*, Italic: _text_, Code: \`code\`, Block: \`\`\`code\`\`\`, Links: <url|text>
 Do NOT use **double asterisks** or [markdown](links).`;
 
+type SlackReplyMode = "top-level" | "thread";
+
 export interface SlackAdapterOptions {
   initialMessageTs?: string;
+  replyMode?: SlackReplyMode;
 }
 
 const MAX_MAIN_LENGTH = 35000; // Best-effort streaming cap; final responses use Slack error-driven fallback.
@@ -123,6 +126,8 @@ export function createSlackAdapters(
   const eventFilename = event.ts.match(/^event:([^:]+(?:\.json)?)/)?.[1];
 
   const { rootTs, isThreaded } = sessionPlan;
+  const replyMode = adapterOptions.replyMode ?? "top-level";
+  const replyInThread = Boolean(rootTs && (isThreaded || replyMode === "thread"));
 
   /**
    * Post the first visible reply.
@@ -130,7 +135,7 @@ export function createSlackAdapters(
    * If the triggering message is already inside a thread, stay in that thread.
    */
   const postFirstMessage = async (text: string): Promise<string> => {
-    if (isThreaded && rootTs) {
+    if (replyInThread && rootTs) {
       return slack.postInThread(channelId, rootTs, text);
     }
     return slack.postMessage(channelId, text);
@@ -205,7 +210,7 @@ export function createSlackAdapters(
       await slack.updateMessage(channelId, messageTs, body);
       return;
     }
-    if (isThreaded && rootTs) {
+    if (replyInThread && rootTs) {
       messageTs = await slack.postInThread(channelId, rootTs, body);
       return;
     }
@@ -223,7 +228,7 @@ export function createSlackAdapters(
         await slack.appendMessageStream(channelId, messageTs, chunk);
         return;
       }
-      if (!rootTs) {
+      if (!replyInThread || !rootTs) {
         streamUnavailable = true;
         await postOrUpdateMain(displayText);
         return;
@@ -308,7 +313,7 @@ export function createSlackAdapters(
           await startOrAppendStream(text, displayText);
 
           if (messageTs) {
-            slack.logBotResponse(channelId, text, messageTs, isThreaded ? rootTs : undefined);
+            slack.logBotResponse(channelId, text, messageTs, replyInThread ? rootTs : undefined);
           }
         },
         () => ({
@@ -326,7 +331,7 @@ export function createSlackAdapters(
         async () => {
           await stream.append(delta);
           if (messageTs) {
-            slack.logBotResponse(channelId, delta, messageTs, isThreaded ? rootTs : undefined);
+            slack.logBotResponse(channelId, delta, messageTs, replyInThread ? rootTs : undefined);
           }
         },
         () => ({ textLength: delta.length, accumulatedLength: stream.getText().length }),
@@ -419,7 +424,7 @@ export function createSlackAdapters(
       updatePromise = updatePromise.then(async () => {
         isWorking = false;
         accumulatedText = response.text;
-        if (isThreaded && rootTs) {
+        if (replyInThread && rootTs) {
           messageTs = await slack.postInThreadBlocks(
             channelId,
             rootTs,
@@ -434,7 +439,7 @@ export function createSlackAdapters(
           channelId,
           response.text,
           messageTs,
-          isThreaded ? rootTs : undefined,
+          replyInThread ? rootTs : undefined,
           response.blocks,
         );
       });

--- a/src/admin/portal.ts
+++ b/src/admin/portal.ts
@@ -12,6 +12,7 @@ import {
   saveConversationAutoReplyConfig,
   saveConversationModelConfig,
   saveConversationSandboxConfig,
+  saveConversationSlackConfig,
   type AgentConfig,
 } from "../config.js";
 import { escapeHtml } from "../html.js";
@@ -175,6 +176,10 @@ function routeApiRequest(
         serveConversationAutoReplyUpdate(res, body, services, token);
         return;
       }
+      if (url.pathname === "/admin/api/conversations/slack") {
+        serveConversationSlackUpdate(res, body, services, token);
+        return;
+      }
       if (url.pathname === "/admin/api/conversations/session-link") {
         serveConversationSessionLink(res, body, services, token);
         return;
@@ -193,6 +198,10 @@ function routeApiRequest(
       }
       if (url.pathname === "/admin/api/settings/sandbox") {
         serveGlobalSandboxUpdate(res, body);
+        return;
+      }
+      if (url.pathname === "/admin/api/settings/slack") {
+        serveGlobalSlackUpdate(res, body);
         return;
       }
       jsonRes(res, 404, { error: "Not found" });
@@ -346,6 +355,8 @@ function serveConversationState(
     modelConfig = null;
   }
   const autoReply = loadConversationAutoReplyConfig(dir);
+  const globalConfig = loadAgentConfig();
+  const localSettings = loadAgentConfigForConversation(dir);
 
   jsonRes(res, 200, {
     conversationId,
@@ -355,6 +366,10 @@ function serveConversationState(
     sandboxImageWorkspaceMount: modelConfig?.sandboxImageWorkspaceMount ?? null,
     autoReplyEnabled: autoReply.enabled,
     autoReplyRules: autoReply.rules,
+    slack: {
+      replyMode: localSettings.slack?.replyMode ?? globalConfig.slack?.replyMode ?? "top-level",
+      globalReplyMode: globalConfig.slack?.replyMode ?? "top-level",
+    },
   });
 }
 
@@ -371,6 +386,9 @@ function serveGlobalSettings(res: ServerResponse): void {
       sandboxBoostMemory: config.sandboxBoostMemory ?? null,
       sandboxImageWorkspaceMount: config.sandboxImageWorkspaceMount ?? null,
       defaultSharedVault: config.defaultSharedVault ?? null,
+      slack: {
+        replyMode: config.slack?.replyMode ?? "top-level",
+      },
     });
   } catch (err) {
     jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
@@ -465,6 +483,33 @@ function serveConversationSandboxUpdate(
   const dir = join(workingDir, scope.conversationId);
   try {
     saveConversationSandboxConfig(dir, { imageWorkspaceMount: workspaceMount });
+    jsonRes(res, 200, { ok: true });
+  } catch (err) {
+    jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+function serveConversationSlackUpdate(
+  res: ServerResponse,
+  body: Record<string, unknown>,
+  services: AdminServices,
+  token: AdminToken,
+): void {
+  const replyMode = body.replyMode;
+  if (replyMode !== "top-level" && replyMode !== "thread") {
+    jsonRes(res, 400, { error: "replyMode must be 'top-level' or 'thread'" });
+    return;
+  }
+  const scope = resolveTargetConversation(body, token);
+  if (scope.error) {
+    jsonRes(res, 403, { error: scope.error });
+    return;
+  }
+  const workingDir = requireAdminWorkingDir(res, services);
+  if (!workingDir) return;
+  const dir = join(workingDir, scope.conversationId);
+  try {
+    saveConversationSlackConfig(dir, { replyMode });
     jsonRes(res, 200, { ok: true });
   } catch (err) {
     jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
@@ -621,6 +666,21 @@ function serveGlobalModelUpdate(res: ServerResponse, body: Record<string, unknow
       model,
       ...(thinkingLevel ? { thinkingLevel } : {}),
     });
+    jsonRes(res, 200, { ok: true });
+  } catch (err) {
+    jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+function serveGlobalSlackUpdate(res: ServerResponse, body: Record<string, unknown>): void {
+  const replyMode = body.replyMode;
+  if (replyMode !== "top-level" && replyMode !== "thread") {
+    jsonRes(res, 400, { error: "replyMode must be 'top-level' or 'thread'" });
+    return;
+  }
+
+  try {
+    saveAgentConfig({ slack: { replyMode } });
     jsonRes(res, 200, { ok: true });
   } catch (err) {
     jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
@@ -1550,6 +1610,11 @@ function renderAdminPage(token: AdminToken): string {
         '<option value="' + m + '"' + (data.sandboxImageWorkspaceMount === m ? ' selected' : '') + '>' + m + '</option>'
       ).join('');
       const rulesText = (data.autoReplyRules || []).join('\\n');
+      const replyModes = ['top-level','thread'];
+      const replyModeOpts = replyModes.map((m) =>
+        '<option value="' + m + '"' + (((data.slack && data.slack.replyMode) || 'top-level') === m ? ' selected' : '') + '>' + m + '</option>'
+      ).join('');
+      const globalReplyMode = (data.slack && data.slack.globalReplyMode) || 'top-level';
       return [
         '<div class="config-grid">',
           '<div class="config-block">',
@@ -1571,6 +1636,13 @@ function renderAdminPage(token: AdminToken): string {
             '<div class="config-row"><label>Mode</label><select id="m-mount">' + mountOpts + '</select></div>',
             '<button class="primary-action-btn" onclick="saveMount(this)">Save mount</button>',
             '<div id="mount-save-result" class="inline-result" style="display:none"></div>',
+          '</div>',
+          '<div class="config-block">',
+            '<h3 class="card-subtitle">Slack</h3>',
+            '<div class="config-row"><label>Reply mode</label><select id="m-slack-reply-mode">' + replyModeOpts + '</select></div>',
+            '<p class="muted-note">Global default: ' + escHtml(globalReplyMode) + '</p>',
+            '<button class="primary-action-btn" onclick="saveSlack(this)">Save Slack</button>',
+            '<div id="slack-save-result" class="inline-result" style="display:none"></div>',
           '</div>',
         '</div>',
       ].join('');
@@ -1634,6 +1706,22 @@ function renderAdminPage(token: AdminToken): string {
         result.style.display = 'block'; result.className = 'inline-result err'; result.textContent = err.message;
       } finally {
         btn.disabled = false; btn.textContent = 'Save mount';
+      }
+    }
+
+    async function saveSlack(btn) {
+      const replyMode = document.getElementById('m-slack-reply-mode').value;
+      const result = document.getElementById('slack-save-result');
+      btn.disabled = true; btn.textContent = 'Saving…'; result.style.display = 'none';
+      try {
+        await apiPost('/admin/api/conversations/slack', {
+          conversationId: activeConversationId, replyMode,
+        });
+        result.style.display = 'block'; result.className = 'inline-result ok'; result.textContent = 'Saved ✓';
+      } catch (err) {
+        result.style.display = 'block'; result.className = 'inline-result err'; result.textContent = err.message;
+      } finally {
+        btn.disabled = false; btn.textContent = 'Save Slack';
       }
     }
 
@@ -1902,6 +1990,10 @@ function renderAdminPage(token: AdminToken): string {
       const mountOpts = mounts.map((m) =>
         '<option value="' + m + '"' + (data.sandboxImageWorkspaceMount === m ? ' selected' : '') + '>' + m + '</option>'
       ).join('');
+      const replyModes = ['top-level','thread'];
+      const replyModeOpts = replyModes.map((m) =>
+        '<option value="' + m + '"' + (((data.slack && data.slack.replyMode) || 'top-level') === m ? ' selected' : '') + '>' + m + '</option>'
+      ).join('');
       return [
         '<div class="config-grid">',
           '<div class="config-block">',
@@ -1920,6 +2012,12 @@ function renderAdminPage(token: AdminToken): string {
             '<div class="config-row"><label>Mount</label><select id="g-mount">' + mountOpts + '</select></div>',
             '<button class="primary-action-btn" onclick="saveGlobalSandbox(this)">Save sandbox</button>',
             '<div id="g-sandbox-result" class="inline-result" style="display:none"></div>',
+          '</div>',
+          '<div class="config-block">',
+            '<h3 class="card-subtitle">Slack</h3>',
+            '<div class="config-row"><label>Reply mode</label><select id="g-slack-reply-mode">' + replyModeOpts + '</select></div>',
+            '<button class="primary-action-btn" onclick="saveGlobalSlack(this)">Save Slack</button>',
+            '<div id="g-slack-result" class="inline-result" style="display:none"></div>',
           '</div>',
         '</div>',
       ].join('');
@@ -1961,6 +2059,20 @@ function renderAdminPage(token: AdminToken): string {
         result.style.display = 'block'; result.className = 'inline-result err'; result.textContent = err.message;
       } finally {
         btn.disabled = false; btn.textContent = 'Save sandbox';
+      }
+    }
+
+    async function saveGlobalSlack(btn) {
+      const replyMode = document.getElementById('g-slack-reply-mode').value;
+      const result = document.getElementById('g-slack-result');
+      btn.disabled = true; btn.textContent = 'Saving…'; result.style.display = 'none';
+      try {
+        await apiPost('/admin/api/settings/slack', { replyMode });
+        result.style.display = 'block'; result.className = 'inline-result ok'; result.textContent = 'Saved ✓';
+      } catch (err) {
+        result.style.display = 'block'; result.className = 'inline-result err'; result.textContent = err.message;
+      } finally {
+        btn.disabled = false; btn.textContent = 'Save Slack';
       }
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,12 @@ export class MissingGlobalSettingsError extends Error {
   }
 }
 
+type SlackReplyMode = "top-level" | "thread";
+
+export interface SlackConfig {
+  replyMode?: SlackReplyMode;
+}
+
 export interface AgentConfig {
   provider: string;
   model: string;
@@ -25,6 +31,7 @@ export interface AgentConfig {
   sandboxBoostMemory?: string;
   sandboxImageWorkspaceMount?: "private" | "full";
   defaultSharedVault?: string;
+  slack?: SlackConfig;
 }
 
 export interface AutoReplyConfig {
@@ -46,6 +53,9 @@ const ONBOARD_SETTINGS: SettingsFileConfig = {
       provider: "anthropic",
       model: "claude-haiku-4-5",
     },
+  },
+  slack: {
+    replyMode: "top-level",
   },
   sandbox: {
     cpus: "0.5",
@@ -87,6 +97,11 @@ const SettingsFileSchema = Type.Object({
   sentry: Type.Optional(
     Type.Object({
       dsn: Type.Optional(Type.String()),
+    }),
+  ),
+  slack: Type.Optional(
+    Type.Object({
+      replyMode: Type.Optional(Type.Union([Type.Literal("top-level"), Type.Literal("thread")])),
     }),
   ),
   sandbox: Type.Optional(
@@ -152,6 +167,7 @@ function normalizeSettingsConfig(config: SettingsFileConfig): Partial<AgentConfi
     ...(config.sandbox?.defaultSharedVault?.trim()
       ? { defaultSharedVault: config.sandbox.defaultSharedVault.trim() }
       : {}),
+    ...(config.slack !== undefined ? { slack: config.slack } : {}),
   };
 }
 
@@ -192,6 +208,7 @@ function toAgentConfig(fromFile: Partial<AgentConfig>): AgentConfig {
   const sandboxBoostMemory = fromFile.sandboxBoostMemory;
   const sandboxImageWorkspaceMount = fromFile.sandboxImageWorkspaceMount;
   const defaultSharedVault = fromFile.defaultSharedVault;
+  const slack = fromFile.slack;
 
   return {
     provider,
@@ -204,6 +221,7 @@ function toAgentConfig(fromFile: Partial<AgentConfig>): AgentConfig {
     sandboxBoostMemory,
     sandboxImageWorkspaceMount,
     defaultSharedVault,
+    slack,
   };
 }
 
@@ -233,6 +251,17 @@ export function saveConversationModelConfig(
   const scopedConfig: SettingsFileConfig = {
     ...existing,
     llm: { ...existing.llm, ...config },
+  };
+  atomicWritePrivateFile(settingsPath, JSON.stringify(scopedConfig, null, 2));
+}
+
+export function saveConversationSlackConfig(conversationDir: string, config: SlackConfig): void {
+  ensureDirExists(conversationDir);
+  const settingsPath = join(conversationDir, "settings.json");
+  const existing = loadSettingsFile(settingsPath) ?? {};
+  const scopedConfig: SettingsFileConfig = {
+    ...existing,
+    slack: { ...existing.slack, ...config },
   };
   atomicWritePrivateFile(settingsPath, JSON.stringify(scopedConfig, null, 2));
 }
@@ -405,6 +434,7 @@ function compactSettingsConfig(config: SettingsFileConfig): SettingsFileConfig {
     ...(hasDefinedValue(config.sentry) ? { sentry: config.sentry } : {}),
     ...(hasDefinedValue(config.sandbox) ? { sandbox: config.sandbox } : {}),
     ...(hasDefinedValue(config.autoReply) ? { autoReply: config.autoReply } : {}),
+    ...(hasDefinedValue(config.slack) ? { slack: config.slack } : {}),
   };
 }
 
@@ -439,6 +469,10 @@ function patchSettingsConfig(
             },
           }
         : {}),
+    },
+    slack: {
+      ...existing.slack,
+      ...config.slack,
     },
   };
   return compactSettingsConfig(patched);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -284,6 +284,7 @@ describe("saveAgentConfig", () => {
         image: { workspaceMount: "private" },
         defaultSharedVault: "",
       },
+      slack: { replyMode: "top-level" },
     });
   });
 
@@ -307,6 +308,7 @@ describe("saveAgentConfig", () => {
         image: { workspaceMount: "private" },
         defaultSharedVault: "",
       },
+      slack: { replyMode: "top-level" },
     });
   });
 

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { BotHandler } from "../src/adapter.js";
 import { SlackBot } from "../src/adapters/slack/bot.js";
 import { defaultCommandHandlers } from "../src/commands/index.js";
+import { createGlobalSettingsFile } from "../src/config.js";
 import type { CommandServices } from "../src/commands/types.js";
 import { ConversationOrchestrator } from "../src/runtime/conversation-orchestrator.js";
 import { createManagedSessionFileAtPath, getThreadSessionFile } from "../src/sessions/store.js";
@@ -56,9 +57,12 @@ describe("SlackBot slash commands", () => {
 
   beforeEach(() => {
     workingDir = mkdtempSync(join(tmpdir(), "mikan-slack-bot-"));
+    process.env.MIKAN_STATE_DIR = workingDir;
+    createGlobalSettingsFile(workingDir);
   });
 
   afterEach(() => {
+    delete process.env.MIKAN_STATE_DIR;
     if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
   });
 
@@ -456,9 +460,12 @@ describe("SlackBot queues follow-up messages", () => {
 
   beforeEach(() => {
     workingDir = mkdtempSync(join(tmpdir(), "mikan-slack-queue-"));
+    process.env.MIKAN_STATE_DIR = workingDir;
+    createGlobalSettingsFile(workingDir);
   });
 
   afterEach(() => {
+    delete process.env.MIKAN_STATE_DIR;
     if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
   });
 
@@ -1333,9 +1340,12 @@ describe("SlackBot backfill", () => {
 
   beforeEach(() => {
     workingDir = mkdtempSync(join(tmpdir(), "mikan-slack-backfill-"));
+    process.env.MIKAN_STATE_DIR = workingDir;
+    createGlobalSettingsFile(workingDir);
   });
 
   afterEach(() => {
+    delete process.env.MIKAN_STATE_DIR;
     if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
   });
 
@@ -1475,9 +1485,12 @@ describe("SlackBot attachments", () => {
 
   beforeEach(() => {
     workingDir = mkdtempSync(join(tmpdir(), "mikan-slack-attachments-"));
+    process.env.MIKAN_STATE_DIR = workingDir;
+    createGlobalSettingsFile(workingDir);
   });
 
   afterEach(() => {
+    delete process.env.MIKAN_STATE_DIR;
     if (existsSync(workingDir)) rmSync(workingDir, { recursive: true, force: true });
   });
 

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -55,8 +55,7 @@ describe("SlackBot slash commands", () => {
   let workingDir: string;
 
   beforeEach(() => {
-    workingDir = join(tmpdir(), `mikan-slack-bot-${Date.now()}`);
-    mkdirSync(workingDir, { recursive: true });
+    workingDir = mkdtempSync(join(tmpdir(), "mikan-slack-bot-"));
   });
 
   afterEach(() => {
@@ -456,8 +455,7 @@ describe("SlackBot queues follow-up messages", () => {
   let workingDir: string;
 
   beforeEach(() => {
-    workingDir = join(tmpdir(), `mikan-slack-queue-${Date.now()}`);
-    mkdirSync(workingDir, { recursive: true });
+    workingDir = mkdtempSync(join(tmpdir(), "mikan-slack-queue-"));
   });
 
   afterEach(() => {
@@ -1334,8 +1332,7 @@ describe("SlackBot backfill", () => {
   let workingDir: string;
 
   beforeEach(() => {
-    workingDir = join(tmpdir(), `mikan-slack-backfill-${Date.now()}`);
-    mkdirSync(workingDir, { recursive: true });
+    workingDir = mkdtempSync(join(tmpdir(), "mikan-slack-backfill-"));
   });
 
   afterEach(() => {
@@ -1477,8 +1474,7 @@ describe("SlackBot attachments", () => {
   let workingDir: string;
 
   beforeEach(() => {
-    workingDir = join(tmpdir(), `mikan-slack-attachments-${Date.now()}`);
-    mkdirSync(workingDir, { recursive: true });
+    workingDir = mkdtempSync(join(tmpdir(), "mikan-slack-attachments-"));
   });
 
   afterEach(() => {

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -153,25 +153,51 @@ describe("respond() — non-threaded", () => {
     expect(bot.postInThread).not.toHaveBeenCalled();
   });
 
-  test("uses Slack stream APIs when available", async () => {
+  test("default top-level reply mode uses chat.update streaming", async () => {
+    const bot = makeSlackBot({
+      postMessage: vi.fn().mockResolvedValue("MSG1"),
+      startMessageStream: vi.fn().mockResolvedValue("STREAM1"),
+    });
+    const event = makeEvent({ thread_ts: undefined });
+    const { responseCtx } = createSlackAdapters(event, bot);
+
+    await responseCtx.appendResponseDelta?.("first");
+    await responseCtx.appendResponseDelta?.(" second".repeat(20));
+    await responseCtx.finishResponse?.("final");
+
+    expect(bot.startMessageStream).not.toHaveBeenCalled();
+    expect(bot.postMessage).toHaveBeenCalledWith("C001", expect.stringContaining("first"));
+    expect(bot.updateMessage).toHaveBeenCalledWith(
+      "C001",
+      "MSG1",
+      expect.stringContaining("second"),
+    );
+    expect(bot.updateMessage).toHaveBeenLastCalledWith("C001", "MSG1", "final");
+  });
+
+  test("thread reply mode streams top-level inputs in the user message thread", async () => {
     const bot = makeSlackBot({
       startMessageStream: vi.fn().mockResolvedValue("STREAM1"),
       appendMessageStream: vi.fn().mockResolvedValue(undefined),
       stopMessageStream: vi.fn().mockResolvedValue(undefined),
     });
     const event = makeEvent({ thread_ts: undefined });
-    const { responseCtx } = createSlackAdapters(event, bot);
+    const { responseCtx } = createSlackAdapters(event, bot, { replyMode: "thread" });
 
-    await responseCtx.respond("first");
-    await responseCtx.respond("second");
-    await responseCtx.setWorking(false);
+    await responseCtx.appendResponseDelta?.("first");
+    await responseCtx.appendResponseDelta?.(" second".repeat(20));
+    await responseCtx.finishResponse?.("final");
 
     expect(bot.startMessageStream).toHaveBeenCalledWith(
       "C001",
       expect.stringContaining("first"),
       "1000.0001",
     );
-    expect(bot.appendMessageStream).toHaveBeenCalledWith("C001", "STREAM1", "second");
+    expect(bot.appendMessageStream).toHaveBeenCalledWith(
+      "C001",
+      "STREAM1",
+      expect.stringContaining("second"),
+    );
     expect(bot.stopMessageStream).toHaveBeenCalledWith("C001", "STREAM1");
     expect(bot.postMessage).not.toHaveBeenCalled();
     expect(bot.updateMessage).not.toHaveBeenCalled();
@@ -179,6 +205,26 @@ describe("respond() — non-threaded", () => {
 });
 
 describe("respond() — threaded", () => {
+  test("streaming stays in user's thread regardless of top-level reply mode", async () => {
+    const bot = makeSlackBot({
+      startMessageStream: vi.fn().mockResolvedValue("STREAM1"),
+      appendMessageStream: vi.fn().mockResolvedValue(undefined),
+      stopMessageStream: vi.fn().mockResolvedValue(undefined),
+    });
+    const event = makeEvent({ ts: "1000.0003", thread_ts: "1000.0001" });
+    const { responseCtx } = createSlackAdapters(event, bot, { replyMode: "top-level" });
+
+    await responseCtx.appendResponseDelta?.("first");
+    await responseCtx.finishResponse?.("final");
+
+    expect(bot.startMessageStream).toHaveBeenCalledWith(
+      "C001",
+      expect.stringContaining("first"),
+      "1000.0001",
+    );
+    expect(bot.postMessage).not.toHaveBeenCalled();
+  });
+
   test("first call posts in user's thread (rootTs)", async () => {
     const bot = makeSlackBot();
     const event = makeEvent({ ts: "1000.0003", thread_ts: "1000.0001" });
@@ -613,25 +659,29 @@ describe("thread_ts boundary values", () => {
 });
 
 describe("streaming lifecycle", () => {
-  test("native stream failure falls back to incremental chat.update for later deltas", async () => {
+  test("thread reply mode native stream failure falls back to incremental chat.update", async () => {
     const bot = makeSlackBot({
       startMessageStream: vi.fn().mockRejectedValue(new Error("missing required field: thread_ts")),
       postMessage: vi.fn().mockResolvedValue("T001"),
       updateMessage: vi.fn().mockResolvedValue(undefined),
     });
     const event = makeEvent({ thread_ts: undefined });
-    const { responseCtx } = createSlackAdapters(event, bot);
+    const { responseCtx } = createSlackAdapters(event, bot, { replyMode: "thread" });
 
     await responseCtx.appendResponseDelta?.("hello");
     await responseCtx.appendResponseDelta?.(" world".repeat(20));
     await responseCtx.finishResponse?.("hello final");
 
-    expect(bot.postMessage).toHaveBeenCalledWith("C001", expect.stringContaining("hello"));
+    expect(bot.postInThread).toHaveBeenCalledWith(
+      "C001",
+      "1000.0001",
+      expect.stringContaining("hello"),
+    );
     expect(bot.updateMessage).toHaveBeenCalledWith(
       "C001",
-      "T001",
+      "T002",
       expect.stringContaining("world"),
     );
-    expect(bot.updateMessage).toHaveBeenLastCalledWith("C001", "T001", "hello final");
+    expect(bot.updateMessage).toHaveBeenLastCalledWith("C001", "T002", "hello final");
   });
 });


### PR DESCRIPTION
## Summary

- Add `slack.replyMode` to global and conversation settings
- Expose Slack reply mode controls in the admin portal
- Route Slack responses using effective conversation settings
- Keep top-level mode on `postMessage`/`chat.update`; use native stream only for thread targets

## Verification

- npm test
- npm run build

Closes #70