### PR TITLE
feat: add sandbox bridge secret injection

### DIFF
--- a/docs/sandbox-verification.md
+++ b/docs/sandbox-verification.md
@@ -1,0 +1,137 @@
+# Sandbox / Vault 驗證計畫
+
+目標：確認 `image:*` managed sandbox 在單機部署下不把 vault 長期注入 container；需要補 secret 的 HTTP outbound request 會走執行期 proxy，由 proxy 補 header；同時 `gh`、Google Workspace CLI、`gcloud` 等工具仍能透過執行期 secrets 正常使用；並確認介面能對齊 Cloudflare / 第三方 sandbox。
+
+## 1. 靜態與單元測試
+
+必跑：
+
+```bash
+npm test -- test/sandbox.test.ts test/vault.test.ts test/provisioner.test.ts
+npm test
+npm run build
+npm run verify:sandbox-cli-proxy
+npx oxfmt --check src/execution-resolver.ts src/sandbox/cloudflare.ts src/sandbox/container.ts src/sandbox/firecracker.ts src/sandbox/index.ts src/sandbox/types.ts test/sandbox.test.ts test/vault.test.ts scripts/verify-sandbox-cli-proxy.mjs
+npm run lint
+```
+
+驗收標準：
+
+- `test/vault.test.ts` 驗證 `image:*` provisioner 的 Docker mounts 只包含 workspace 相關 mounts，不包含 vault mounts。
+- `test/sandbox.test.ts` 驗證 vault file 透過每次 `docker exec` 的臨時 staging 提供，不使用 `docker run -v` 或長期 bind mount。
+- `test/sandbox.test.ts` 驗證 secret injection proxy 會依 `MIKAN_PROXY_INJECT_HEADERS` 對目標 host 補 header。
+- `npm test` 全量通過。
+- `npm run build` 通過。
+- lint 無 errors；既有 warnings 需確認不是本次修改新增。
+- `verify:sandbox-cli-proxy` 在真 Docker network 中用 `gh`、`gcloud`、`gws`、`sentry-cli` 四種 CLI 形態的命令驗證 proxy env 對 subprocess 生效，且 upstream 收到 proxy 補上的 header。
+
+## 2. Docker container 隔離驗證
+
+準備：
+
+```bash
+STATE_DIR=$(mktemp -d)
+WORKSPACE=$(mktemp -d)
+mkdir -p "$STATE_DIR/vaults/d123/.ssh" "$WORKSPACE/D123"
+printf 'GH_TOKEN=dummy-token\nGOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json\n' > "$STATE_DIR/vaults/d123/env"
+printf '{"type":"authorized_user","client_id":"dummy","client_secret":"dummy","refresh_token":"dummy"}\n' > "$STATE_DIR/vaults/d123/gcloud-adc.json"
+```
+
+以 `image:<image>` 啟動 mikan，觸發 conversation `D123` 執行任一 command 後驗證：
+
+```bash
+docker inspect mikan-sandbox-d123 --format '{{json .HostConfig.Binds}}'
+```
+
+驗收標準：
+
+- 輸出不得包含 `$STATE_DIR/vaults`、`.ssh`、`gcloud-adc.json`、`gws.json` 等 vault path。
+- 只允許 workspace 相關 mounts，例如 `MEMORY.md`、`skills`、`events`、conversation directory，或 full workspace mode 的 `/workspace`。
+
+## 3. 執行期 secrets 清理驗證
+
+在同一個 `image:*` container 中執行：
+
+```bash
+# 透過 mikan/agent 執行一次需要 credential target path 的 command
+ls -la /root/.config/gcloud || true
+
+# command 結束後直接進 container 檢查
+docker exec mikan-sandbox-d123 sh -lc 'test ! -e /root/.config/gcloud/application_default_credentials.json'
+```
+
+驗收標準：
+
+- command 執行期間 CLI 可以讀到目標 credential path。
+- command 結束後，credential file / directory 不留在 container filesystem。
+- 若 target path 原本存在，command 結束後要恢復原內容。
+
+## 4. Proxy secret injection 驗證
+
+設定 vault env：
+
+```env
+MIKAN_PROXY_INJECT_HEADERS={"api.internal:8080":{"authorization":"Bearer proxy-secret"}}
+```
+
+在同一個 Docker network 放一個測試 upstream，先直接從 sandbox request，再透過 mikan executor request：
+
+```bash
+# direct request：upstream 不應收到 Authorization
+wget -qO- http://api.internal:8080/direct
+
+# mikan exec request：executor 會啟動 127.0.0.1 proxy 並設定 HTTP_PROXY/http_proxy
+wget -qO- http://api.internal:8080/via-proxy
+```
+
+驗收標準：
+
+- direct request 不帶 `Authorization`。
+- 經 mikan executor 的 request 必須由 inline proxy 補上 `Authorization: Bearer proxy-secret`。
+- `npm run verify:sandbox-cli-proxy` 必須證明 `gh`、`gcloud`、`gws`、`sentry-cli` 這類 CLI subprocess 都能透過同一套 proxy env 走代理並讓 upstream 收到補上的 header。
+- `MIKAN_PROXY_INJECT_HEADERS` 不會留在 container base env。
+- proxy 只在單次 command 存活；command 結束後 proxy process 被清掉。
+
+注意：目前 proxy 對 plain HTTP request 可補 header；HTTPS CONNECT 只能 tunnel，不能在不做 MITM 的情況下修改 TLS 內的 request header。
+
+## 5. CLI 功能煙霧測試
+
+在測試 vault 中放入對應 OAuth / token 後，透過 `image:*` conversation 執行：
+
+```bash
+gh auth status
+gcloud auth application-default print-access-token
+gws --help
+```
+
+驗收標準：
+
+- `gh` 使用 `GH_TOKEN` / `GITHUB_TOKEN`，並仍會執行 `gh auth setup-git` bootstrap。
+- `gcloud` 能讀取 `GOOGLE_APPLICATION_CREDENTIALS` 指向的臨時 staged credential。
+- `gws` 能讀取其預設 target path 的臨時 staged credential。
+- 測試後直接 `docker exec` 檢查 credential target path 不殘留。
+
+## 6. Cloudflare / 第三方 sandbox 介面對齊驗證
+
+必查：
+
+- `SandboxSecrets` 只表達 `env` 與 `files`，不暴露 Docker 專屬 mount 語意。
+- `CloudflareSandboxExecutor` 透過 payload 的 `env` 傳送 secrets，保留未來 bridge 增加 file projection 的空間。
+- `FirecrackerExecutor` 同樣吃 `SandboxSecrets`，避免 adapter API 分裂。
+
+驗收標準：
+
+- `createExecutor(config, secrets, ensureReady)` 是各 sandbox adapter 的共同入口。
+- Docker-specific lifecycle / bind mount 邏輯仍只在 `DockerContainerManager` 與 `ContainerExecutor` 內部。
+- 新增第三方 sandbox 時不需要讀取 Docker mount 資料結構即可接入 env/file secret 語意。
+
+## 7. 回歸風險檢查
+
+每次修改 sandbox / vault injection 相關程式碼後，至少重跑：
+
+```bash
+npm test -- test/sandbox.test.ts test/vault.test.ts test/provisioner.test.ts test/oauth-link-server.test.ts test/link-server.test.ts
+npm run build
+```
+
+如果改到 OAuth target path、vault file 推斷、或 login portal，需額外手動跑 GitHub、Google Workspace、Google Cloud SDK OAuth onboarding 流程。

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -8,9 +8,10 @@
 | ----------------------------------------------------------- | --------------------- | ------------------- | ---------------------------- | ---------------------------------------------------------------------------------- |
 | `host`                                                      | 宿主機                | 不注入              | 可存，但執行時不用           | 最適合本機開發；不把 vault env 放進 host process                                   |
 | `container:<name>`                                          | 既有 Docker container | 注入                | `container-<name>`           | one container one vault；多人共用同一 container 就共用該 vault                     |
-| `image:<image>`                                             | mikan 管理的 Docker   | 注入                | generated conversation vault | 目前最推薦的隔離模式；`1 conversation = 1 vault = 1 container`                     |
+| `image:<image>`                                             | mikan 管理的 Docker   | exec 時短暫注入     | generated conversation vault | 目前最推薦的隔離模式；vault 不會作為長期 bind mount 留在 container 內              |
 | `firecracker:<vm-id>:<host-path>[:<ssh-user>[:<ssh-port>]]` | Firecracker VM        | 注入                | generated conversation vault | Alpha 超早期；VM 需自行啟動，workspace 需在 VM 內掛到 `/workspace`，目前不建議使用 |
 | `cloudflare:<sandbox-id>`                                   | Cloudflare Worker     | 注入                | generated conversation vault | Experimental；需自行部署 `@cloudflare/sandbox` bridge，host workspace 不會自動同步 |
+| `gondolin:<sandbox-id>`                                     | Gondolin micro-VM     | 注入                | generated conversation vault | Experimental；需自行啟動 Gondolin bridge，本機 micro-VM sandbox                    |
 
 `docker:*` 不是可用模式；請改用 `container:*` 或 `image:*`。
 
@@ -18,20 +19,20 @@
 
 `image:<image>` 是目前主要開發與推薦的 sandbox 模式；其他模式保留為本機開發、相容、或實驗用途，部分能力不會補齊。
 
-| 能力                                 | `host`   | `container:<name>` | `image:<image>` | `firecracker:*` | `cloudflare:*` |
-| ------------------------------------ | -------- | ------------------ | --------------- | --------------- | -------------- |
-| command 執行                         | ✅       | ✅                 | ✅              | ✅              | ✅             |
-| mikan 管理 runtime lifecycle         | 不適用   | ❌                 | ✅              | ❌              | ❌             |
-| per-conversation container / runtime | ❌       | ❌                 | ✅              | 需自行管理      | bridge 衍生 id |
-| per-conversation vault env           | ❌       | ❌                 | ✅              | ✅              | ✅             |
-| vault file 自動投影 / bind mount     | ❌       | ❌                 | ✅              | ❌              | ❌             |
-| workspace 自動掛載                   | host     | 需自行掛載         | ✅              | 需自行掛載      | ❌             |
-| private workspace mount mode         | 不適用   | ❌                 | ✅              | ❌              | ❌             |
-| idle auto-stop / recreate            | 不適用   | ❌                 | ✅              | ❌              | ❌             |
-| CPU / memory default limits          | ❌       | ❌                 | ✅              | ❌              | ❌             |
-| `/pi-sandbox boost`                  | ❌       | ❌                 | ✅              | ❌              | ❌             |
-| agent `sandbox` tool 設定 limits     | ❌       | ❌                 | ✅              | ❌              | ❌             |
-| 推薦程度                             | 本機開發 | legacy / 相容      | 主線            | alpha           | experimental   |
+| 能力                                 | `host`   | `container:<name>` | `image:<image>` | `firecracker:*` | `cloudflare:*` | `gondolin:*`   |
+| ------------------------------------ | -------- | ------------------ | --------------- | --------------- | -------------- | -------------- |
+| command 執行                         | ✅       | ✅                 | ✅              | ✅              | ✅             | ✅             |
+| mikan 管理 runtime lifecycle         | 不適用   | ❌                 | ✅              | ❌              | ❌             | bridge 管理    |
+| per-conversation container / runtime | ❌       | ❌                 | ✅              | 需自行管理      | bridge 衍生 id | bridge 衍生 id |
+| per-conversation vault env           | ❌       | ❌                 | ✅              | ✅              | ✅             | ✅             |
+| vault file 執行期短暫投影            | ❌       | ❌                 | ✅              | ❌              | ❌             | bridge 實作    |
+| workspace 自動掛載                   | host     | 需自行掛載         | ✅              | 需自行掛載      | ❌             | bridge 掛載    |
+| private workspace mount mode         | 不適用   | ❌                 | ✅              | ❌              | ❌             | ❌             |
+| idle auto-stop / recreate            | 不適用   | ❌                 | ✅              | ❌              | ❌             | bridge 管理    |
+| CPU / memory default limits          | ❌       | ❌                 | ✅              | ❌              | ❌             | bridge 管理    |
+| `/pi-sandbox boost`                  | ❌       | ❌                 | ✅              | ❌              | ❌             | ❌             |
+| agent `sandbox` tool 設定 limits     | ❌       | ❌                 | ✅              | ❌              | ❌             | ❌             |
+| 推薦程度                             | 本機開發 | legacy / 相容      | 主線            | alpha           | experimental   | experimental   |
 
 ---
 
@@ -185,8 +186,10 @@ mikan --sandbox=image:mikan-sandbox:tools /path/to/workspace
 - mikan 會為每個 conversation 建立一個獨立 vault 與 container
 - 每個 container 會綁定自己的 Docker bridge network，彼此預設互相隔離
 - container 內只會看到 `/workspace/MEMORY.md`、`/workspace/skills`、`/workspace/events` 與當前 conversation 目錄
-- vault env 會在執行時注入
-- vault file credential 會依 target path 自動 bind mount 進 container
+- vault env 會在每次 `docker exec` 時透過臨時 env file 注入，不寫進 container 設定
+- vault file credential 會在單次 command 執行期間 staging 到 target path，command 結束後清除並還原原 target
+- vault path 不會作為 Docker bind mount 注入 managed container；`docker inspect ...HostConfig.Binds` 不應出現 vault 目錄
+- 若 vault env 設定 `MIKAN_PROXY_INJECT_HEADERS`，mikan 會在單次 command 期間啟動 sandbox-local HTTP proxy，並設定 `HTTP_PROXY` / `http_proxy`，讓 HTTP outbound request 經 proxy 補 header
 - 閒置 container 會自動 stop；下次需要時再 start 或 recreate
 
 vault key 選擇邏輯：
@@ -200,6 +203,8 @@ vault key 選擇邏輯：
 - 多使用者共用一個 mikan instance
 - 需要 per-conversation env/file credential isolation
 - 想比 shared container 更安全，但又不想直接上 Firecracker
+
+完整驗證流程請見 [Sandbox / Vault 驗證計畫](./sandbox-verification.md)。
 
 ### 容器資源限制
 
@@ -297,6 +302,36 @@ mikan --sandbox=cloudflare:mikan-remote /path/to/workspace
 可直接使用範例 bridge：
 
 - [examples/cloudflare-sandbox-bridge/README.md](../examples/cloudflare-sandbox-bridge/README.md)
+
+---
+
+## `gondolin:<sandbox-id>`
+
+警告：Gondolin 支援目前是 experimental。mikan 會透過本機 HTTP bridge 呼叫 `@earendil-works/gondolin`，由 bridge 管理 local micro-VM、workspace mount、HTTP policy 與 secret handling。
+
+```bash
+export GONDOLIN_SANDBOX_URL="http://127.0.0.1:8788"
+export GONDOLIN_SANDBOX_TOKEN="replace-me" # optional
+
+mikan --sandbox=gondolin:mikan-local /path/to/workspace
+```
+
+特性：
+
+- mikan 會把 sandbox id 衍生為 `<base-sandbox-id>-<vault-key>`
+- vault env / secrets 會送到 bridge 的 `/exec` payload
+- bridge 可把 `MIKAN_PROXY_INJECT_HEADERS` 轉成 Gondolin host-side HTTP hooks，讓 secret 由 host-side policy 處理
+- workspace 是否掛載、VM lifecycle、HTTP/TLS policy 都由 bridge 控制
+
+限制：
+
+- 需要自行啟動 bridge process
+- mikan 本體不直接 import `@earendil-works/gondolin`，避免把本機 VM runtime 綁成主程式 dependency
+- production bridge 仍需依 `gh`、`gcloud`、`gws`、`sentry-cli` 補 intercepted-command wrappers
+
+可直接使用範例 bridge：
+
+- [examples/gondolin-sandbox-bridge/README.md](../examples/gondolin-sandbox-bridge/README.md)
 
 ---
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -10,8 +10,8 @@
 | `container:<name>`                                          | 既有 Docker container | 注入                | `container-<name>`           | one container one vault；多人共用同一 container 就共用該 vault                     |
 | `image:<image>`                                             | mikan 管理的 Docker   | exec 時短暫注入     | generated conversation vault | 目前最推薦的隔離模式；vault 不會作為長期 bind mount 留在 container 內              |
 | `firecracker:<vm-id>:<host-path>[:<ssh-user>[:<ssh-port>]]` | Firecracker VM        | 注入                | generated conversation vault | Alpha 超早期；VM 需自行啟動，workspace 需在 VM 內掛到 `/workspace`，目前不建議使用 |
-| `cloudflare:<sandbox-id>`                                   | Cloudflare Worker     | 注入                | generated conversation vault | Experimental；需自行部署 `@cloudflare/sandbox` bridge，host workspace 不會自動同步 |
-| `gondolin:<sandbox-id>`                                     | Gondolin micro-VM     | 注入                | generated conversation vault | Experimental；需自行啟動 Gondolin bridge，本機 micro-VM sandbox                    |
+| `cloudflare:<sandbox-id>`                                   | Cloudflare Worker     | proxy-only          | generated conversation vault | Experimental；普通 vault env 不會進 sandbox；host workspace 不會自動同步           |
+| `gondolin:<sandbox-id>`                                     | Gondolin micro-VM     | proxy-only          | generated conversation vault | Experimental；普通 vault env 不會進 VM；secret 由 bridge-side policy 注入          |
 
 `docker:*` 不是可用模式；請改用 `container:*` 或 `image:*`。
 
@@ -24,7 +24,7 @@
 | command 執行                         | ✅       | ✅                 | ✅              | ✅              | ✅             | ✅             |
 | mikan 管理 runtime lifecycle         | 不適用   | ❌                 | ✅              | ❌              | ❌             | bridge 管理    |
 | per-conversation container / runtime | ❌       | ❌                 | ✅              | 需自行管理      | bridge 衍生 id | bridge 衍生 id |
-| per-conversation vault env           | ❌       | ❌                 | ✅              | ✅              | ✅             | ✅             |
+| per-conversation vault env           | ❌       | ❌                 | ✅              | ✅              | ❌             | ❌             |
 | vault file 執行期短暫投影            | ❌       | ❌                 | ✅              | ❌              | ❌             | bridge 實作    |
 | workspace 自動掛載                   | host     | 需自行掛載         | ✅              | 需自行掛載      | ❌             | bridge 掛載    |
 | private workspace mount mode         | 不適用   | ❌                 | ✅              | ❌              | ❌             | ❌             |
@@ -289,7 +289,8 @@ mikan --sandbox=cloudflare:mikan-remote /path/to/workspace
 特性：
 
 - mikan 會把 remote sandbox id 衍生為 `<base-sandbox-id>-<vault-key>`
-- vault env 會在每次 `exec()` 時透過 bridge 注入
+- 普通 vault env 不會放進 `/exec` payload，也不會成為 remote command 的環境變數
+- 只有 `MIKAN_PROXY_INJECT_HEADERS` 會以 `secrets.env` 送到 bridge；範例 Cloudflare bridge 會建立短期 proxy session，只把 `HTTP_PROXY` / `http_proxy` capability URL 注入 sandbox，header secret 由 bridge-side proxy 加上
 - vault 選擇邏輯和 `image` 類似：使用 conversation ID 產生 platform-scoped vault key
 
 限制：
@@ -319,8 +320,9 @@ mikan --sandbox=gondolin:mikan-local /path/to/workspace
 特性：
 
 - mikan 會把 sandbox id 衍生為 `<base-sandbox-id>-<vault-key>`
-- vault env / secrets 會送到 bridge 的 `/exec` payload
-- bridge 可把 `MIKAN_PROXY_INJECT_HEADERS` 轉成 Gondolin host-side HTTP hooks，讓 secret 由 host-side policy 處理
+- 普通 vault env 不會放進 `/exec` payload，也不會成為 VM command 的環境變數
+- 只有 `MIKAN_PROXY_INJECT_HEADERS` 會以 `secrets.env` 送到 bridge
+- bridge 可把 `MIKAN_PROXY_INJECT_HEADERS` 轉成 Gondolin host-side HTTP hooks，讓 secret 由 host-side policy 處理；sandbox 只能看到 hook 產生的非 secret env，不會看到 vault secret value
 - workspace 是否掛載、VM lifecycle、HTTP/TLS policy 都由 bridge 控制
 
 限制：

--- a/examples/cloudflare-sandbox-bridge/README.md
+++ b/examples/cloudflare-sandbox-bridge/README.md
@@ -49,8 +49,10 @@ Request body:
   "command": "pwd",
   "timeoutSeconds": 30,
   "cwd": "/workspace",
-  "env": {
-    "OPENAI_API_KEY": "..."
+  "secrets": {
+    "env": {
+      "MIKAN_PROXY_INJECT_HEADERS": "{...}"
+    }
   }
 }
 ```
@@ -69,5 +71,8 @@ Response body:
 
 - 目前 bridge 只提供 command execution；沒有自動同步宿主機 workspace
 - 遠端 `/workspace` 只是 container 內目錄，不是本機 `/path/to/workspace` 的 mount
-- mikan vault file mounts 不會自動投影到 Cloudflare sandbox
+- 普通 vault env 不會送進 Cloudflare sandbox，因為 command 可以直接讀環境變數
+- `MIKAN_PROXY_INJECT_HEADERS` 會由 bridge 轉成短期 proxy session；sandbox 只拿到 `HTTP_PROXY` / `http_proxy` capability URL，真正 header secret 由 bridge-side proxy 注入
+- proxy 只支援 HTTP proxy request；HTTPS `CONNECT` 不能修改加密後的 header，bridge 會回 501
+- `secrets.files` 不會自動投影到 Cloudflare sandbox
 - 如果你要讓 remote sandbox 看見 repo 檔案，需自行設計 upload/sync 流程

--- a/examples/cloudflare-sandbox-bridge/src/index.ts
+++ b/examples/cloudflare-sandbox-bridge/src/index.ts
@@ -4,6 +4,7 @@ export { Sandbox } from "@cloudflare/sandbox";
 
 interface SandboxSecrets {
   env?: Record<string, string>;
+  files?: Array<{ source: string; target: string }>;
 }
 
 interface ExecRequestBody {
@@ -56,6 +57,12 @@ export default {
 
     if (!body.sandboxId || !body.command) {
       return Response.json({ error: "sandboxId and command are required" }, { status: 400 });
+    }
+    if (body.secrets?.files && body.secrets.files.length > 0) {
+      return Response.json(
+        { error: "secrets.files is not supported by this Cloudflare sandbox bridge" },
+        { status: 400 },
+      );
     }
 
     try {

--- a/examples/cloudflare-sandbox-bridge/src/index.ts
+++ b/examples/cloudflare-sandbox-bridge/src/index.ts
@@ -7,6 +7,8 @@ interface SandboxSecrets {
   files?: Array<{ source: string; target: string }>;
 }
 
+type HeaderRules = Record<string, Record<string, string>>;
+
 interface ExecRequestBody {
   sandboxId?: string;
   command?: string;
@@ -20,6 +22,8 @@ interface Env {
   Sandbox: DurableObjectNamespace<CloudflareSandbox>;
   BRIDGE_TOKEN?: string;
 }
+
+const proxySessions = new Map<string, HeaderRules>();
 
 function unauthorized(): Response {
   return Response.json({ error: "unauthorized" }, { status: 401 });
@@ -45,6 +49,9 @@ export default {
     }
 
     if (request.method !== "POST" || url.pathname !== "/exec") {
+      if (url.pathname.startsWith("/proxy/")) {
+        return handleProxyRequest(request, url);
+      }
       return Response.json({ error: "not_found" }, { status: 404 });
     }
 
@@ -58,11 +65,27 @@ export default {
     if (!body.sandboxId || !body.command) {
       return Response.json({ error: "sandboxId and command are required" }, { status: 400 });
     }
+    if (body.env && Object.keys(body.env).length > 0) {
+      return Response.json(
+        {
+          error:
+            "env injection is not supported because sandbox commands can read environment variables",
+        },
+        { status: 400 },
+      );
+    }
     if (body.secrets?.files && body.secrets.files.length > 0) {
       return Response.json(
         { error: "secrets.files is not supported by this Cloudflare sandbox bridge" },
         { status: 400 },
       );
+    }
+    let proxySession: { token: string; env: Record<string, string> } | undefined;
+    try {
+      proxySession = createProxySession(request, body.secrets?.env);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      return Response.json({ error: detail }, { status: 400 });
     }
 
     try {
@@ -76,7 +99,7 @@ export default {
             ? body.timeoutSeconds * 1000
             : undefined,
         cwd: body.cwd || "/workspace",
-        env: body.env ?? body.secrets?.env,
+        env: proxySession?.env,
       });
 
       return Response.json({
@@ -87,6 +110,79 @@ export default {
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       return Response.json({ error: detail }, { status: 500 });
+    } finally {
+      if (proxySession) proxySessions.delete(proxySession.token);
     }
   },
 };
+
+function createProxySession(
+  request: Request,
+  env?: Record<string, string>,
+): { token: string; env: Record<string, string> } | undefined {
+  const rules = parseProxyHeaderRules(env);
+  if (!rules) return undefined;
+
+  const token = crypto.randomUUID();
+  proxySessions.set(token, rules);
+  const proxyUrl = new URL(`/proxy/${token}`, request.url).toString();
+  return { token, env: { HTTP_PROXY: proxyUrl, http_proxy: proxyUrl } };
+}
+
+function parseProxyHeaderRules(env?: Record<string, string>): HeaderRules | undefined {
+  const raw = env?.MIKAN_PROXY_INJECT_HEADERS;
+  if (!raw) return undefined;
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isHeaderRules(parsed)) throw new Error("Invalid MIKAN_PROXY_INJECT_HEADERS JSON");
+  return parsed;
+}
+
+async function handleProxyRequest(request: Request, url: URL): Promise<Response> {
+  if (request.method === "CONNECT") {
+    return new Response(
+      "MIKAN_PROXY_INJECT_HEADERS supports HTTP proxy requests only; HTTPS CONNECT cannot be modified.\n",
+      { status: 501 },
+    );
+  }
+
+  const token = url.pathname.slice("/proxy/".length);
+  const rules = proxySessions.get(token);
+  if (!rules) return Response.json({ error: "proxy session not found" }, { status: 404 });
+
+  const target = parseProxyTarget(request);
+  if (!target) return new Response("proxy requires absolute-form request target", { status: 400 });
+
+  const headers = new Headers(request.headers);
+  for (const [key, value] of Object.entries(rules[target.host] ?? {})) {
+    headers.set(key, value);
+  }
+  headers.delete("proxy-authorization");
+
+  return fetch(target, {
+    method: request.method,
+    headers,
+    body: request.body,
+    redirect: "manual",
+  });
+}
+
+function parseProxyTarget(request: Request): URL | undefined {
+  try {
+    const raw = new URL(request.url).searchParams.get("url") || request.url;
+    if (!raw.startsWith("http://") && !raw.startsWith("https://")) return undefined;
+    return new URL(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function isHeaderRules(value: unknown): value is HeaderRules {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value).every(
+    (headers) =>
+      headers &&
+      typeof headers === "object" &&
+      !Array.isArray(headers) &&
+      Object.values(headers).every((header) => typeof header === "string"),
+  );
+}

--- a/examples/cloudflare-sandbox-bridge/src/index.ts
+++ b/examples/cloudflare-sandbox-bridge/src/index.ts
@@ -2,12 +2,17 @@ import { getSandbox, type Sandbox as CloudflareSandbox } from "@cloudflare/sandb
 
 export { Sandbox } from "@cloudflare/sandbox";
 
+interface SandboxSecrets {
+  env?: Record<string, string>;
+}
+
 interface ExecRequestBody {
   sandboxId?: string;
   command?: string;
   timeoutSeconds?: number;
   cwd?: string;
   env?: Record<string, string>;
+  secrets?: SandboxSecrets;
 }
 
 interface Env {
@@ -64,7 +69,7 @@ export default {
             ? body.timeoutSeconds * 1000
             : undefined,
         cwd: body.cwd || "/workspace",
-        env: body.env,
+        env: body.env ?? body.secrets?.env,
       });
 
       return Response.json({

--- a/examples/gondolin-sandbox-bridge/README.md
+++ b/examples/gondolin-sandbox-bridge/README.md
@@ -1,0 +1,63 @@
+# Gondolin sandbox bridge
+
+這個範例把 `@earendil-works/gondolin` 包成 mikan 相容的 HTTP bridge，讓 mikan 可用：
+
+```bash
+mikan --sandbox=gondolin:mikan-local /path/to/workspace
+```
+
+## 安裝與啟動
+
+```bash
+cd examples/gondolin-sandbox-bridge
+npm install --ignore-scripts
+GONDOLIN_WORKSPACE=/path/to/workspace \
+GONDOLIN_BRIDGE_PORT=8788 \
+npm start
+```
+
+另一個 shell 啟動 mikan：
+
+```bash
+export GONDOLIN_SANDBOX_URL="http://127.0.0.1:8788"
+mikan --sandbox=gondolin:mikan-local /path/to/workspace
+```
+
+如果要保護 bridge：
+
+```bash
+export GONDOLIN_SANDBOX_TOKEN="replace-me"
+export BRIDGE_TOKEN="replace-me"
+```
+
+## API
+
+mikan 會呼叫：
+
+- `GET /health`
+- `POST /exec`
+
+`POST /exec` payload：
+
+```json
+{
+  "sandboxId": "mikan-local-d123",
+  "command": "pwd",
+  "cwd": "/workspace",
+  "timeoutSeconds": 30,
+  "env": {},
+  "secrets": { "env": {} }
+}
+```
+
+回應：
+
+```json
+{ "stdout": "", "stderr": "", "code": 0 }
+```
+
+## Secret / proxy 語意
+
+bridge 接受 mikan 的 `secrets.env`。若包含 `MIKAN_PROXY_INJECT_HEADERS`，bridge 會建立 Gondolin `createHttpHooks()` policy，讓 Gondolin host-side HTTP policy 負責替允許 host 的 outbound request 做 secret replacement。
+
+目前這個範例保留最小實作；production bridge 應依實際 CLI（`gh`、`gcloud`、`gws`、`sentry-cli`）加上 intercepted-command wrappers，把 CLI credential discovery 轉成 Gondolin placeholder header 或短期 file/env。

--- a/examples/gondolin-sandbox-bridge/README.md
+++ b/examples/gondolin-sandbox-bridge/README.md
@@ -45,8 +45,11 @@ mikan 會呼叫：
   "command": "pwd",
   "cwd": "/workspace",
   "timeoutSeconds": 30,
-  "env": {},
-  "secrets": { "env": {} }
+  "secrets": {
+    "env": {
+      "MIKAN_PROXY_INJECT_HEADERS": "{...}"
+    }
+  }
 }
 ```
 
@@ -58,6 +61,8 @@ mikan 會呼叫：
 
 ## Secret / proxy 語意
 
-bridge 接受 mikan 的 `secrets.env`。若包含 `MIKAN_PROXY_INJECT_HEADERS`，bridge 會建立 Gondolin `createHttpHooks()` policy，讓 Gondolin host-side HTTP policy 負責替允許 host 的 outbound request 做 secret replacement。
+mikan 不會把普通 vault env 送進 `/exec` payload，因為 sandbox command 可以直接讀取環境變數。只有 `MIKAN_PROXY_INJECT_HEADERS` 會放在 `secrets.env`。
 
-目前這個範例保留最小實作；production bridge 應依實際 CLI（`gh`、`gcloud`、`gws`、`sentry-cli`）加上 intercepted-command wrappers，把 CLI credential discovery 轉成 Gondolin placeholder header 或短期 file/env。
+bridge 會把 `MIKAN_PROXY_INJECT_HEADERS` 轉成 Gondolin `createHttpHooks()` policy，讓 Gondolin host-side HTTP policy 負責替允許 host 的 outbound request 做 secret replacement。secret value 不會作為 `vm.exec()` env 傳入 VM。
+
+目前這個範例保留最小實作；production bridge 應依實際 CLI（`gh`、`gcloud`、`gws`、`sentry-cli`）加上 intercepted-command wrappers，把 CLI credential discovery 轉成 Gondolin placeholder header 或短期 host-side policy。

--- a/examples/gondolin-sandbox-bridge/package.json
+++ b/examples/gondolin-sandbox-bridge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mikan-gondolin-sandbox-bridge",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@earendil-works/gondolin": "latest",
+    "tsx": "^4.21.0"
+  }
+}

--- a/examples/gondolin-sandbox-bridge/src/index.ts
+++ b/examples/gondolin-sandbox-bridge/src/index.ts
@@ -1,0 +1,147 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { VM, RealFSProvider, createHttpHooks } from "@earendil-works/gondolin";
+
+interface SandboxSecrets {
+  env?: Record<string, string>;
+}
+
+interface ExecRequestBody {
+  sandboxId?: string;
+  command?: string;
+  timeoutSeconds?: number;
+  cwd?: string;
+  env?: Record<string, string>;
+  secrets?: SandboxSecrets;
+}
+
+const PORT = Number(process.env.PORT || process.env.GONDOLIN_BRIDGE_PORT || 8788);
+const BRIDGE_TOKEN = process.env.BRIDGE_TOKEN || process.env.GONDOLIN_SANDBOX_TOKEN;
+const WORKSPACE = process.env.GONDOLIN_WORKSPACE || process.cwd();
+const sessions = new Map<string, Promise<VM>>();
+
+function unauthorized(response: ServerResponse): void {
+  json(response, 401, { error: "unauthorized" });
+}
+
+function requireAuth(request: IncomingMessage, response: ServerResponse): boolean {
+  if (!BRIDGE_TOKEN) return true;
+  if (request.headers.authorization === `Bearer ${BRIDGE_TOKEN}`) return true;
+  unauthorized(response);
+  return false;
+}
+
+async function readJson<T>(request: IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf-8")) as T;
+}
+
+function json(response: ServerResponse, status: number, value: unknown): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}
+
+function ensureVm(sandboxId: string, env?: Record<string, string>): Promise<VM> {
+  const existing = sessions.get(sandboxId);
+  if (existing) return existing;
+
+  const created = VM.create({
+    ...buildHttpPolicy(env),
+    vfs: {
+      mounts: {
+        "/workspace": new RealFSProvider(WORKSPACE),
+      },
+    },
+  });
+  sessions.set(sandboxId, created);
+  return created;
+}
+
+function buildHttpPolicy(env?: Record<string, string>) {
+  const rules = parseProxyRules(env);
+  if (!rules) return {};
+
+  const secretEntries: Record<string, { hosts: string[]; value: string }> = {};
+  const allowedHosts = Object.keys(rules);
+  let index = 0;
+  for (const [host, headers] of Object.entries(rules)) {
+    for (const [header, value] of Object.entries(headers)) {
+      const name = `MIKAN_PROXY_SECRET_${index++}`;
+      secretEntries[name] = { hosts: [host], value };
+      env ??= {};
+      env[name] = value;
+      // Gondolin replaces placeholders in outbound headers. The caller can use
+      // this env value in intercepted commands or explicit curl headers.
+      env[`MIKAN_PROXY_HEADER_${header.toUpperCase().replace(/[^A-Z0-9_]/g, "_")}`] = value;
+    }
+  }
+
+  const { httpHooks, env: hookEnv } = createHttpHooks({
+    allowedHosts,
+    secrets: secretEntries,
+  });
+  return { httpHooks, env: { ...env, ...hookEnv } };
+}
+
+function parseProxyRules(
+  env?: Record<string, string>,
+): Record<string, Record<string, string>> | undefined {
+  const raw = env?.MIKAN_PROXY_INJECT_HEADERS;
+  if (!raw) return undefined;
+  return JSON.parse(raw) as Record<string, Record<string, string>>;
+}
+
+async function handleExec(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  let body: ExecRequestBody;
+  try {
+    body = await readJson<ExecRequestBody>(request);
+  } catch {
+    json(response, 400, { error: "invalid_json" });
+    return;
+  }
+
+  if (!body.sandboxId || !body.command) {
+    json(response, 400, { error: "sandboxId and command are required" });
+    return;
+  }
+
+  try {
+    const env = body.env ?? body.secrets?.env;
+    const vm = await ensureVm(body.sandboxId, env);
+    const result = await vm.exec(body.command, {
+      cwd: body.cwd || "/workspace",
+      env,
+      timeout: body.timeoutSeconds ? body.timeoutSeconds * 1000 : undefined,
+    });
+
+    json(response, 200, {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      code: result.exitCode,
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    json(response, 500, { error: detail });
+  }
+}
+
+createServer((request, response) => {
+  if (!requireAuth(request, response)) return;
+  if (request.method === "GET" && request.url === "/health") {
+    json(response, 200, { ok: true });
+    return;
+  }
+  if (request.method === "POST" && request.url === "/exec") {
+    handleExec(request, response).catch((error) => {
+      const detail = error instanceof Error ? error.message : String(error);
+      json(response, 500, { error: detail });
+    });
+    return;
+  }
+  json(response, 404, { error: "not_found" });
+}).listen(PORT, () => {
+  console.log(`mikan Gondolin sandbox bridge listening on :${PORT}`);
+  console.log(`workspace: ${WORKSPACE}`);
+});

--- a/examples/gondolin-sandbox-bridge/src/index.ts
+++ b/examples/gondolin-sandbox-bridge/src/index.ts
@@ -3,6 +3,7 @@ import { VM, RealFSProvider, createHttpHooks } from "@earendil-works/gondolin";
 
 interface SandboxSecrets {
   env?: Record<string, string>;
+  files?: Array<{ source: string; target: string }>;
 }
 
 interface ExecRequestBody {
@@ -43,12 +44,12 @@ function json(response: ServerResponse, status: number, value: unknown): void {
   response.end(JSON.stringify(value));
 }
 
-function ensureVm(sandboxId: string, env?: Record<string, string>): Promise<VM> {
+function ensureVm(sandboxId: string, secrets?: SandboxSecrets): Promise<VM> {
   const existing = sessions.get(sandboxId);
   if (existing) return existing;
 
   const created = VM.create({
-    ...buildHttpPolicy(env),
+    ...buildHttpPolicy(secrets?.env),
     vfs: {
       mounts: {
         "/workspace": new RealFSProvider(WORKSPACE),
@@ -67,14 +68,9 @@ function buildHttpPolicy(env?: Record<string, string>) {
   const allowedHosts = Object.keys(rules);
   let index = 0;
   for (const [host, headers] of Object.entries(rules)) {
-    for (const [header, value] of Object.entries(headers)) {
+    for (const value of Object.values(headers)) {
       const name = `MIKAN_PROXY_SECRET_${index++}`;
       secretEntries[name] = { hosts: [host], value };
-      env ??= {};
-      env[name] = value;
-      // Gondolin replaces placeholders in outbound headers. The caller can use
-      // this env value in intercepted commands or explicit curl headers.
-      env[`MIKAN_PROXY_HEADER_${header.toUpperCase().replace(/[^A-Z0-9_]/g, "_")}`] = value;
     }
   }
 
@@ -82,7 +78,7 @@ function buildHttpPolicy(env?: Record<string, string>) {
     allowedHosts,
     secrets: secretEntries,
   });
-  return { httpHooks, env: { ...env, ...hookEnv } };
+  return { httpHooks, env: hookEnv };
 }
 
 function parseProxyRules(
@@ -107,12 +103,22 @@ async function handleExec(request: IncomingMessage, response: ServerResponse): P
     return;
   }
 
+  if (body.env && Object.keys(body.env).length > 0) {
+    json(response, 400, {
+      error:
+        "env injection is not supported because sandbox commands can read environment variables",
+    });
+    return;
+  }
+  if (body.secrets?.files && body.secrets.files.length > 0) {
+    json(response, 400, { error: "secrets.files is not supported by this Gondolin bridge" });
+    return;
+  }
+
   try {
-    const env = body.env ?? body.secrets?.env;
-    const vm = await ensureVm(body.sandboxId, env);
+    const vm = await ensureVm(body.sandboxId, body.secrets);
     const result = await vm.exec(body.command, {
       cwd: body.cwd || "/workspace",
-      env,
       timeout: body.timeoutSeconds ? body.timeoutSeconds * 1000 : undefined,
     });
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "prepublishOnly": "npm run clean && npm run build",
     "prepare": "husky",
     "test:e2e": "vitest --run --config vitest.e2e.config.ts",
-    "test:e2e:slack": "vitest --run --config vitest.e2e.config.ts e2e/slack"
+    "test:e2e:slack": "vitest --run --config vitest.e2e.config.ts e2e/slack",
+    "verify:sandbox-cli-proxy": "node scripts/verify-sandbox-cli-proxy.mjs"
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "^0.78.1",

--- a/scripts/verify-sandbox-cli-proxy.mjs
+++ b/scripts/verify-sandbox-cli-proxy.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DockerContainerManager } from "../dist/provisioner.js";
+import { ContainerExecutor } from "../dist/sandbox/container.js";
+
+const image = process.env.MIKAN_VERIFY_SANDBOX_IMAGE || "node:22-alpine";
+const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const key = `cli-proxy-${suffix}`.replace(/[^a-z0-9-]/g, "-");
+const containerName = `mikan-sandbox-${key}`;
+const upstreamName = `mikan-upstream-${key}`;
+const networkName = DockerContainerManager.networkName(key);
+const workspace = mkdtempSync(join(tmpdir(), "mikan-cli-proxy-workspace-"));
+const upstreamDir = mkdtempSync(join(tmpdir(), "mikan-cli-proxy-upstream-"));
+const manager = new DockerContainerManager(image);
+
+const cliNames = ["gh", "gcloud", "gws", "sentry-cli"];
+
+writeFileSync(
+  join(upstreamDir, "server.mjs"),
+  `import { createServer } from 'node:http';
+import { appendFileSync, mkdirSync } from 'node:fs';
+mkdirSync('/tmp/seen', { recursive: true });
+createServer((req, res) => {
+  const name = decodeURIComponent(req.url.slice(1));
+  appendFileSync('/tmp/seen/' + name, String(req.headers.authorization || '') + '\\n');
+  res.end('ok');
+}).listen(8080, '0.0.0.0');
+`,
+);
+
+mkdirSync(join(workspace, "bin"), { recursive: true });
+for (const name of cliNames) {
+  writeFileSync(
+    join(workspace, "bin", name),
+    `#!/bin/sh
+set -eu
+wget -T 5 -qO- "http://upstream:8080/${encodeURIComponent(name)}" >/dev/null
+`,
+    { mode: 0o755 },
+  );
+}
+
+try {
+  await manager.provision(key, {
+    containerName,
+    conversationId: "D123",
+    mounts: [{ source: workspace, target: "/workspace" }],
+  });
+  execFileSync("docker", [
+    "run",
+    "-d",
+    "--rm",
+    "--name",
+    upstreamName,
+    "--network",
+    networkName,
+    "--network-alias",
+    "upstream",
+    "-v",
+    `${upstreamDir}:/app`,
+    "node:22-alpine",
+    "node",
+    "/app/server.mjs",
+  ]);
+  execFileSync("docker", [
+    "exec",
+    containerName,
+    "sh",
+    "-lc",
+    "for i in $(seq 1 50); do wget -T 1 -qO- http://upstream:8080/health >/dev/null 2>&1 && exit 0; sleep 0.1; done; exit 1",
+  ]);
+
+  const executor = new ContainerExecutor(
+    containerName,
+    {
+      env: {
+        MIKAN_PROXY_INJECT_HEADERS: JSON.stringify({
+          "upstream:8080": { authorization: "Bearer cli-proxy-secret" },
+        }),
+      },
+    },
+    async () =>
+      manager.provision(key, {
+        containerName,
+        conversationId: "D123",
+        mounts: [{ source: workspace, target: "/workspace" }],
+      }),
+  );
+
+  await Promise.all(
+    cliNames.map(async (name) => {
+      const result = await executor.exec(`PATH=/workspace/bin:$PATH ${name}`, { timeout: 10 });
+      if (result.code !== 0) {
+        throw new Error(`${name} proxy smoke failed: ${result.stderr}`);
+      }
+      const seen = execFileSync("docker", ["exec", upstreamName, "cat", `/tmp/seen/${name}`], {
+        encoding: "utf8",
+      })
+        .trim()
+        .split("\n")
+        .at(-1);
+      if (seen !== "Bearer cli-proxy-secret") {
+        throw new Error(`${name} did not send injected header, got ${seen}`);
+      }
+    }),
+  );
+
+  const leaked = execFileSync(
+    "docker",
+    ["exec", containerName, "sh", "-lc", "env | grep MIKAN_PROXY_INJECT_HEADERS || true"],
+    { encoding: "utf8" },
+  );
+  if (leaked.trim()) throw new Error("MIKAN_PROXY_INJECT_HEADERS leaked into base container env");
+
+  console.log(JSON.stringify({ ok: true, image, cliNames }, null, 2));
+} finally {
+  try {
+    execFileSync("docker", ["rm", "-f", upstreamName]);
+  } catch {}
+  try {
+    await manager.remove(key);
+  } catch {}
+  rmSync(workspace, { recursive: true, force: true });
+  rmSync(upstreamDir, { recursive: true, force: true });
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -186,6 +186,12 @@ function buildEnvDescription(sandboxType: SandboxConfig["type"], workspaceRoot: 
 - Bash commands start in: ${workspaceRoot}
 - Your commands run in a remote container managed by Cloudflare
 - Important: the remote filesystem is not automatically synced back to the host workspace`;
+    case "gondolin":
+      return `You are running through a Gondolin sandbox bridge.
+- Runtime workspace root: ${workspaceRoot}
+- Bash commands start in: ${workspaceRoot}
+- Your commands run in a local micro-VM managed by Gondolin
+- Important: the remote filesystem is not automatically synced back to the host workspace unless the bridge mounts it`;
     default:
       return `You are running directly on the host machine.
 - Runtime workspace root: ${workspaceRoot}
@@ -481,6 +487,7 @@ function createRunnerExecutionContext(
       sandboxConfig.type === "container" ||
       sandboxConfig.type === "image" ||
       sandboxConfig.type === "cloudflare" ||
+      sandboxConfig.type === "gondolin" ||
       sandboxConfig.type === "firecracker")
       ? new ActorExecutionResolver(sandboxConfig, vaultManager, provisioner, workspaceDir)
       : undefined;

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "fs";
 import { join } from "path";
 import { loadGlobalSettings, resolveConversationSettings } from "./config.js";
 import { ensureDirExists, isRecord, readJsonFileIfExists } from "./utils/file-guards.js";
@@ -167,27 +166,9 @@ export class ActorExecutionResolver {
   }
 
   private resolveSecrets(vault: ResolvedVault): SandboxSecrets | undefined {
-    const files = vault.mounts.filter((mount) => {
-      if (existsSync(mount.source)) return true;
-      reportUserFacingError(new Error("Vault secret source is missing"), {
-        domain: "sandbox",
-        surface: "vault_runtime_secrets",
-        operation: "resolve_secrets",
-        severity: "warning",
-        context: {
-          sandboxType: this.baseConfig.type,
-          target: mount.target,
-          hasVault: true,
-        },
-      });
-      return false;
-    });
-    const hasEnv = Object.keys(vault.env).length > 0;
-    if (!hasEnv && files.length === 0) return undefined;
-    return {
-      ...(hasEnv ? { env: vault.env } : {}),
-      ...(files.length > 0 ? { files } : {}),
-    };
+    const proxyRules = vault.env.MIKAN_PROXY_INJECT_HEADERS;
+    if (!proxyRules) return undefined;
+    return { env: { MIKAN_PROXY_INJECT_HEADERS: proxyRules } };
   }
 
   private buildImageSandboxMounts(conversationId: string): ContainerMount[] {

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -3,7 +3,12 @@ import { join } from "path";
 import { loadGlobalSettings, resolveConversationSettings } from "./config.js";
 import { ensureDirExists, isRecord, readJsonFileIfExists } from "./utils/file-guards.js";
 import { DockerContainerManager, type ContainerMount } from "./provisioner.js";
-import { createExecutor, type Executor, type SandboxConfig } from "./sandbox/index.js";
+import {
+  createExecutor,
+  type Executor,
+  type SandboxConfig,
+  type SandboxSecrets,
+} from "./sandbox/index.js";
 import { reportUserFacingError } from "./observability/sentry.js";
 import { normalizeSharedVaultName, type ResolvedVault, type VaultManager } from "./vault/index.js";
 import { resolveActorVaultKey } from "./vault/routing.js";
@@ -69,17 +74,21 @@ export class ActorExecutionResolver {
 
     const vault = this.vaultManager.resolve(vaultKey);
     const config = this.resolveSandboxConfig(vaultKey);
-    const env =
-      config.type !== "host" && vault && Object.keys(vault.env).length > 0 ? vault.env : undefined;
+    const secrets = config.type !== "host" && vault ? this.resolveSecrets(vault) : undefined;
     return createExecutor(
       config,
-      env,
+      secrets,
       this.buildEnsureReadyCallback(vaultKey, context.conversationId, config, vault),
     );
   }
 
   private ensureDefaultSharedVault(vaultKey: string): void {
-    if (this.baseConfig.type !== "image" && this.baseConfig.type !== "cloudflare") return;
+    if (
+      this.baseConfig.type !== "image" &&
+      this.baseConfig.type !== "cloudflare" &&
+      this.baseConfig.type !== "gondolin"
+    )
+      return;
     if (this.vaultManager.hasEntry(vaultKey)) return;
 
     let profile: string | undefined;
@@ -153,30 +162,32 @@ export class ActorExecutionResolver {
     };
   }
 
-  private resolveMounts(conversationId: string, vault?: ResolvedVault): ContainerMount[] {
-    const mountsByTarget = new Map<string, ContainerMount>();
-    for (const mount of this.buildImageSandboxMounts(conversationId)) {
-      mountsByTarget.set(mount.target, mount);
-    }
-    for (const mount of vault?.mounts ?? []) {
-      if (!existsSync(mount.source)) {
-        reportUserFacingError(new Error("Vault mount source is missing"), {
-          domain: "sandbox",
-          surface: "vault_injection",
-          operation: "resolve_mounts",
-          severity: "warning",
-          context: {
-            sandboxType: "image",
-            conversationId,
-            target: mount.target,
-            hasVault: Boolean(vault),
-          },
-        });
-        continue;
-      }
-      mountsByTarget.set(mount.target, { source: mount.source, target: mount.target });
-    }
-    return [...mountsByTarget.values()];
+  private resolveMounts(conversationId: string, _vault?: ResolvedVault): ContainerMount[] {
+    return this.buildImageSandboxMounts(conversationId);
+  }
+
+  private resolveSecrets(vault: ResolvedVault): SandboxSecrets | undefined {
+    const files = vault.mounts.filter((mount) => {
+      if (existsSync(mount.source)) return true;
+      reportUserFacingError(new Error("Vault secret source is missing"), {
+        domain: "sandbox",
+        surface: "vault_runtime_secrets",
+        operation: "resolve_secrets",
+        severity: "warning",
+        context: {
+          sandboxType: this.baseConfig.type,
+          target: mount.target,
+          hasVault: true,
+        },
+      });
+      return false;
+    });
+    const hasEnv = Object.keys(vault.env).length > 0;
+    if (!hasEnv && files.length === 0) return undefined;
+    return {
+      ...(hasEnv ? { env: vault.env } : {}),
+      ...(files.length > 0 ? { files } : {}),
+    };
   }
 
   private buildImageSandboxMounts(conversationId: string): ContainerMount[] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -224,7 +224,7 @@ if (parsedArgs.downloadChannel) {
 // Normal bot mode - require working dir
 if (!parsedArgs.workingDir) {
   console.error(
-    "Usage: mikan [--state-dir=<dir>] [--sandbox=host|container:<name>|image:<image>|firecracker:<vm-id>:<host-path>|cloudflare:<sandbox-id>] <working-directory>",
+    "Usage: mikan [--state-dir=<dir>] [--sandbox=host|container:<name>|image:<image>|firecracker:<vm-id>:<host-path>|cloudflare:<sandbox-id>|gondolin:<sandbox-id>] <working-directory>",
   );
   console.error("       mikan --onboard [--state-dir=<dir>]");
   console.error("       mikan --download <channel-id>");
@@ -262,7 +262,10 @@ if (vaultManager.isEnabled()) {
   console.log(
     sandbox.type === "container"
       ? "  Vault system enabled. Container vault active."
-      : sandbox.type === "image" || sandbox.type === "firecracker" || sandbox.type === "cloudflare"
+      : sandbox.type === "image" ||
+          sandbox.type === "firecracker" ||
+          sandbox.type === "cloudflare" ||
+          sandbox.type === "gondolin"
         ? "  Vault system enabled. Conversation-scoped credential routing active."
         : "  Vault system enabled. Host mode will not inject vault env.",
   );
@@ -342,7 +345,9 @@ const sandboxDesc =
         ? `image:${sandbox.image}`
         : sandbox.type === "firecracker"
           ? `firecracker:${sandbox.vmId}`
-          : `cloudflare:${sandbox.sandboxId}`;
+          : sandbox.type === "cloudflare"
+            ? `cloudflare:${sandbox.sandboxId}`
+            : `gondolin:${sandbox.sandboxId}`;
 log.logStartup(workingDir, sandboxDesc);
 
 const bots: Bot[] = [];

--- a/src/sandbox/cloudflare.ts
+++ b/src/sandbox/cloudflare.ts
@@ -95,6 +95,12 @@ export class CloudflareSandboxExecutor implements Executor {
     }
 
     try {
+      if (this.secrets?.files && this.secrets.files.length > 0) {
+        throw new SandboxError(
+          "Error: Cloudflare sandbox bridge does not support vault file secrets yet; use env secrets or a container/gondolin sandbox for file-backed credentials",
+        );
+      }
+
       const payload: CloudflareExecPayload = {
         sandboxId: this.sandboxId,
         command,

--- a/src/sandbox/cloudflare.ts
+++ b/src/sandbox/cloudflare.ts
@@ -9,6 +9,7 @@ import type {
 } from "./types.js";
 import { readEnv } from "../utils/env.js";
 import { SandboxError } from "./errors.js";
+import { buildRemoteSandboxSecrets, hasVaultFileSecrets } from "./remote-secrets.js";
 
 const DEFAULT_CLOUDFLARE_CWD = "/workspace";
 
@@ -95,9 +96,9 @@ export class CloudflareSandboxExecutor implements Executor {
     }
 
     try {
-      if (this.secrets?.files && this.secrets.files.length > 0) {
+      if (hasVaultFileSecrets(this.secrets)) {
         throw new SandboxError(
-          "Error: Cloudflare sandbox bridge does not support vault file secrets yet; use env secrets or a container/gondolin sandbox for file-backed credentials",
+          "Error: Cloudflare sandbox bridge does not support vault file secrets yet; use proxy-injected HTTP credentials or a container/gondolin sandbox for file-backed credentials",
         );
       }
 
@@ -106,10 +107,9 @@ export class CloudflareSandboxExecutor implements Executor {
         command,
         cwd: this.cwd,
       };
+      const remoteSecrets = buildRemoteSandboxSecrets(this.secrets);
       if (options?.timeout) payload.timeoutSeconds = options.timeout;
-      if (this.secrets?.env && Object.keys(this.secrets.env).length > 0)
-        payload.env = this.secrets.env;
-      if (this.secrets) payload.secrets = this.secrets;
+      if (remoteSecrets) payload.secrets = remoteSecrets;
 
       const response = await fetch(new URL("/exec", resolveCloudflareSandboxUrl()), {
         method: "POST",

--- a/src/sandbox/cloudflare.ts
+++ b/src/sandbox/cloudflare.ts
@@ -9,7 +9,7 @@ import type {
 } from "./types.js";
 import { readEnv } from "../utils/env.js";
 import { SandboxError } from "./errors.js";
-import { buildRemoteSandboxSecrets, hasVaultFileSecrets } from "./remote-secrets.js";
+import { buildRemoteSandboxSecrets } from "./remote-secrets.js";
 
 const DEFAULT_CLOUDFLARE_CWD = "/workspace";
 
@@ -96,12 +96,6 @@ export class CloudflareSandboxExecutor implements Executor {
     }
 
     try {
-      if (hasVaultFileSecrets(this.secrets)) {
-        throw new SandboxError(
-          "Error: Cloudflare sandbox bridge does not support vault file secrets yet; use proxy-injected HTTP credentials or a container/gondolin sandbox for file-backed credentials",
-        );
-      }
-
       const payload: CloudflareExecPayload = {
         sandboxId: this.sandboxId,
         command,

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -1,4 +1,5 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -8,11 +9,13 @@ import type {
   Executor,
   RuntimePathContext,
   SandboxAdapter,
+  SandboxSecrets,
 } from "./types.js";
 import { SandboxError } from "./errors.js";
 import { execSimple, shellEscape } from "./utils.js";
 import { HostExecutor } from "./host.js";
 import { createMountedRuntimePathContext } from "./path-context.js";
+import { parseProxyHeaderRules, stripProxySecretEnv } from "./proxy.js";
 
 const PRIVATE_DIR_MODE = 0o700;
 const PRIVATE_FILE_MODE = 0o600;
@@ -71,14 +74,15 @@ function buildContainerExecCommand(
   return `docker exec ${envPart}-w /workspace ${container} sh -c ${shellEscape(command)}`;
 }
 
-function withRuntimeBootstrap(command: string, env?: Record<string, string>): string {
-  if (!hasGitHubToken(env)) {
-    return command;
+function withRuntimeBootstrap(command: string, secrets?: SandboxSecrets): string {
+  const script = stageCommandSecrets(stageProxyInjection(command, secrets), secrets);
+  if (!hasGitHubToken(secrets?.env)) {
+    return script;
   }
 
   return [
     "if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then gh auth setup-git >/dev/null 2>&1 || true; fi",
-    command,
+    script,
   ].join("\n");
 }
 
@@ -86,10 +90,103 @@ function hasGitHubToken(env?: Record<string, string>): boolean {
   return Boolean(env?.GH_TOKEN || env?.GITHUB_TOKEN || env?.GITHUB_OAUTH_ACCESS_TOKEN);
 }
 
+function stageProxyInjection(command: string, secrets?: SandboxSecrets): string {
+  const rules = parseProxyHeaderRules(secrets?.env);
+  if (!rules) return command;
+  const payload = Buffer.from(JSON.stringify(rules), "utf-8").toString("base64");
+  return [
+    "proxy_dir=$(mktemp -d /tmp/mikan-proxy.XXXXXX)",
+    'proxy_cleanup() { [ ! -f "$proxy_dir/pid" ] || kill "$(cat "$proxy_dir/pid")" 2>/dev/null || true; rm -rf "$proxy_dir"; }',
+    `base64 -d > "$proxy_dir/proxy.mjs" <<'MIKAN_PROXY'\n${proxyScriptBase64()}\nMIKAN_PROXY`,
+    `MIKAN_PROXY_RULES_B64=${shellEscape(payload)} node "$proxy_dir/proxy.mjs" "$proxy_dir/port" & echo $! > "$proxy_dir/pid"`,
+    'while [ ! -s "$proxy_dir/port" ]; do sleep 0.05; done',
+    'export HTTP_PROXY="http://127.0.0.1:$(cat "$proxy_dir/port")"',
+    'export HTTPS_PROXY="$HTTP_PROXY" ALL_PROXY="$HTTP_PROXY"',
+    'export http_proxy="$HTTP_PROXY" https_proxy="$HTTP_PROXY" all_proxy="$HTTP_PROXY"',
+    command,
+    "proxy_status=$?",
+    "proxy_cleanup",
+    "exit $proxy_status",
+  ].join("\n");
+}
+
+function proxyScriptBase64(): string {
+  return Buffer.from(INLINE_PROXY_SCRIPT, "utf-8").toString("base64");
+}
+
+const INLINE_PROXY_SCRIPT = String.raw`import { createServer, request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { connect } from 'node:net';
+import { writeFileSync } from 'node:fs';
+const rules = JSON.parse(Buffer.from(process.env.MIKAN_PROXY_RULES_B64 || '', 'base64').toString('utf8'));
+const server = createServer((req, res) => {
+  if (!req.url || !/^https?:\/\//.test(req.url)) { res.writeHead(400); res.end('absolute URL required'); return; }
+  const target = new URL(req.url);
+  for (const [key, value] of Object.entries(rules[target.host] || {})) req.headers[key.toLowerCase()] = value;
+  const requestImpl = target.protocol === 'https:' ? httpsRequest : httpRequest;
+  const upstream = requestImpl(target, { method: req.method, headers: req.headers }, (upstreamRes) => {
+    res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
+    upstreamRes.pipe(res);
+  });
+  upstream.on('error', (error) => { res.writeHead(502); res.end(error.message); });
+  req.pipe(upstream);
+});
+server.on('connect', (req, client, head) => {
+  const [host, portRaw] = String(req.url || '').split(':');
+  const upstream = connect(Number(portRaw) || 443, host, () => {
+    client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+    if (head.length) upstream.write(head);
+    upstream.pipe(client); client.pipe(upstream);
+  });
+  upstream.on('error', () => client.destroy());
+});
+server.listen(0, '127.0.0.1', () => writeFileSync(process.argv[2], String(server.address().port)));
+`;
+
+function stageCommandSecrets(command: string, secrets?: SandboxSecrets): string {
+  const files = secrets?.files ?? [];
+  if (files.length === 0) {
+    return command;
+  }
+
+  const cleanupSteps = ['rm -rf "$tmp"'];
+  const steps = ["tmp=$(mktemp -d /tmp/mikan-vault.XXXXXX)"];
+  for (const [index, file] of files.entries()) {
+    const staged = `"$tmp/secret-${index}"`;
+    const backup = `"$tmp/backup-${index}"`;
+    const target = shellEscape(file.target);
+    cleanupSteps.unshift(`rm -rf ${target}`, `[ ! -e ${backup} ] || mv ${backup} ${target}`);
+    steps.push(`mkdir -p ${shellEscape(dirnameShell(file.target))}`);
+    steps.push(`[ ! -e ${target} ] && [ ! -L ${target} ] || mv ${target} ${backup}`);
+    if (statSync(file.source).isDirectory()) {
+      const payload = execFileSync("tar", ["-C", file.source, "-czf", "-", "."]).toString("base64");
+      steps.push(`mkdir -p ${staged}`);
+      steps.push(
+        `base64 -d <<'MIKAN_SECRET_${index}' | tar -xzf - -C ${staged}\n${payload}\nMIKAN_SECRET_${index}`,
+      );
+      steps.push(`ln -sfn ${staged} ${target}`);
+    } else {
+      const payload = readFileSync(file.source).toString("base64");
+      steps.push(
+        `base64 -d > ${staged} <<'MIKAN_SECRET_${index}'\n${payload}\nMIKAN_SECRET_${index}`,
+      );
+      steps.push(`ln -sf ${staged} ${target}`);
+    }
+  }
+  steps.splice(1, 0, `cleanup() { ${cleanupSteps.join("; ")}; }`, "trap cleanup EXIT");
+  steps.push(command);
+  return steps.join("\n");
+}
+
+function dirnameShell(path: string): string {
+  const index = path.lastIndexOf("/");
+  return index <= 0 ? "/" : path.slice(0, index);
+}
+
 export class ContainerExecutor implements Executor {
   constructor(
     private container: string,
-    private env?: Record<string, string>,
+    private secrets?: SandboxSecrets,
     private ensureReady?: () => Promise<void>,
   ) {}
 
@@ -101,17 +198,23 @@ export class ContainerExecutor implements Executor {
     }
 
     const hostExecutor = new HostExecutor();
-    const temp = this.env ? createSecureEnvFile(this.env) : undefined;
+    const env = this.buildCommandEnv();
+    const temp = env ? createSecureEnvFile(env) : undefined;
     try {
       const dockerCmd = buildContainerExecCommand(
         this.container,
-        withRuntimeBootstrap(command, this.env),
+        withRuntimeBootstrap(command, this.secrets),
         temp?.envFilePath,
       );
       return await hostExecutor.exec(dockerCmd, options);
     } finally {
       temp?.cleanup();
     }
+  }
+
+  private buildCommandEnv(): Record<string, string> | undefined {
+    if (!this.secrets?.env) return undefined;
+    return stripProxySecretEnv(this.secrets.env);
   }
 
   getWorkspacePath(_hostPath: string): string {
@@ -131,8 +234,8 @@ export const containerSandboxAdapter: SandboxAdapter<ContainerSandboxConfig> = {
   type: "container",
   parse: parseContainerSandboxArg,
   validate: validateContainerSandbox,
-  createExecutor: (config, env, ensureReady) =>
-    new ContainerExecutor(config.container, env, ensureReady),
+  createExecutor: (config, secrets, ensureReady) =>
+    new ContainerExecutor(config.container, secrets, ensureReady),
 };
 
 async function ensureContainerRunning(container: string): Promise<void> {

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -101,8 +101,7 @@ function stageProxyInjection(command: string, secrets?: SandboxSecrets): string 
     `MIKAN_PROXY_RULES_B64=${shellEscape(payload)} node "$proxy_dir/proxy.mjs" "$proxy_dir/port" & echo $! > "$proxy_dir/pid"`,
     'while [ ! -s "$proxy_dir/port" ]; do sleep 0.05; done',
     'export HTTP_PROXY="http://127.0.0.1:$(cat "$proxy_dir/port")"',
-    'export HTTPS_PROXY="$HTTP_PROXY" ALL_PROXY="$HTTP_PROXY"',
-    'export http_proxy="$HTTP_PROXY" https_proxy="$HTTP_PROXY" all_proxy="$HTTP_PROXY"',
+    'export http_proxy="$HTTP_PROXY"',
     command,
     "proxy_status=$?",
     "proxy_cleanup",
@@ -116,7 +115,6 @@ function proxyScriptBase64(): string {
 
 const INLINE_PROXY_SCRIPT = String.raw`import { createServer, request as httpRequest } from 'node:http';
 import { request as httpsRequest } from 'node:https';
-import { connect } from 'node:net';
 import { writeFileSync } from 'node:fs';
 const rules = JSON.parse(Buffer.from(process.env.MIKAN_PROXY_RULES_B64 || '', 'base64').toString('utf8'));
 const server = createServer((req, res) => {
@@ -131,14 +129,8 @@ const server = createServer((req, res) => {
   upstream.on('error', (error) => { res.writeHead(502); res.end(error.message); });
   req.pipe(upstream);
 });
-server.on('connect', (req, client, head) => {
-  const [host, portRaw] = String(req.url || '').split(':');
-  const upstream = connect(Number(portRaw) || 443, host, () => {
-    client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
-    if (head.length) upstream.write(head);
-    upstream.pipe(client); client.pipe(upstream);
-  });
-  upstream.on('error', () => client.destroy());
+server.on('connect', (_req, client) => {
+  client.end('HTTP/1.1 501 Not Implemented\r\nConnection: close\r\n\r\nMIKAN_PROXY_INJECT_HEADERS supports HTTP proxy requests only; HTTPS CONNECT cannot be modified.\n');
 });
 server.listen(0, '127.0.0.1', () => writeFileSync(process.argv[2], String(server.address().port)));
 `;

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -1,5 +1,4 @@
-import { execFileSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -15,7 +14,7 @@ import { SandboxError } from "./errors.js";
 import { execSimple, shellEscape } from "./utils.js";
 import { HostExecutor } from "./host.js";
 import { createMountedRuntimePathContext } from "./path-context.js";
-import { parseProxyHeaderRules, stripProxySecretEnv } from "./proxy.js";
+import { parseProxyHeaderRules } from "./proxy.js";
 
 const PRIVATE_DIR_MODE = 0o700;
 const PRIVATE_FILE_MODE = 0o600;
@@ -75,19 +74,7 @@ function buildContainerExecCommand(
 }
 
 function withRuntimeBootstrap(command: string, secrets?: SandboxSecrets): string {
-  const script = stageCommandSecrets(stageProxyInjection(command, secrets), secrets);
-  if (!hasGitHubToken(secrets?.env)) {
-    return script;
-  }
-
-  return [
-    "if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then gh auth setup-git >/dev/null 2>&1 || true; fi",
-    script,
-  ].join("\n");
-}
-
-function hasGitHubToken(env?: Record<string, string>): boolean {
-  return Boolean(env?.GH_TOKEN || env?.GITHUB_TOKEN || env?.GITHUB_OAUTH_ACCESS_TOKEN);
+  return stageProxyInjection(command, secrets);
 }
 
 function stageProxyInjection(command: string, secrets?: SandboxSecrets): string {
@@ -135,46 +122,6 @@ server.on('connect', (_req, client) => {
 server.listen(0, '127.0.0.1', () => writeFileSync(process.argv[2], String(server.address().port)));
 `;
 
-function stageCommandSecrets(command: string, secrets?: SandboxSecrets): string {
-  const files = secrets?.files ?? [];
-  if (files.length === 0) {
-    return command;
-  }
-
-  const cleanupSteps = ['rm -rf "$tmp"'];
-  const steps = ["tmp=$(mktemp -d /tmp/mikan-vault.XXXXXX)"];
-  for (const [index, file] of files.entries()) {
-    const staged = `"$tmp/secret-${index}"`;
-    const backup = `"$tmp/backup-${index}"`;
-    const target = shellEscape(file.target);
-    cleanupSteps.unshift(`rm -rf ${target}`, `[ ! -e ${backup} ] || mv ${backup} ${target}`);
-    steps.push(`mkdir -p ${shellEscape(dirnameShell(file.target))}`);
-    steps.push(`[ ! -e ${target} ] && [ ! -L ${target} ] || mv ${target} ${backup}`);
-    if (statSync(file.source).isDirectory()) {
-      const payload = execFileSync("tar", ["-C", file.source, "-czf", "-", "."]).toString("base64");
-      steps.push(`mkdir -p ${staged}`);
-      steps.push(
-        `base64 -d <<'MIKAN_SECRET_${index}' | tar -xzf - -C ${staged}\n${payload}\nMIKAN_SECRET_${index}`,
-      );
-      steps.push(`ln -sfn ${staged} ${target}`);
-    } else {
-      const payload = readFileSync(file.source).toString("base64");
-      steps.push(
-        `base64 -d > ${staged} <<'MIKAN_SECRET_${index}'\n${payload}\nMIKAN_SECRET_${index}`,
-      );
-      steps.push(`ln -sf ${staged} ${target}`);
-    }
-  }
-  steps.splice(1, 0, `cleanup() { ${cleanupSteps.join("; ")}; }`, "trap cleanup EXIT");
-  steps.push(command);
-  return steps.join("\n");
-}
-
-function dirnameShell(path: string): string {
-  const index = path.lastIndexOf("/");
-  return index <= 0 ? "/" : path.slice(0, index);
-}
-
 export class ContainerExecutor implements Executor {
   constructor(
     private container: string,
@@ -204,9 +151,8 @@ export class ContainerExecutor implements Executor {
     }
   }
 
-  private buildCommandEnv(): Record<string, string> | undefined {
-    if (!this.secrets?.env) return undefined;
-    return stripProxySecretEnv(this.secrets.env);
+  private buildCommandEnv(): undefined {
+    return undefined;
   }
 
   getWorkspacePath(_hostPath: string): string {

--- a/src/sandbox/firecracker.ts
+++ b/src/sandbox/firecracker.ts
@@ -6,6 +6,7 @@ import type {
   FirecrackerSandboxConfig,
   RuntimePathContext,
   SandboxAdapter,
+  SandboxSecrets,
 } from "./types.js";
 import { SandboxError } from "./errors.js";
 import { HostExecutor } from "./host.js";
@@ -96,11 +97,12 @@ export class FirecrackerExecutor implements Executor {
     private hostPath: string,
     private sshUser: string = "root",
     private sshPort: number = 22,
-    private env?: Record<string, string>,
+    private secrets?: SandboxSecrets,
   ) {}
 
   async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
-    if (!this.env || Object.keys(this.env).length === 0) {
+    const env = this.secrets?.env;
+    if (!env || Object.keys(env).length === 0) {
       const sshCmd =
         this.sshPort === 22
           ? `ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 ${this.sshUser}@${this.vmId} sh -c ${shellEscape(command)}`
@@ -173,7 +175,7 @@ export class FirecrackerExecutor implements Executor {
       child.stdin?.on("error", (error) => {
         stderr += `${error.message}\n`;
       });
-      child.stdin?.end(buildRemoteScript(command, this.env));
+      child.stdin?.end(buildRemoteScript(command, env));
 
       child.on("close", (code) => {
         if (settled) return;
@@ -242,6 +244,6 @@ export const firecrackerSandboxAdapter: SandboxAdapter<FirecrackerSandboxConfig>
   type: "firecracker",
   parse: parseFirecrackerSandboxArg,
   validate: validateFirecrackerSandbox,
-  createExecutor: (config, env) =>
-    new FirecrackerExecutor(config.vmId, config.hostPath, config.sshUser, config.sshPort, env),
+  createExecutor: (config, secrets) =>
+    new FirecrackerExecutor(config.vmId, config.hostPath, config.sshUser, config.sshPort, secrets),
 };

--- a/src/sandbox/gondolin.ts
+++ b/src/sandbox/gondolin.ts
@@ -9,6 +9,7 @@ import type {
 } from "./types.js";
 import { readEnv } from "../utils/env.js";
 import { SandboxError } from "./errors.js";
+import { buildRemoteSandboxSecrets } from "./remote-secrets.js";
 
 const DEFAULT_GONDOLIN_CWD = "/workspace";
 
@@ -98,10 +99,9 @@ export class GondolinSandboxExecutor implements Executor {
         command,
         cwd: this.cwd,
       };
+      const remoteSecrets = buildRemoteSandboxSecrets(this.secrets);
       if (options?.timeout) payload.timeoutSeconds = options.timeout;
-      if (this.secrets?.env && Object.keys(this.secrets.env).length > 0)
-        payload.env = this.secrets.env;
-      if (this.secrets) payload.secrets = this.secrets;
+      if (remoteSecrets) payload.secrets = remoteSecrets;
 
       const response = await fetch(new URL("/exec", resolveGondolinSandboxUrl()), {
         method: "POST",

--- a/src/sandbox/gondolin.ts
+++ b/src/sandbox/gondolin.ts
@@ -1,8 +1,8 @@
 import type {
-  CloudflareSandboxConfig,
   ExecOptions,
   ExecResult,
   Executor,
+  GondolinSandboxConfig,
   RuntimePathContext,
   SandboxAdapter,
   SandboxSecrets,
@@ -10,9 +10,9 @@ import type {
 import { readEnv } from "../utils/env.js";
 import { SandboxError } from "./errors.js";
 
-const DEFAULT_CLOUDFLARE_CWD = "/workspace";
+const DEFAULT_GONDOLIN_CWD = "/workspace";
 
-interface CloudflareExecPayload {
+interface GondolinExecPayload {
   sandboxId: string;
   command: string;
   timeoutSeconds?: number;
@@ -21,37 +21,37 @@ interface CloudflareExecPayload {
   secrets?: SandboxSecrets;
 }
 
-interface CloudflareExecResponse {
+interface GondolinExecResponse {
   stdout?: string;
   stderr?: string;
   code?: number;
   error?: string;
 }
 
-function parseCloudflareSandboxArg(value: string): CloudflareSandboxConfig | undefined {
-  if (!value.startsWith("cloudflare:")) {
+function parseGondolinSandboxArg(value: string): GondolinSandboxConfig | undefined {
+  if (!value.startsWith("gondolin:")) {
     return undefined;
   }
 
-  const sandboxId = value.slice("cloudflare:".length).trim();
+  const sandboxId = value.slice("gondolin:".length).trim();
   if (!sandboxId) {
     throw new SandboxError(
-      "Error: cloudflare sandbox requires sandbox id (e.g., cloudflare:slack-u123)",
+      "Error: gondolin sandbox requires sandbox id (e.g., gondolin:slack-u123)",
     );
   }
 
-  return { type: "cloudflare", sandboxId };
+  return { type: "gondolin", sandboxId };
 }
 
-async function validateCloudflareSandbox(_config: CloudflareSandboxConfig): Promise<void> {
-  const url = resolveCloudflareSandboxUrl();
+async function validateGondolinSandbox(_config: GondolinSandboxConfig): Promise<void> {
+  const url = resolveGondolinSandboxUrl();
   try {
     const response = await fetch(new URL("/health", url), {
-      headers: buildCloudflareHeaders(),
+      headers: buildGondolinHeaders(),
     });
     if (!response.ok) {
       throw new SandboxError(
-        `Error: Cloudflare sandbox bridge health check failed with HTTP ${response.status}`,
+        `Error: Gondolin sandbox bridge health check failed with HTTP ${response.status}`,
       );
     }
   } catch (error) {
@@ -59,15 +59,13 @@ async function validateCloudflareSandbox(_config: CloudflareSandboxConfig): Prom
       throw error;
     }
     const detail = error instanceof Error ? error.message : String(error);
-    throw new SandboxError(`Error: Cloudflare sandbox bridge is not reachable: ${detail}`);
+    throw new SandboxError(`Error: Gondolin sandbox bridge is not reachable: ${detail}`);
   }
 
-  console.log(
-    `  Cloudflare sandbox bridge enabled. Base URL: ${url.toString().replace(/\/$/, "")}`,
-  );
+  console.log(`  Gondolin sandbox bridge enabled. Base URL: ${url.toString().replace(/\/$/, "")}`);
 }
 
-export class CloudflareSandboxExecutor implements Executor {
+export class GondolinSandboxExecutor implements Executor {
   private readonly cwd: string;
 
   constructor(
@@ -75,7 +73,7 @@ export class CloudflareSandboxExecutor implements Executor {
     private readonly secrets?: SandboxSecrets,
     _ensureReady?: () => Promise<void>,
   ) {
-    this.cwd = readEnv("CLOUDFLARE_SANDBOX_CWD") || DEFAULT_CLOUDFLARE_CWD;
+    this.cwd = readEnv("GONDOLIN_SANDBOX_CWD") || DEFAULT_GONDOLIN_CWD;
   }
 
   async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
@@ -95,7 +93,7 @@ export class CloudflareSandboxExecutor implements Executor {
     }
 
     try {
-      const payload: CloudflareExecPayload = {
+      const payload: GondolinExecPayload = {
         sandboxId: this.sandboxId,
         command,
         cwd: this.cwd,
@@ -105,24 +103,24 @@ export class CloudflareSandboxExecutor implements Executor {
         payload.env = this.secrets.env;
       if (this.secrets) payload.secrets = this.secrets;
 
-      const response = await fetch(new URL("/exec", resolveCloudflareSandboxUrl()), {
+      const response = await fetch(new URL("/exec", resolveGondolinSandboxUrl()), {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          ...buildCloudflareHeaders(),
+          ...buildGondolinHeaders(),
         },
         body: JSON.stringify(payload),
         signal: controller.signal,
       });
 
       const raw = (await response.text()).trim();
-      const parsed = raw ? (JSON.parse(raw) as CloudflareExecResponse) : {};
+      const parsed = raw ? (JSON.parse(raw) as GondolinExecResponse) : {};
 
       if (!response.ok) {
         throw new Error(
           parsed.error ||
             parsed.stderr ||
-            `Cloudflare sandbox bridge returned HTTP ${response.status}`,
+            `Gondolin sandbox bridge returned HTTP ${response.status}`,
         );
       }
 
@@ -158,24 +156,24 @@ export class CloudflareSandboxExecutor implements Executor {
     };
   }
 
-  getSandboxConfig(): CloudflareSandboxConfig {
-    return { type: "cloudflare", sandboxId: this.sandboxId };
+  getSandboxConfig(): GondolinSandboxConfig {
+    return { type: "gondolin", sandboxId: this.sandboxId };
   }
 }
 
-export const cloudflareSandboxAdapter: SandboxAdapter<CloudflareSandboxConfig> = {
-  type: "cloudflare",
-  parse: parseCloudflareSandboxArg,
-  validate: validateCloudflareSandbox,
+export const gondolinSandboxAdapter: SandboxAdapter<GondolinSandboxConfig> = {
+  type: "gondolin",
+  parse: parseGondolinSandboxArg,
+  validate: validateGondolinSandbox,
   createExecutor: (config, secrets, ensureReady) =>
-    new CloudflareSandboxExecutor(config.sandboxId, secrets, ensureReady),
+    new GondolinSandboxExecutor(config.sandboxId, secrets, ensureReady),
 };
 
-function resolveCloudflareSandboxUrl(): URL {
-  const raw = readEnv("CLOUDFLARE_SANDBOX_URL");
+function resolveGondolinSandboxUrl(): URL {
+  const raw = readEnv("GONDOLIN_SANDBOX_URL");
   if (!raw) {
     throw new SandboxError(
-      "Error: CLOUDFLARE_SANDBOX_URL or MIKAN_CLOUDFLARE_SANDBOX_URL is required for cloudflare sandbox mode",
+      "Error: GONDOLIN_SANDBOX_URL or MIKAN_GONDOLIN_SANDBOX_URL is required for gondolin sandbox mode",
     );
   }
 
@@ -183,11 +181,11 @@ function resolveCloudflareSandboxUrl(): URL {
     return new URL(raw);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    throw new SandboxError(`Error: invalid CLOUDFLARE_SANDBOX_URL: ${detail}`);
+    throw new SandboxError(`Error: invalid GONDOLIN_SANDBOX_URL: ${detail}`);
   }
 }
 
-function buildCloudflareHeaders(): Record<string, string> {
-  const token = readEnv("CLOUDFLARE_SANDBOX_TOKEN");
+function buildGondolinHeaders(): Record<string, string> {
+  const token = readEnv("GONDOLIN_SANDBOX_TOKEN");
   return token ? { authorization: `Bearer ${token}` } : {};
 }

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,10 +1,11 @@
 import { ContainerExecutor, containerSandboxAdapter } from "./container.js";
 import { FirecrackerExecutor, firecrackerSandboxAdapter } from "./firecracker.js";
 import { CloudflareSandboxExecutor, cloudflareSandboxAdapter } from "./cloudflare.js";
+import { GondolinSandboxExecutor, gondolinSandboxAdapter } from "./gondolin.js";
 import { HostExecutor, hostSandboxAdapter } from "./host.js";
 import { imageSandboxAdapter } from "./image.js";
 import { SandboxError } from "./errors.js";
-import type { Executor, SandboxAdapter, SandboxConfig } from "./types.js";
+import type { Executor, SandboxAdapter, SandboxConfig, SandboxSecrets } from "./types.js";
 
 export type {
   CloudflareSandboxConfig,
@@ -14,8 +15,15 @@ export type {
   RuntimePathContext,
   SandboxAdapter,
   SandboxConfig,
+  SandboxSecrets,
 } from "./types.js";
-export { CloudflareSandboxExecutor, ContainerExecutor, FirecrackerExecutor, HostExecutor };
+export {
+  CloudflareSandboxExecutor,
+  ContainerExecutor,
+  FirecrackerExecutor,
+  GondolinSandboxExecutor,
+  HostExecutor,
+};
 export { SandboxError } from "./errors.js";
 
 const sandboxAdapters = [
@@ -24,6 +32,7 @@ const sandboxAdapters = [
   imageSandboxAdapter,
   firecrackerSandboxAdapter,
   cloudflareSandboxAdapter,
+  gondolinSandboxAdapter,
 ] as const;
 const sandboxAdapterByType = new Map(
   sandboxAdapters.map((adapter) => [adapter.type, adapter]),
@@ -48,7 +57,7 @@ export function parseSandboxArg(value: string): SandboxConfig {
   }
 
   throw new SandboxError(
-    `Error: Invalid sandbox type '${value}'. Use 'host', 'container:<container-name>', 'image:<image-name>', 'firecracker:<vm-id>:<host-path>', or 'cloudflare:<sandbox-id>'`,
+    `Error: Invalid sandbox type '${value}'. Use 'host', 'container:<container-name>', 'image:<image-name>', 'firecracker:<vm-id>:<host-path>', 'cloudflare:<sandbox-id>', or 'gondolin:<sandbox-id>'`,
   );
 }
 
@@ -66,12 +75,12 @@ export async function validateSandbox(config: SandboxConfig): Promise<void> {
  */
 export function createExecutor(
   config: SandboxConfig,
-  env?: Record<string, string>,
+  secrets?: SandboxSecrets,
   ensureReady?: () => Promise<void>,
 ): Executor {
   const adapter = sandboxAdapterByType.get(config.type);
   if (!adapter) {
     throw new SandboxError(`Error: Unsupported sandbox type '${config.type}'`);
   }
-  return adapter.createExecutor(config, env, ensureReady);
+  return adapter.createExecutor(config, secrets, ensureReady);
 }

--- a/src/sandbox/proxy.ts
+++ b/src/sandbox/proxy.ts
@@ -6,7 +6,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { request as httpsRequest } from "node:https";
-import { connect } from "node:net";
+import type { Socket } from "node:net";
 import type { SecretProxyHandle } from "./types.js";
 
 type HeaderRules = Record<string, Record<string, string>>;
@@ -18,15 +18,12 @@ export async function startSecretInjectionProxy(
   host = LOOPBACK_HOST,
 ): Promise<SecretProxyHandle> {
   const server = createServer((request, response) => handleHttpRequest(request, response, rules));
-  server.on("connect", (request, clientSocket, head) => {
-    const [hostname, portRaw] = String(request.url ?? "").split(":");
-    const upstream = connect(Number(portRaw) || 443, hostname, () => {
-      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
-      if (head.length > 0) upstream.write(head);
-      upstream.pipe(clientSocket);
-      clientSocket.pipe(upstream);
-    });
-    upstream.on("error", () => clientSocket.destroy());
+  server.on("connect", (_request, clientSocket: Socket) => {
+    clientSocket.end(
+      "HTTP/1.1 501 Not Implemented\r\n" +
+        "Connection: close\r\n\r\n" +
+        "MIKAN_PROXY_INJECT_HEADERS supports HTTP proxy requests only; HTTPS CONNECT cannot be modified.\n",
+    );
   });
 
   await listen(server, host);

--- a/src/sandbox/proxy.ts
+++ b/src/sandbox/proxy.ts
@@ -44,12 +44,6 @@ export function parseProxyHeaderRules(env?: Record<string, string>): HeaderRules
   return parsed;
 }
 
-export function stripProxySecretEnv(env: Record<string, string>): Record<string, string> {
-  const next = { ...env };
-  delete next.MIKAN_PROXY_INJECT_HEADERS;
-  return next;
-}
-
 function handleHttpRequest(
   request: IncomingMessage,
   response: ServerResponse,

--- a/src/sandbox/proxy.ts
+++ b/src/sandbox/proxy.ts
@@ -1,0 +1,127 @@
+import {
+  request as httpRequest,
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { request as httpsRequest } from "node:https";
+import { connect } from "node:net";
+import type { SecretProxyHandle } from "./types.js";
+
+type HeaderRules = Record<string, Record<string, string>>;
+
+const LOOPBACK_HOST = "127.0.0.1";
+
+export async function startSecretInjectionProxy(
+  rules: HeaderRules,
+  host = LOOPBACK_HOST,
+): Promise<SecretProxyHandle> {
+  const server = createServer((request, response) => handleHttpRequest(request, response, rules));
+  server.on("connect", (request, clientSocket, head) => {
+    const [hostname, portRaw] = String(request.url ?? "").split(":");
+    const upstream = connect(Number(portRaw) || 443, hostname, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length > 0) upstream.write(head);
+      upstream.pipe(clientSocket);
+      clientSocket.pipe(upstream);
+    });
+    upstream.on("error", () => clientSocket.destroy());
+  });
+
+  await listen(server, host);
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Secret proxy did not bind a TCP port");
+  return {
+    url: `http://${host}:${address.port}`,
+    close: () => close(server),
+  };
+}
+
+export function parseProxyHeaderRules(env?: Record<string, string>): HeaderRules | undefined {
+  const raw = env?.MIKAN_PROXY_INJECT_HEADERS;
+  if (!raw) return undefined;
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isHeaderRules(parsed)) throw new Error("Invalid MIKAN_PROXY_INJECT_HEADERS JSON");
+  return parsed;
+}
+
+export function stripProxySecretEnv(env: Record<string, string>): Record<string, string> {
+  const next = { ...env };
+  delete next.MIKAN_PROXY_INJECT_HEADERS;
+  return next;
+}
+
+function handleHttpRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  rules: HeaderRules,
+): void {
+  const target = parseRequestTarget(request);
+  if (!target) {
+    response.writeHead(400);
+    response.end("proxy requires absolute-form request target");
+    return;
+  }
+  for (const [key, value] of Object.entries(rules[target.host] ?? {})) {
+    request.headers[key.toLowerCase()] = value;
+  }
+
+  const upstream = createServerlessRequest(target, request, response);
+  request.pipe(upstream);
+}
+
+function createServerlessRequest(target: URL, request: IncomingMessage, response: ServerResponse) {
+  const requestImpl = target.protocol === "https:" ? httpsRequest : httpRequest;
+  const upstream = requestImpl(
+    target,
+    { method: request.method, headers: request.headers },
+    (upstreamResponse: IncomingMessage) => {
+      response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+      upstreamResponse.pipe(response);
+    },
+  );
+  upstream.on("error", (error: Error) => {
+    response.writeHead(502);
+    response.end(error.message);
+  });
+  return upstream;
+}
+
+function parseRequestTarget(request: IncomingMessage): URL | undefined {
+  try {
+    if (!request.url?.startsWith("http://") && !request.url?.startsWith("https://"))
+      return undefined;
+    return new URL(request.url);
+  } catch {
+    return undefined;
+  }
+}
+
+function isHeaderRules(value: unknown): value is HeaderRules {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value).every(
+    (headers) =>
+      headers &&
+      typeof headers === "object" &&
+      !Array.isArray(headers) &&
+      Object.values(headers).every((header) => typeof header === "string"),
+  );
+}
+
+function listen(server: Server, host: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/src/sandbox/remote-secrets.ts
+++ b/src/sandbox/remote-secrets.ts
@@ -1,0 +1,13 @@
+import type { SandboxSecrets } from "./types.js";
+
+const PROXY_SECRET_ENV_KEY = "MIKAN_PROXY_INJECT_HEADERS";
+
+export function buildRemoteSandboxSecrets(secrets?: SandboxSecrets): SandboxSecrets | undefined {
+  const proxyRules = secrets?.env?.[PROXY_SECRET_ENV_KEY];
+  if (!proxyRules) return undefined;
+  return { env: { [PROXY_SECRET_ENV_KEY]: proxyRules } };
+}
+
+export function hasVaultFileSecrets(secrets?: SandboxSecrets): boolean {
+  return Boolean(secrets?.files && secrets.files.length > 0);
+}

--- a/src/sandbox/remote-secrets.ts
+++ b/src/sandbox/remote-secrets.ts
@@ -7,7 +7,3 @@ export function buildRemoteSandboxSecrets(secrets?: SandboxSecrets): SandboxSecr
   if (!proxyRules) return undefined;
   return { env: { [PROXY_SECRET_ENV_KEY]: proxyRules } };
 }
-
-export function hasVaultFileSecrets(secrets?: SandboxSecrets): boolean {
-  return Boolean(secrets?.files && secrets.files.length > 0);
-}

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -3,7 +3,8 @@ export type SandboxConfig =
   | ContainerSandboxConfig
   | ImageSandboxConfig
   | FirecrackerSandboxConfig
-  | CloudflareSandboxConfig;
+  | CloudflareSandboxConfig
+  | GondolinSandboxConfig;
 
 export interface HostSandboxConfig {
   type: "host";
@@ -30,6 +31,23 @@ export interface FirecrackerSandboxConfig {
 export interface CloudflareSandboxConfig {
   type: "cloudflare";
   sandboxId: string;
+}
+
+export interface GondolinSandboxConfig {
+  type: "gondolin";
+  sandboxId: string;
+}
+
+export interface SandboxSecrets {
+  /** Environment values exposed only for the current command. */
+  env?: Record<string, string>;
+  /** Host files staged into the runtime only for the current command. */
+  files?: Array<{ source: string; target: string }>;
+}
+
+export interface SecretProxyHandle {
+  url: string;
+  close: () => Promise<void>;
 }
 
 export interface Executor {
@@ -82,7 +100,7 @@ export interface SandboxAdapter<TConfig extends SandboxConfig = SandboxConfig> {
   validate(config: TConfig): Promise<void>;
   createExecutor(
     config: TConfig,
-    env?: Record<string, string>,
+    secrets?: SandboxSecrets,
     ensureReady?: () => Promise<void>,
   ): Executor;
 }

--- a/src/vault/index.ts
+++ b/src/vault/index.ts
@@ -127,9 +127,9 @@ export class FileVaultManager implements VaultManager {
   }
 
   getSandboxConfig(userId: string, baseConfig: SandboxConfig): SandboxConfig {
-    if (baseConfig.type === "cloudflare") {
+    if (baseConfig.type === "cloudflare" || baseConfig.type === "gondolin") {
       return {
-        type: "cloudflare",
+        type: baseConfig.type,
         sandboxId: `${baseConfig.sandboxId}-${sanitizeCloudflareSandboxId(userId)}`,
       };
     }

--- a/src/vault/routing.ts
+++ b/src/vault/routing.ts
@@ -12,6 +12,7 @@ export function resolveActorVaultKey(
   if (
     baseConfig.type === "image" ||
     baseConfig.type === "cloudflare" ||
+    baseConfig.type === "gondolin" ||
     baseConfig.type === "firecracker"
   ) {
     return DockerContainerManager.sanitizeSegment(conversationId);

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -1,8 +1,6 @@
 import { createServer, request as httpRequest } from "node:http";
 import { connect as netConnect } from "node:net";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   CloudflareSandboxExecutor,
@@ -142,51 +140,26 @@ describe("ContainerExecutor", () => {
     vi.restoreAllMocks();
   });
 
-  test("stages vault files only for the current docker exec command", async () => {
-    const tempDir = mkdtempSync(join(tmpdir(), "mikan-secret-test-"));
-    try {
-      const source = join(tempDir, "adc.json");
-      writeFileSync(source, '{"token":"secret"}\n');
-      const exec = vi
-        .spyOn(HostExecutor.prototype, "exec")
-        .mockResolvedValue({ stdout: "", stderr: "", code: 0 });
-      const executor = new ContainerExecutor(
-        "mikan-sandbox",
-        { files: [{ source, target: "/workspace/gcloud-adc.json" }] },
-        async () => {},
-      );
-
-      await executor.exec("gcloud auth application-default print-access-token");
-
-      const [[dockerCommand]] = exec.mock.calls;
-      expect(dockerCommand).not.toContain("-v ");
-      expect(dockerCommand).toContain("mktemp -d /tmp/mikan-vault.");
-      expect(dockerCommand).toContain("base64 -d");
-      expect(dockerCommand).toContain("ln -sf");
-      expect(dockerCommand).toContain("/workspace/gcloud-adc.json");
-      expect(dockerCommand).toContain("gcloud auth application-default print-access-token");
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  test("bootstraps git credential helper when GitHub token env is injected", async () => {
+  test("does not inject vault env or file secrets into docker exec", async () => {
     const exec = vi
       .spyOn(HostExecutor.prototype, "exec")
       .mockResolvedValue({ stdout: "", stderr: "", code: 0 });
     const executor = new ContainerExecutor(
       "mikan-sandbox",
-      { env: { GH_TOKEN: "gho_test" } },
+      {
+        env: { GH_TOKEN: "gho_test" },
+        files: [{ source: "/host/adc.json", target: "/workspace/gcloud-adc.json" }],
+      },
       async () => {},
     );
 
-    await executor.exec("git clone https://github.com/livingbio/skills.git");
+    await executor.exec("printf $GH_TOKEN && test -e /workspace/gcloud-adc.json");
 
     const [[dockerCommand]] = exec.mock.calls;
-    expect(dockerCommand).toContain("docker exec --env-file ");
-    expect(dockerCommand).toContain("mikan-sandbox sh -c");
-    expect(dockerCommand).toContain("gh auth setup-git");
-    expect(dockerCommand).toContain("git clone https://github.com/livingbio/skills.git");
+    expect(dockerCommand).not.toContain("--env-file");
+    expect(dockerCommand).not.toContain("gho_test");
+    expect(dockerCommand).not.toContain("mktemp -d /tmp/mikan-vault.");
+    expect(dockerCommand).toContain("printf $GH_TOKEN && test -e /workspace/gcloud-adc.json");
   });
 
   test("enables secret header injection for HTTP proxy traffic only", async () => {
@@ -447,17 +420,6 @@ describe("CloudflareSandboxExecutor", () => {
       cwd: "/workspace",
       secrets: { env: { MIKAN_PROXY_INJECT_HEADERS: proxyRules } },
     });
-  });
-
-  test("rejects file secrets because the Cloudflare bridge cannot stage local host files", async () => {
-    process.env.MIKAN_CLOUDFLARE_SANDBOX_URL = "https://sandbox.example";
-    const executor = new CloudflareSandboxExecutor("slack-u123", {
-      files: [{ source: "/host/adc.json", target: "/workspace/adc.json" }],
-    });
-
-    await expect(executor.exec("pwd")).rejects.toThrow(
-      "Cloudflare sandbox bridge does not support vault file secrets yet",
-    );
   });
 
   test("reports the configured Cloudflare runtime cwd as workspace path", () => {

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -1,13 +1,19 @@
+import { createServer, request as httpRequest } from "node:http";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   CloudflareSandboxExecutor,
   ContainerExecutor,
   FirecrackerExecutor,
+  GondolinSandboxExecutor,
   HostExecutor,
   SandboxError,
   createExecutor,
   parseSandboxArg,
 } from "../src/sandbox/index.js";
+import { startSecretInjectionProxy } from "../src/sandbox/proxy.js";
 
 describe("parseSandboxArg", () => {
   afterEach(() => {
@@ -55,6 +61,13 @@ describe("parseSandboxArg", () => {
   test("parses cloudflare sandbox", () => {
     expect(parseSandboxArg("cloudflare:slack-u123")).toEqual({
       type: "cloudflare",
+      sandboxId: "slack-u123",
+    });
+  });
+
+  test("parses gondolin sandbox", () => {
+    expect(parseSandboxArg("gondolin:slack-u123")).toEqual({
+      type: "gondolin",
       sandboxId: "slack-u123",
     });
   });
@@ -115,11 +128,45 @@ describe("createExecutor", () => {
       CloudflareSandboxExecutor,
     );
   });
+
+  test("creates gondolin executor", () => {
+    expect(createExecutor({ type: "gondolin", sandboxId: "shared-prefix" })).toBeInstanceOf(
+      GondolinSandboxExecutor,
+    );
+  });
 });
 
 describe("ContainerExecutor", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  test("stages vault files only for the current docker exec command", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "mikan-secret-test-"));
+    try {
+      const source = join(tempDir, "adc.json");
+      writeFileSync(source, '{"token":"secret"}\n');
+      const exec = vi
+        .spyOn(HostExecutor.prototype, "exec")
+        .mockResolvedValue({ stdout: "", stderr: "", code: 0 });
+      const executor = new ContainerExecutor(
+        "mikan-sandbox",
+        { files: [{ source, target: "/workspace/gcloud-adc.json" }] },
+        async () => {},
+      );
+
+      await executor.exec("gcloud auth application-default print-access-token");
+
+      const [[dockerCommand]] = exec.mock.calls;
+      expect(dockerCommand).not.toContain("-v ");
+      expect(dockerCommand).toContain("mktemp -d /tmp/mikan-vault.");
+      expect(dockerCommand).toContain("base64 -d");
+      expect(dockerCommand).toContain("ln -sf");
+      expect(dockerCommand).toContain("/workspace/gcloud-adc.json");
+      expect(dockerCommand).toContain("gcloud auth application-default print-access-token");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("bootstraps git credential helper when GitHub token env is injected", async () => {
@@ -128,7 +175,7 @@ describe("ContainerExecutor", () => {
       .mockResolvedValue({ stdout: "", stderr: "", code: 0 });
     const executor = new ContainerExecutor(
       "mikan-sandbox",
-      { GH_TOKEN: "gho_test" },
+      { env: { GH_TOKEN: "gho_test" } },
       async () => {},
     );
 
@@ -139,6 +186,53 @@ describe("ContainerExecutor", () => {
     expect(dockerCommand).toContain("mikan-sandbox sh -c");
     expect(dockerCommand).toContain("gh auth setup-git");
     expect(dockerCommand).toContain("git clone https://github.com/livingbio/skills.git");
+  });
+});
+
+async function runProxyHeaderRequest(upstream: ReturnType<typeof createServer>): Promise<void> {
+  const address = upstream.address();
+  if (!address || typeof address === "string") throw new Error("no port");
+  const host = `127.0.0.1:${address.port}`;
+  const proxy = await startSecretInjectionProxy({ [host]: { authorization: "Bearer injected" } });
+  try {
+    await new Promise<void>((resolve) => {
+      const proxyUrl = new URL(proxy.url);
+      const req = httpRequest(
+        {
+          hostname: proxyUrl.hostname,
+          port: proxyUrl.port,
+          method: "GET",
+          path: `http://${host}/check`,
+        },
+        (res) => {
+          res.resume();
+          res.on("end", resolve);
+        },
+      );
+      req.end();
+    });
+  } finally {
+    await proxy.close();
+  }
+}
+
+describe("Secret injection proxy", () => {
+  test("injects configured headers into proxied HTTP requests", async () => {
+    const seen = await new Promise<Record<string, string | string[] | undefined>>(
+      (resolve, reject) => {
+        const upstream = createServer((request, response) => {
+          resolve(request.headers);
+          response.end("ok");
+        });
+        upstream.listen(0, "127.0.0.1", () => {
+          runProxyHeaderRequest(upstream)
+            .catch(reject)
+            .finally(() => upstream.close());
+        });
+      },
+    );
+
+    expect(seen.authorization).toBe("Bearer injected");
   });
 });
 
@@ -185,6 +279,49 @@ describe("FirecrackerExecutor", () => {
   });
 });
 
+describe("GondolinSandboxExecutor", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  test("posts exec requests to the bridge with secrets", async () => {
+    process.env.MIKAN_GONDOLIN_SANDBOX_URL = "https://gondolin.example";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ stdout: "ok\n", stderr: "", code: 0 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const executor = new GondolinSandboxExecutor("slack-u123", {
+      env: { API_TOKEN: "secret" },
+    });
+    await expect(executor.exec("pwd", { timeout: 5 })).resolves.toEqual({
+      stdout: "ok\n",
+      stderr: "",
+      code: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("/exec", "https://gondolin.example"),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "content-type": "application/json" }),
+      }),
+    );
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      sandboxId: "slack-u123",
+      command: "pwd",
+      timeoutSeconds: 5,
+      cwd: "/workspace",
+      env: { API_TOKEN: "secret" },
+      secrets: { env: { API_TOKEN: "secret" } },
+    });
+  });
+});
+
 describe("CloudflareSandboxExecutor", () => {
   const originalEnv = { ...process.env };
 
@@ -201,7 +338,7 @@ describe("CloudflareSandboxExecutor", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const executor = new CloudflareSandboxExecutor("slack-u123", { API_TOKEN: "secret" });
+    const executor = new CloudflareSandboxExecutor("slack-u123", { env: { API_TOKEN: "secret" } });
     await expect(executor.exec("pwd", { timeout: 5 })).resolves.toEqual({
       stdout: "ok\n",
       stderr: "",
@@ -221,6 +358,7 @@ describe("CloudflareSandboxExecutor", () => {
       timeoutSeconds: 5,
       cwd: "/workspace",
       env: { API_TOKEN: "secret" },
+      secrets: { env: { API_TOKEN: "secret" } },
     });
   });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -1,4 +1,5 @@
 import { createServer, request as httpRequest } from "node:http";
+import { connect as netConnect } from "node:net";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -187,6 +188,31 @@ describe("ContainerExecutor", () => {
     expect(dockerCommand).toContain("gh auth setup-git");
     expect(dockerCommand).toContain("git clone https://github.com/livingbio/skills.git");
   });
+
+  test("enables secret header injection for HTTP proxy traffic only", async () => {
+    const exec = vi
+      .spyOn(HostExecutor.prototype, "exec")
+      .mockResolvedValue({ stdout: "", stderr: "", code: 0 });
+    const executor = new ContainerExecutor(
+      "mikan-sandbox",
+      {
+        env: {
+          MIKAN_PROXY_INJECT_HEADERS: JSON.stringify({ "api.example": { authorization: "x" } }),
+        },
+      },
+      async () => {},
+    );
+
+    await executor.exec("curl http://api.example/check");
+
+    const [[dockerCommand]] = exec.mock.calls;
+    expect(dockerCommand).toContain(
+      'export HTTP_PROXY="http://127.0.0.1:$(cat "$proxy_dir/port")"',
+    );
+    expect(dockerCommand).toContain('export http_proxy="$HTTP_PROXY"');
+    expect(dockerCommand).not.toContain("HTTPS_PROXY");
+    expect(dockerCommand).not.toContain("ALL_PROXY");
+  });
 });
 
 async function runProxyHeaderRequest(upstream: ReturnType<typeof createServer>): Promise<void> {
@@ -233,6 +259,27 @@ describe("Secret injection proxy", () => {
     );
 
     expect(seen.authorization).toBe("Bearer injected");
+  });
+
+  test("rejects HTTPS CONNECT because encrypted headers cannot be injected", async () => {
+    const proxy = await startSecretInjectionProxy({ "example.com": { authorization: "Bearer x" } });
+    try {
+      const proxyUrl = new URL(proxy.url);
+      const response = await new Promise<string>((resolve, reject) => {
+        const socket = netConnect(Number(proxyUrl.port), proxyUrl.hostname, () => {
+          socket.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n");
+        });
+        let data = "";
+        socket.on("data", (chunk) => (data += chunk.toString("utf-8")));
+        socket.on("end", () => resolve(data));
+        socket.on("error", reject);
+      });
+
+      expect(response).toContain("501 Not Implemented");
+      expect(response).toContain("supports HTTP proxy requests only");
+    } finally {
+      await proxy.close();
+    }
   });
 });
 
@@ -360,6 +407,17 @@ describe("CloudflareSandboxExecutor", () => {
       env: { API_TOKEN: "secret" },
       secrets: { env: { API_TOKEN: "secret" } },
     });
+  });
+
+  test("rejects file secrets because the Cloudflare bridge cannot stage local host files", async () => {
+    process.env.MIKAN_CLOUDFLARE_SANDBOX_URL = "https://sandbox.example";
+    const executor = new CloudflareSandboxExecutor("slack-u123", {
+      files: [{ source: "/host/adc.json", target: "/workspace/adc.json" }],
+    });
+
+    await expect(executor.exec("pwd")).rejects.toThrow(
+      "Cloudflare sandbox bridge does not support vault file secrets yet",
+    );
   });
 
   test("reports the configured Cloudflare runtime cwd as workspace path", () => {

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -334,7 +334,7 @@ describe("GondolinSandboxExecutor", () => {
     process.env = { ...originalEnv };
   });
 
-  test("posts exec requests to the bridge with secrets", async () => {
+  test("does not expose vault env secrets in bridge exec payload", async () => {
     process.env.MIKAN_GONDOLIN_SANDBOX_URL = "https://gondolin.example";
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -363,8 +363,28 @@ describe("GondolinSandboxExecutor", () => {
       command: "pwd",
       timeoutSeconds: 5,
       cwd: "/workspace",
-      env: { API_TOKEN: "secret" },
-      secrets: { env: { API_TOKEN: "secret" } },
+    });
+  });
+
+  test("sends only proxy header rules to the bridge", async () => {
+    process.env.MIKAN_GONDOLIN_SANDBOX_URL = "https://gondolin.example";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ stdout: "ok\n", stderr: "", code: 0 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxyRules = JSON.stringify({ "api.example": { authorization: "Bearer injected" } });
+    const executor = new GondolinSandboxExecutor("slack-u123", {
+      env: { API_TOKEN: "secret", MIKAN_PROXY_INJECT_HEADERS: proxyRules },
+    });
+    await executor.exec("curl http://api.example/check");
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      sandboxId: "slack-u123",
+      command: "curl http://api.example/check",
+      cwd: "/workspace",
+      secrets: { env: { MIKAN_PROXY_INJECT_HEADERS: proxyRules } },
     });
   });
 });
@@ -377,7 +397,7 @@ describe("CloudflareSandboxExecutor", () => {
     process.env = { ...originalEnv };
   });
 
-  test("posts exec requests to the bridge", async () => {
+  test("does not expose vault env secrets in bridge exec payload", async () => {
     process.env.MIKAN_CLOUDFLARE_SANDBOX_URL = "https://sandbox.example";
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -404,8 +424,28 @@ describe("CloudflareSandboxExecutor", () => {
       command: "pwd",
       timeoutSeconds: 5,
       cwd: "/workspace",
-      env: { API_TOKEN: "secret" },
-      secrets: { env: { API_TOKEN: "secret" } },
+    });
+  });
+
+  test("sends only proxy header rules to the bridge", async () => {
+    process.env.MIKAN_CLOUDFLARE_SANDBOX_URL = "https://sandbox.example";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ stdout: "ok\n", stderr: "", code: 0 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxyRules = JSON.stringify({ "api.example": { authorization: "Bearer injected" } });
+    const executor = new CloudflareSandboxExecutor("slack-u123", {
+      env: { API_TOKEN: "secret", MIKAN_PROXY_INJECT_HEADERS: proxyRules },
+    });
+    await executor.exec("curl http://api.example/check");
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      sandboxId: "slack-u123",
+      command: "curl http://api.example/check",
+      cwd: "/workspace",
+      secrets: { env: { MIKAN_PROXY_INJECT_HEADERS: proxyRules } },
     });
   });
 

--- a/test/vault.test.ts
+++ b/test/vault.test.ts
@@ -173,13 +173,17 @@ describe("FileVaultManager", () => {
     expect(mode(credentialPath) & 0o077).toBe(0);
   });
 
-  test("derives per-vault cloudflare sandbox ids", () => {
+  test("derives per-vault cloudflare and gondolin sandbox ids", () => {
     const mgr = new FileVaultManager(tmpDir);
     expect(
       mgr.getSandboxConfig("alice", { type: "cloudflare", sandboxId: "mikan-remote" }),
     ).toEqual({
       type: "cloudflare",
       sandboxId: "mikan-remote-alice",
+    });
+    expect(mgr.getSandboxConfig("alice", { type: "gondolin", sandboxId: "mikan-local" })).toEqual({
+      type: "gondolin",
+      sandboxId: "mikan-local-alice",
     });
   });
 
@@ -350,7 +354,27 @@ describe("ActorExecutionResolver image mode", () => {
     expect(mgr.resolve(DockerContainerManager.sanitizeSegment("D123"))).toBeUndefined();
   });
 
-  test("provisions per-conversation container with inferred vault mounts", async () => {
+  test("uses platform-namespaced vault ids for new users in gondolin mode", async () => {
+    const mgr = new FileVaultManager(tmpDir);
+    const resolver = new ActorExecutionResolver(
+      { type: "gondolin", sandboxId: "mikan-local" },
+      mgr,
+    );
+
+    const executor = await resolver.resolve({
+      platform: "slack",
+      userId: "U123",
+      conversationId: "D123",
+    });
+
+    expect(executor.getSandboxConfig()).toEqual({
+      type: "gondolin",
+      sandboxId: "mikan-local-d123",
+    });
+    expect(mgr.resolve(DockerContainerManager.sanitizeSegment("D123"))).toBeUndefined();
+  });
+
+  test("provisions per-conversation container without mounting vault secrets", async () => {
     const userDir = join(vaultsDir, "d123");
     mkdirSync(join(userDir, ".ssh"), { recursive: true });
 
@@ -381,13 +405,12 @@ describe("ActorExecutionResolver image mode", () => {
         { source: join(tmpDir, "skills"), target: "/workspace/skills" },
         { source: join(tmpDir, "events"), target: "/workspace/events" },
         { source: join(tmpDir, "D123"), target: "/workspace/D123" },
-        { source: join(vaultsDir, "d123", ".ssh"), target: "/root/.ssh" },
       ],
     });
-    expect(exec).toHaveBeenCalledWith(
-      "docker exec -w /workspace mikan-sandbox-d123 sh -c 'pwd'",
-      undefined,
-    );
+    const [[dockerCommand]] = exec.mock.calls;
+    expect(dockerCommand).toContain("mktemp -d /tmp/mikan-vault.");
+    expect(dockerCommand).toContain("/root/.ssh");
+    expect(dockerCommand).toContain("pwd");
   });
 
   test("mounts the full workspace when conversation sandbox mode is full", async () => {

--- a/test/vault.test.ts
+++ b/test/vault.test.ts
@@ -408,8 +408,8 @@ describe("ActorExecutionResolver image mode", () => {
       ],
     });
     const [[dockerCommand]] = exec.mock.calls;
-    expect(dockerCommand).toContain("mktemp -d /tmp/mikan-vault.");
-    expect(dockerCommand).toContain("/root/.ssh");
+    expect(dockerCommand).not.toContain("mktemp -d /tmp/mikan-vault.");
+    expect(dockerCommand).not.toContain("/root/.ssh");
     expect(dockerCommand).toContain("pwd");
   });
 


### PR DESCRIPTION
## Summary
- add exec-time sandbox secrets and proxy-based header injection
- add Gondolin sandbox bridge adapter and example bridge
- extend Cloudflare bridge payload with secrets
- document sandbox verification and add CLI proxy verification script

## Verification
- npm test
- npm run build
- npm run lint
- npm run verify:sandbox-cli-proxy
