### PR TITLE
Add Token Usage Bar Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 data/
 bin/
 .workspace/
+workspace/
 
 *.env
 .env*

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": []
+  "ignorePatterns": ["**/.claude/**"]
 }

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -90,6 +90,10 @@ async function routeApiRequest(
       serveSessionUsage(res, services);
       return;
     }
+    if (url.pathname === "/admin/api/conversation-usage") {
+      serveConversationUsage(res, url, services);
+      return;
+    }
     if (url.pathname === "/admin/api/conversation-state") {
       serveConversationState(res, url, services, token);
       return;
@@ -421,6 +425,128 @@ interface AssistantUsageMessage {
 
 function numberOrZero(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+interface UsageBucket {
+  date: string;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+  cost: number;
+}
+
+function localDayKey(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function emptyBucket(date: string): UsageBucket {
+  return { date, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 };
+}
+
+/** Per-conversation daily token usage over the last N days (N clamped to 1..7). */
+function serveConversationUsage(res: ServerResponse, url: URL, services: AdminServices): void {
+  const workingDir = requireAdminWorkingDir(res, services);
+  if (!workingDir) return;
+
+  const conversationId = url.searchParams.get("conversationId") ?? "";
+  if (!conversationId || !listConversationDirs(workingDir).includes(conversationId)) {
+    jsonRes(res, 400, { error: "Unknown conversationId" });
+    return;
+  }
+
+  const daysRaw = parseInt(url.searchParams.get("days") ?? "7", 10);
+  const days = Number.isFinite(daysRaw) ? Math.min(7, Math.max(1, daysRaw)) : 7;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const buckets = new Map<string, UsageBucket>();
+  const order: string[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    const key = localDayKey(d);
+    order.push(key);
+    buckets.set(key, emptyBucket(key));
+  }
+  const cutoff = new Date(today);
+  cutoff.setDate(today.getDate() - (days - 1));
+
+  const sessionDir = join(workingDir, conversationId, "sessions");
+  try {
+    for (const entry of readdirSync(sessionDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      accumulateSessionUsageByDay(join(sessionDir, entry.name), cutoff, buckets);
+    }
+  } catch {
+    // No sessions directory yet — return empty buckets.
+  }
+
+  const series = order.map((key) => buckets.get(key) ?? emptyBucket(key));
+  const totals = series.reduce((sum, b) => {
+    sum.input += b.input;
+    sum.output += b.output;
+    sum.cacheRead += b.cacheRead;
+    sum.cacheWrite += b.cacheWrite;
+    sum.total += b.total;
+    sum.cost += b.cost;
+    return sum;
+  }, emptyBucket(""));
+
+  jsonRes(res, 200, {
+    conversationId,
+    label: conversationDisplayLabel(services, conversationId),
+    days,
+    buckets: series,
+    totals: {
+      input: totals.input,
+      output: totals.output,
+      cacheRead: totals.cacheRead,
+      cacheWrite: totals.cacheWrite,
+      total: totals.total,
+      cost: totals.cost,
+    },
+  });
+}
+
+function accumulateSessionUsageByDay(
+  sessionFile: string,
+  cutoff: Date,
+  buckets: Map<string, UsageBucket>,
+): void {
+  try {
+    const manager = SessionManager.open(sessionFile);
+    if (!manager.getHeader()) return;
+
+    for (const entry of manager.getEntries()) {
+      if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+      const usage = (entry.message as unknown as AssistantUsageMessage).usage;
+      if (!usage || !entry.timestamp) continue;
+
+      const when = new Date(entry.timestamp);
+      if (Number.isNaN(when.getTime()) || when < cutoff) continue;
+
+      const bucket = buckets.get(localDayKey(when));
+      if (!bucket) continue;
+
+      const input = numberOrZero(usage.input);
+      const output = numberOrZero(usage.output);
+      const cacheRead = numberOrZero(usage.cacheRead);
+      const cacheWrite = numberOrZero(usage.cacheWrite);
+      bucket.input += input;
+      bucket.output += output;
+      bucket.cacheRead += cacheRead;
+      bucket.cacheWrite += cacheWrite;
+      bucket.total += input + output + cacheRead + cacheWrite;
+      bucket.cost += numberOrZero(usage.cost?.total);
+    }
+  } catch {
+    // Skip unreadable session files.
+  }
 }
 
 function serveConversationState(
@@ -1512,6 +1638,26 @@ function renderAdminPage(token: AdminToken): string {
       <section class="card sect">
         <header class="sect-head">
           <div>
+            <p class="eyebrow">Token Usage</p>
+            <h2 class="card-title">Usage timeline</h2>
+          </div>
+          <button class="refresh-btn" onclick="loadUsageTimeline()">↻</button>
+        </header>
+        <div class="timeline-controls">
+          <label>Conversation
+            <select id="timeline-conv" onchange="loadUsageTimeline()"></select>
+          </label>
+          <label>Range
+            <input type="range" id="timeline-days" min="1" max="7" value="7" step="1" oninput="onTimelineDaysInput()">
+            <span id="timeline-days-out">7 d</span>
+          </label>
+        </div>
+        <div id="usage-timeline-content"><div class="loading-msg">Loading…</div></div>
+      </section>
+
+      <section class="card sect">
+        <header class="sect-head">
+          <div>
             <p class="eyebrow">Global Settings</p>
             <h2 class="card-title">全域預設</h2>
           </div>
@@ -2039,6 +2185,7 @@ function renderAdminPage(token: AdminToken): string {
       globalLoaded = true;
       loadAllConversations();
       loadSessionUsage();
+      loadUsageTimeline();
       loadGlobalSettings();
       loadGlobalSkills();
       loadEvents();
@@ -2095,6 +2242,91 @@ function renderAdminPage(token: AdminToken): string {
 
     function fmtNum(value) {
       return Number(value || 0).toLocaleString('en-US');
+    }
+
+    let timelineConvLoaded = false;
+    async function ensureTimelineConvOptions() {
+      if (timelineConvLoaded) return;
+      const sel = document.getElementById('timeline-conv');
+      const data = await apiGet('/admin/api/conversations');
+      if (!data.conversations.length) {
+        sel.innerHTML = '<option value="">No conversations</option>';
+        return;
+      }
+      sel.innerHTML = data.conversations.map((c) =>
+        '<option value="' + escAttr(c.conversationId) + '"' +
+        (c.conversationId === defaultConversationId ? ' selected' : '') + '>' +
+        escHtml(c.label || c.conversationId) + '</option>'
+      ).join('');
+      timelineConvLoaded = true;
+    }
+
+    function onTimelineDaysInput() {
+      const days = document.getElementById('timeline-days').value;
+      document.getElementById('timeline-days-out').textContent = days + ' d';
+      loadUsageTimeline();
+    }
+
+    async function loadUsageTimeline() {
+      const container = document.getElementById('usage-timeline-content');
+      try {
+        await ensureTimelineConvOptions();
+        const conv = document.getElementById('timeline-conv').value;
+        if (!conv) {
+          container.innerHTML = '<div class="empty-state">No conversations found</div>';
+          return;
+        }
+        const days = document.getElementById('timeline-days').value || '7';
+        container.innerHTML = '<div class="loading-msg">Loading…</div>';
+        const data = await apiGet('/admin/api/conversation-usage?conversationId=' +
+          encodeURIComponent(conv) + '&days=' + encodeURIComponent(days));
+        container.innerHTML = renderUsageTimeline(data);
+      } catch (err) {
+        container.innerHTML = '<div class="err-msg">' + escHtml(err.message) + '</div>';
+      }
+    }
+
+    function tlCard(label, value) {
+      return '<div class="tl-card"><div class="tl-card-label">' + label +
+        '</div><div class="tl-card-value">' + value + '</div></div>';
+    }
+
+    function renderUsageTimeline(data) {
+      const buckets = data.buckets || [];
+      const totals = data.totals || { total: 0, cost: 0, cacheRead: 0 };
+      const cacheHit = totals.total > 0 ? Math.round((totals.cacheRead / totals.total) * 100) : 0;
+      const cards = '<div class="tl-cards">' +
+        tlCard('Total cost', totals.cost > 0 ? '$' + Number(totals.cost).toFixed(4) : '—') +
+        tlCard('Total tokens', fmtNum(totals.total)) +
+        tlCard('Cache hit', cacheHit + '%') +
+      '</div>';
+
+      if (totals.total === 0) {
+        return cards + '<div class="empty-state">No token usage in this range</div>';
+      }
+
+      const max = Math.max(1, ...buckets.map((b) => b.total));
+      const px = (v) => Math.round((v / max) * 120);
+      const legend = '<div class="tl-legend">' +
+        '<span><i class="sw sw-cache"></i>Cache read</span>' +
+        '<span><i class="sw sw-input"></i>Input</span>' +
+        '<span><i class="sw sw-output"></i>Output</span>' +
+      '</div>';
+      const bars = buckets.map((b) => {
+        const title = b.date + ' · ' + fmtNum(b.total) + ' tok' +
+          (b.cost > 0 ? ' · $' + Number(b.cost).toFixed(4) : '');
+        const inner = b.total > 0
+          ? '<span class="tl-seg tl-output" style="height:' + px(b.output) + 'px"></span>' +
+            '<span class="tl-seg tl-input" style="height:' + px(b.input) + 'px"></span>' +
+            '<span class="tl-seg tl-cache" style="height:' + px(b.cacheRead + b.cacheWrite) + 'px"></span>'
+          : '<span class="tl-empty"></span>';
+        return '<div class="tl-bar" title="' + escAttr(title) + '">' + inner + '</div>';
+      }).join('');
+      const axis = buckets.length
+        ? '<div class="tl-axis"><span>' + escHtml(buckets[0].date.slice(5)) +
+          '</span><span>' + escHtml(buckets[buckets.length - 1].date.slice(5)) + '</span></div>'
+        : '';
+      return cards + legend + '<div class="tl-chart">' + bars + '</div>' + axis;
     }
 
     async function loadGlobalSettings() {
@@ -2471,6 +2703,44 @@ const adminViewStyles = `
     text-transform: uppercase; letter-spacing: 0.08em;
   }
   .usage-table code { font-size: 0.72rem; }
+
+  .timeline-controls {
+    display: flex; flex-wrap: wrap; gap: 18px; align-items: center; margin-bottom: 16px;
+  }
+  .timeline-controls label {
+    display: flex; align-items: center; gap: 8px;
+    font-size: 0.76rem; color: var(--muted);
+  }
+  .timeline-controls select {
+    padding: 6px 10px; border: 1px solid var(--border); border-radius: 8px;
+    background: #fff; color: var(--text); font-size: 0.8rem; max-width: 240px;
+  }
+  .timeline-controls input[type="range"] { width: 120px; }
+  #timeline-days-out { font-variant-numeric: tabular-nums; color: var(--text); min-width: 26px; }
+  .tl-cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
+  .tl-card { background: rgba(0,0,0,0.025); border-radius: 10px; padding: 10px 12px; }
+  .tl-card-label { font-size: 0.73rem; color: var(--muted); margin-bottom: 4px; }
+  .tl-card-value { font-size: 1.35rem; font-weight: 600; color: var(--text); }
+  .tl-legend { display: flex; gap: 16px; font-size: 0.73rem; color: var(--muted); margin-bottom: 10px; }
+  .tl-legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .sw { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+  .sw-cache { background: rgba(0,0,0,0.18); }
+  .sw-input { background: var(--accent); }
+  .sw-output { background: var(--ok-text); }
+  .tl-chart {
+    display: flex; align-items: flex-end; gap: 6px;
+    height: 132px; border-bottom: 1px solid var(--border);
+  }
+  .tl-bar {
+    flex: 1; min-width: 0; display: flex; flex-direction: column; justify-content: flex-end;
+    border-radius: 3px 3px 0 0; overflow: hidden;
+  }
+  .tl-seg { display: block; width: 100%; }
+  .tl-seg.tl-output { background: var(--ok-text); }
+  .tl-seg.tl-input { background: var(--accent); }
+  .tl-seg.tl-cache { background: rgba(0,0,0,0.18); }
+  .tl-empty { display: block; width: 100%; height: 3px; background: var(--border); }
+  .tl-axis { display: flex; justify-content: space-between; margin-top: 6px; font-size: 0.7rem; color: var(--subtle); }
 
   .status-pill {
     display: inline-flex; padding: 2px 9px; border-radius: 999px;

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -1634,21 +1634,12 @@ function renderAdminPage(token: AdminToken): string {
         <header class="sect-head">
           <div>
             <p class="eyebrow">Token Usage</p>
-            <h2 class="card-title">Top 20 sessions</h2>
           </div>
-          <button class="refresh-btn" onclick="loadSessionUsage()">↻</button>
+          <button class="refresh-btn" onclick="loadTokenUsage()">↻</button>
         </header>
+        <h2 class="card-subtitle" style="margin-bottom:10px">Top 20 sessions</h3>
         <div id="session-usage-content"><div class="loading-msg">Loading…</div></div>
-      </section>
-
-      <section class="card sect">
-        <header class="sect-head">
-          <div>
-            <p class="eyebrow">Token Usage</p>
-            <h2 class="card-title">Usage timeline</h2>
-          </div>
-          <button class="refresh-btn" onclick="loadUsageTimeline()">↻</button>
-        </header>
+        <h2 class="card-subtitle" style="margin:24px 0 10px">Usage timeline</h3>
         <div class="timeline-controls">
           <label>Conversation
             <select id="timeline-conv" onchange="loadUsageTimeline()"></select>
@@ -2186,8 +2177,7 @@ function renderAdminPage(token: AdminToken): string {
       if (globalLoaded) return;
       globalLoaded = true;
       loadAllConversations();
-      loadSessionUsage();
-      loadUsageTimeline();
+      loadTokenUsage();
       loadGlobalSettings();
       loadGlobalSkills();
       loadEvents();
@@ -2250,17 +2240,29 @@ function renderAdminPage(token: AdminToken): string {
     async function ensureTimelineConvOptions() {
       if (timelineConvLoaded) return;
       const sel = document.getElementById('timeline-conv');
+      const prev = sel.value;
       const data = await apiGet('/admin/api/conversations');
       if (!data.conversations.length) {
         sel.innerHTML = '<option value="">No conversations</option>';
+        timelineConvLoaded = true;
         return;
       }
+      const want = prev || defaultConversationId;
       sel.innerHTML = data.conversations.map((c) =>
         '<option value="' + escAttr(c.conversationId) + '"' +
-        (c.conversationId === defaultConversationId ? ' selected' : '') + '>' +
+        (c.conversationId === want ? ' selected' : '') + '>' +
         escHtml(c.label || c.conversationId) + '</option>'
       ).join('');
       timelineConvLoaded = true;
+    }
+
+    // Shared refresh for the merged Token Usage section: reloads the session
+    // ranking and re-fetches the conversation list (so new sessions appear),
+    // preserving the currently selected conversation.
+    async function loadTokenUsage() {
+      loadSessionUsage();
+      timelineConvLoaded = false;
+      await loadUsageTimeline();
     }
 
     async function loadUsageTimeline() {

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -2308,7 +2308,8 @@ function renderAdminPage(token: AdminToken): string {
       const max = Math.max(1, ...buckets.map((b) => b.total));
       const px = (v) => Math.round((v / max) * 180);
       const legend = '<div class="tl-legend">' +
-        '<span><i class="sw sw-cache"></i>Cache read</span>' +
+        '<span><i class="sw sw-cache-read"></i>Cache read</span>' +
+        '<span><i class="sw sw-cache-write"></i>Cache write</span>' +
         '<span><i class="sw sw-input"></i>Input</span>' +
         '<span><i class="sw sw-output"></i>Output</span>' +
       '</div>';
@@ -2318,7 +2319,8 @@ function renderAdminPage(token: AdminToken): string {
         const inner = b.total > 0
           ? '<span class="tl-seg tl-output" style="height:' + px(b.output) + 'px"></span>' +
             '<span class="tl-seg tl-input" style="height:' + px(b.input) + 'px"></span>' +
-            '<span class="tl-seg tl-cache" style="height:' + px(b.cacheRead + b.cacheWrite) + 'px"></span>'
+            '<span class="tl-seg tl-cache-write" style="height:' + px(b.cacheWrite) + 'px"></span>' +
+            '<span class="tl-seg tl-cache-read" style="height:' + px(b.cacheRead) + 'px"></span>'
           : '<span class="tl-empty"></span>';
         return '<div class="tl-bar">' +
           '<span class="tl-tip">' + escHtml(tip) + '</span>' +
@@ -2731,7 +2733,8 @@ const adminViewStyles = `
   .tl-legend { display: flex; gap: 16px; font-size: 0.73rem; color: var(--muted); margin-bottom: 10px; }
   .tl-legend span { display: inline-flex; align-items: center; gap: 6px; }
   .sw { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
-  .sw-cache { background: rgba(0,0,0,0.18); }
+  .sw-cache-read { background: rgba(0,0,0,0.18); }
+  .sw-cache-write { background: #3b6fb0; }
   .sw-input { background: var(--accent); }
   .sw-output { background: var(--ok-text); }
   .tl-chart {
@@ -2768,7 +2771,8 @@ const adminViewStyles = `
   .tl-seg { display: block; width: 100%; }
   .tl-seg.tl-output { background: var(--ok-text); }
   .tl-seg.tl-input { background: var(--accent); }
-  .tl-seg.tl-cache { background: rgba(0,0,0,0.18); }
+  .tl-seg.tl-cache-write { background: #3b6fb0; }
+  .tl-seg.tl-cache-read { background: rgba(0,0,0,0.18); }
   .tl-empty { display: block; width: 100%; height: 3px; background: var(--border); }
   .tl-axis { display: flex; justify-content: space-between; margin-top: 6px; font-size: 0.7rem; color: var(--subtle); }
 

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -2237,6 +2237,8 @@ function renderAdminPage(token: AdminToken): string {
     }
 
     let timelineConvLoaded = false;
+    let timelineData = null;
+    let timelineFilter = null;
     async function ensureTimelineConvOptions() {
       if (timelineConvLoaded) return;
       const sel = document.getElementById('timeline-conv');
@@ -2277,6 +2279,7 @@ function renderAdminPage(token: AdminToken): string {
         container.innerHTML = '<div class="loading-msg">Loading…</div>';
         const data = await apiGet('/admin/api/conversation-usage?conversationId=' +
           encodeURIComponent(conv));
+        timelineData = data;
         container.innerHTML = renderUsageTimeline(data);
       } catch (err) {
         container.innerHTML = '<div class="err-msg">' + escHtml(err.message) + '</div>';
@@ -2286,6 +2289,21 @@ function renderAdminPage(token: AdminToken): string {
     function tlCard(label, value) {
       return '<div class="tl-card"><div class="tl-card-label">' + label +
         '</div><div class="tl-card-value">' + value + '</div></div>';
+    }
+
+    const TL_SERIES = [
+      { key: 'cacheRead', seg: 'tl-cache-read', sw: 'sw-cache-read', label: 'Cache read' },
+      { key: 'cacheWrite', seg: 'tl-cache-write', sw: 'sw-cache-write', label: 'Cache write' },
+      { key: 'input', seg: 'tl-input', sw: 'sw-input', label: 'Input' },
+      { key: 'output', seg: 'tl-output', sw: 'sw-output', label: 'Output' },
+    ];
+
+    // Click a legend item to show only that series; click it again for all.
+    function toggleTimelineFilter(key) {
+      timelineFilter = timelineFilter === key ? null : key;
+      if (timelineData) {
+        document.getElementById('usage-timeline-content').innerHTML = renderUsageTimeline(timelineData);
+      }
     }
 
     function renderUsageTimeline(data) {
@@ -2305,28 +2323,41 @@ function renderAdminPage(token: AdminToken): string {
         return cards + emptyNote;
       }
 
-      const max = Math.max(1, ...buckets.map((b) => b.total));
+      const active = TL_SERIES.find((s) => s.key === timelineFilter) || null;
+      const valueOf = (b) => active ? (b[active.key] || 0) : b.total;
+      const max = Math.max(1, ...buckets.map(valueOf));
       const px = (v) => Math.round((v / max) * 180);
-      const legend = '<div class="tl-legend">' +
-        '<span><i class="sw sw-cache-read"></i>Cache read</span>' +
-        '<span><i class="sw sw-cache-write"></i>Cache write</span>' +
-        '<span><i class="sw sw-input"></i>Input</span>' +
-        '<span><i class="sw sw-output"></i>Output</span>' +
-      '</div>';
+
+      const legend = '<div class="tl-legend">' + TL_SERIES.map((s) => {
+        const cls = 'tl-legend-item' +
+          (active && active.key === s.key ? ' active' : (active ? ' dim' : ''));
+        return '<span class="' + cls + '" onclick="toggleTimelineFilter(\\'' + s.key + '\\')">' +
+          '<i class="sw ' + s.sw + '"></i>' + s.label + '</span>';
+      }).join('') + '</div>';
+
       const bars = buckets.map((b) => {
-        const tip = b.date + ' · ' + fmtNum(b.total) + ' tokens' +
-          (b.cost > 0 ? ' · $' + Number(b.cost).toFixed(4) : '');
-        const inner = b.total > 0
-          ? '<span class="tl-seg tl-output" style="height:' + px(b.output) + 'px"></span>' +
+        const val = valueOf(b);
+        const tip = active
+          ? b.date + ' · ' + active.label + ': ' + fmtNum(b[active.key] || 0) + ' tokens'
+          : b.date + ' · ' + fmtNum(b.total) + ' tokens' +
+            (b.cost > 0 ? ' · $' + Number(b.cost).toFixed(4) : '');
+        let inner;
+        if (val <= 0) {
+          inner = '<span class="tl-empty"></span>';
+        } else if (active) {
+          inner = '<span class="tl-seg ' + active.seg + '" style="height:' + px(val) + 'px"></span>';
+        } else {
+          inner = '<span class="tl-seg tl-output" style="height:' + px(b.output) + 'px"></span>' +
             '<span class="tl-seg tl-input" style="height:' + px(b.input) + 'px"></span>' +
             '<span class="tl-seg tl-cache-write" style="height:' + px(b.cacheWrite) + 'px"></span>' +
-            '<span class="tl-seg tl-cache-read" style="height:' + px(b.cacheRead) + 'px"></span>'
-          : '<span class="tl-empty"></span>';
+            '<span class="tl-seg tl-cache-read" style="height:' + px(b.cacheRead) + 'px"></span>';
+        }
         return '<div class="tl-bar">' +
           '<span class="tl-tip">' + escHtml(tip) + '</span>' +
           '<div class="tl-fill">' + inner + '</div>' +
         '</div>';
       }).join('');
+
       const axis = buckets.length
         ? '<div class="tl-axis"><span>' + escHtml(buckets[0].date.slice(5)) +
           '</span><span>' + escHtml(buckets[buckets.length - 1].date.slice(5)) + '</span></div>'
@@ -2732,6 +2763,10 @@ const adminViewStyles = `
   .tl-card-value { font-size: 1.35rem; font-weight: 600; color: var(--text); }
   .tl-legend { display: flex; gap: 16px; font-size: 0.73rem; color: var(--muted); margin-bottom: 10px; }
   .tl-legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .tl-legend-item { cursor: pointer; transition: opacity 100ms; }
+  .tl-legend-item:hover { text-decoration: underline; }
+  .tl-legend-item.active { color: var(--text); font-weight: 600; text-decoration: underline; }
+  .tl-legend-item.dim { opacity: 0.4; }
   .sw { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
   .sw-cache-read { background: rgba(0,0,0,0.18); }
   .sw-cache-write { background: #3b6fb0; }

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -459,8 +459,7 @@ function serveConversationUsage(res: ServerResponse, url: URL, services: AdminSe
     return;
   }
 
-  const daysRaw = parseInt(url.searchParams.get("days") ?? "7", 10);
-  const days = Number.isFinite(daysRaw) ? Math.min(7, Math.max(1, daysRaw)) : 7;
+  const days = 14;
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -476,11 +475,12 @@ function serveConversationUsage(res: ServerResponse, url: URL, services: AdminSe
   const cutoff = new Date(today);
   cutoff.setDate(today.getDate() - (days - 1));
 
+  const flags = { hasOlder: false };
   const sessionDir = join(workingDir, conversationId, "sessions");
   try {
     for (const entry of readdirSync(sessionDir, { withFileTypes: true })) {
       if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
-      accumulateSessionUsageByDay(join(sessionDir, entry.name), cutoff, buckets);
+      accumulateSessionUsageByDay(join(sessionDir, entry.name), cutoff, buckets, flags);
     }
   } catch {
     // No sessions directory yet — return empty buckets.
@@ -501,6 +501,7 @@ function serveConversationUsage(res: ServerResponse, url: URL, services: AdminSe
     conversationId,
     label: conversationDisplayLabel(services, conversationId),
     days,
+    hasOlder: flags.hasOlder,
     buckets: series,
     totals: {
       input: totals.input,
@@ -517,6 +518,7 @@ function accumulateSessionUsageByDay(
   sessionFile: string,
   cutoff: Date,
   buckets: Map<string, UsageBucket>,
+  flags: { hasOlder: boolean },
 ): void {
   try {
     const manager = SessionManager.open(sessionFile);
@@ -528,7 +530,11 @@ function accumulateSessionUsageByDay(
       if (!usage || !entry.timestamp) continue;
 
       const when = new Date(entry.timestamp);
-      if (Number.isNaN(when.getTime()) || when < cutoff) continue;
+      if (Number.isNaN(when.getTime())) continue;
+      if (when < cutoff) {
+        flags.hasOlder = true;
+        continue;
+      }
 
       const bucket = buckets.get(localDayKey(when));
       if (!bucket) continue;
@@ -1647,10 +1653,6 @@ function renderAdminPage(token: AdminToken): string {
           <label>Conversation
             <select id="timeline-conv" onchange="loadUsageTimeline()"></select>
           </label>
-          <label>Range
-            <input type="range" id="timeline-days" min="1" max="7" value="7" step="1" oninput="onTimelineDaysInput()">
-            <span id="timeline-days-out">7 d</span>
-          </label>
         </div>
         <div id="usage-timeline-content"><div class="loading-msg">Loading…</div></div>
       </section>
@@ -2261,12 +2263,6 @@ function renderAdminPage(token: AdminToken): string {
       timelineConvLoaded = true;
     }
 
-    function onTimelineDaysInput() {
-      const days = document.getElementById('timeline-days').value;
-      document.getElementById('timeline-days-out').textContent = days + ' d';
-      loadUsageTimeline();
-    }
-
     async function loadUsageTimeline() {
       const container = document.getElementById('usage-timeline-content');
       try {
@@ -2276,10 +2272,9 @@ function renderAdminPage(token: AdminToken): string {
           container.innerHTML = '<div class="empty-state">No conversations found</div>';
           return;
         }
-        const days = document.getElementById('timeline-days').value || '7';
         container.innerHTML = '<div class="loading-msg">Loading…</div>';
         const data = await apiGet('/admin/api/conversation-usage?conversationId=' +
-          encodeURIComponent(conv) + '&days=' + encodeURIComponent(days));
+          encodeURIComponent(conv));
         container.innerHTML = renderUsageTimeline(data);
       } catch (err) {
         container.innerHTML = '<div class="err-msg">' + escHtml(err.message) + '</div>';
@@ -2302,7 +2297,10 @@ function renderAdminPage(token: AdminToken): string {
       '</div>';
 
       if (totals.total === 0) {
-        return cards + '<div class="empty-state">No token usage in this range</div>';
+        const emptyNote = data.hasOlder
+          ? '<div class="tl-note">No usage in the last 14 days · earlier activity exists</div>'
+          : '<div class="empty-state">No token usage in the last 14 days</div>';
+        return cards + emptyNote;
       }
 
       const max = Math.max(1, ...buckets.map((b) => b.total));
@@ -2326,7 +2324,10 @@ function renderAdminPage(token: AdminToken): string {
         ? '<div class="tl-axis"><span>' + escHtml(buckets[0].date.slice(5)) +
           '</span><span>' + escHtml(buckets[buckets.length - 1].date.slice(5)) + '</span></div>'
         : '';
-      return cards + legend + '<div class="tl-chart">' + bars + '</div>' + axis;
+      const note = data.hasOlder
+        ? '<div class="tl-note">Showing last 14 days · earlier activity not shown</div>'
+        : '<div class="tl-note">Showing last 14 days</div>';
+      return cards + legend + '<div class="tl-chart">' + bars + '</div>' + axis + note;
     }
 
     async function loadGlobalSettings() {
@@ -2715,8 +2716,7 @@ const adminViewStyles = `
     padding: 6px 10px; border: 1px solid var(--border); border-radius: 8px;
     background: #fff; color: var(--text); font-size: 0.8rem; max-width: 240px;
   }
-  .timeline-controls input[type="range"] { width: 120px; }
-  #timeline-days-out { font-variant-numeric: tabular-nums; color: var(--text); min-width: 26px; }
+  .tl-note { margin-top: 8px; font-size: 0.72rem; color: var(--subtle); }
   .tl-cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
   .tl-card { background: rgba(0,0,0,0.025); border-radius: 10px; padding: 10px 12px; }
   .tl-card-label { font-size: 0.73rem; color: var(--muted); margin-bottom: 4px; }

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -2304,21 +2304,24 @@ function renderAdminPage(token: AdminToken): string {
       }
 
       const max = Math.max(1, ...buckets.map((b) => b.total));
-      const px = (v) => Math.round((v / max) * 120);
+      const px = (v) => Math.round((v / max) * 180);
       const legend = '<div class="tl-legend">' +
         '<span><i class="sw sw-cache"></i>Cache read</span>' +
         '<span><i class="sw sw-input"></i>Input</span>' +
         '<span><i class="sw sw-output"></i>Output</span>' +
       '</div>';
       const bars = buckets.map((b) => {
-        const title = b.date + ' · ' + fmtNum(b.total) + ' tok' +
+        const tip = b.date + ' · ' + fmtNum(b.total) + ' tokens' +
           (b.cost > 0 ? ' · $' + Number(b.cost).toFixed(4) : '');
         const inner = b.total > 0
           ? '<span class="tl-seg tl-output" style="height:' + px(b.output) + 'px"></span>' +
             '<span class="tl-seg tl-input" style="height:' + px(b.input) + 'px"></span>' +
             '<span class="tl-seg tl-cache" style="height:' + px(b.cacheRead + b.cacheWrite) + 'px"></span>'
           : '<span class="tl-empty"></span>';
-        return '<div class="tl-bar" title="' + escAttr(title) + '">' + inner + '</div>';
+        return '<div class="tl-bar">' +
+          '<span class="tl-tip">' + escHtml(tip) + '</span>' +
+          '<div class="tl-fill">' + inner + '</div>' +
+        '</div>';
       }).join('');
       const axis = buckets.length
         ? '<div class="tl-axis"><span>' + escHtml(buckets[0].date.slice(5)) +
@@ -2327,7 +2330,7 @@ function renderAdminPage(token: AdminToken): string {
       const note = data.hasOlder
         ? '<div class="tl-note">Showing last 14 days · earlier activity not shown</div>'
         : '<div class="tl-note">Showing last 14 days</div>';
-      const peak = '<div class="tl-peak" style="bottom:120px"><span class="tl-peak-label">' +
+      const peak = '<div class="tl-peak" style="bottom:180px"><span class="tl-peak-label">' +
         fmtNum(max) + ' tokens</span></div>';
       return cards + legend + '<div class="tl-chart">' + peak + bars + '</div>' + axis + note;
     }
@@ -2732,7 +2735,7 @@ const adminViewStyles = `
   .tl-chart {
     position: relative;
     display: flex; align-items: flex-end; gap: 6px;
-    height: 144px; border-bottom: 1px solid var(--border);
+    height: 216px; border-bottom: 1px solid var(--border);
   }
   .tl-peak {
     position: absolute; left: 0; right: 0; height: 0;
@@ -2743,9 +2746,23 @@ const adminViewStyles = `
     font-size: 0.7rem; color: var(--accent); white-space: nowrap;
   }
   .tl-bar {
-    flex: 1; min-width: 0; display: flex; flex-direction: column; justify-content: flex-end;
+    position: relative; flex: 1; min-width: 0; height: 180px;
+    display: flex; flex-direction: column; justify-content: flex-end;
+    border-radius: 6px 6px 0 0; transition: background 80ms ease;
+  }
+  .tl-bar:hover { background: rgba(0,0,0,0.06); }
+  .tl-bar:hover .tl-seg { opacity: 0.55; }
+  .tl-fill {
+    display: flex; flex-direction: column; justify-content: flex-end;
     border-radius: 3px 3px 0 0; overflow: hidden;
   }
+  .tl-tip {
+    position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%);
+    margin-bottom: 6px; padding: 5px 9px; border-radius: 6px;
+    background: var(--text); color: #fafafa; font-size: 0.7rem; line-height: 1.35;
+    white-space: nowrap; opacity: 0; pointer-events: none; z-index: 5;
+  }
+  .tl-bar:hover .tl-tip { opacity: 1; }
   .tl-seg { display: block; width: 100%; }
   .tl-seg.tl-output { background: var(--ok-text); }
   .tl-seg.tl-input { background: var(--accent); }

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -2327,7 +2327,9 @@ function renderAdminPage(token: AdminToken): string {
       const note = data.hasOlder
         ? '<div class="tl-note">Showing last 14 days · earlier activity not shown</div>'
         : '<div class="tl-note">Showing last 14 days</div>';
-      return cards + legend + '<div class="tl-chart">' + bars + '</div>' + axis + note;
+      const peak = '<div class="tl-peak" style="bottom:120px"><span class="tl-peak-label">' +
+        fmtNum(max) + ' tokens</span></div>';
+      return cards + legend + '<div class="tl-chart">' + peak + bars + '</div>' + axis + note;
     }
 
     async function loadGlobalSettings() {
@@ -2728,8 +2730,17 @@ const adminViewStyles = `
   .sw-input { background: var(--accent); }
   .sw-output { background: var(--ok-text); }
   .tl-chart {
+    position: relative;
     display: flex; align-items: flex-end; gap: 6px;
-    height: 132px; border-bottom: 1px solid var(--border);
+    height: 144px; border-bottom: 1px solid var(--border);
+  }
+  .tl-peak {
+    position: absolute; left: 0; right: 0; height: 0;
+    border-top: 1px dashed var(--accent); pointer-events: none;
+  }
+  .tl-peak-label {
+    position: absolute; left: 0; top: -15px;
+    font-size: 0.7rem; color: var(--accent); white-space: nowrap;
   }
   .tl-bar {
     flex: 1; min-width: 0; display: flex; flex-direction: column; justify-content: flex-end;


### PR DESCRIPTION
<!-- Thanks for the PR! Keep this template short — delete sections that don't apply. -->

## Summary

<!-- What changed and why. One or two sentences. -->

https://github.com/user-attachments/assets/2e2dc053-7207-4340-869c-f54667666bde

在 token usage 下面新增長條圖，顯示特定 session 近 14 天以來 token 的使用情況
點擊左上角圖例可以篩選特定 token (input, output, cached input, cached output) 的數據

## Related issue

<!-- e.g. Closes #123. Omit if not applicable. -->

#79

## How I tested

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [ ] Manual verification (describe below)

<!-- Notes on manual testing — which platform, which sandbox mode, edge cases hit. -->

## Notes for reviewers

<!-- Anything non-obvious: design tradeoffs, follow-ups punted, areas you want a closer look at. -->
