### PR TITLE
feat(harness): replace pi-coding-agent with mikan's own AgentHarness-based harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 Project: **mikan** (`@geminixiang/mikan`)
 
-mikan is a multi-platform AI coding agent for Slack, Telegram, and Discord. It stores chat logs and session state, runs the `pi-coding-agent` harness, and executes tools in host, Docker, Firecracker, or Cloudflare sandbox modes.
+mikan is a multi-platform AI coding agent for Slack, Telegram, and Discord. It stores chat logs and session state, runs its own harness (`src/harness/*`, built on `@earendil-works/pi-agent-core`'s `AgentHarness`), and executes tools in host, Docker, Firecracker, or Cloudflare sandbox modes.
 
 Stack:
 
@@ -23,7 +23,8 @@ Stack:
   - `main.ts`: CLI entrypoint; parses args, loads settings, starts vault/sandbox/runtime/platform bots.
   - `types.ts`: root exported type definitions.
   - `adapter.ts`: platform-neutral bot/message/response interfaces.
-  - `agent.ts`: pi-coding-agent runner integration, prompt, tools, memory, sandbox, vault, response flow.
+  - `agent.ts`: harness (`AgentHarness`) runner integration, prompt, tools, memory, sandbox, vault, response flow.
+  - `harness/`: mikan's own agent harness — session storage, model/auth resolution, skills, execution env, and the extension system, all built on `@earendil-works/pi-agent-core` and `@earendil-works/pi-ai`.
   - `config.ts`: global and per-conversation settings.
   - `runtime/`: conversation/session orchestration.
   - `sessions/`: chat-history sync and persisted session files.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ mikan keeps the chat record, agent session, and execution runtime separate:
 ![mikan architecture](src/content/docs/assets/architecture.png)
 
 - **Chat / conversation data** is the platform-facing record: `log.jsonl`, attachments, and conversation files.
-- **Session orchestration** turns platform events into agent runs, handles top-level/thread scopes, and persists pi-coding-agent structured context under `sessions/*.jsonl`.
-- **pi-coding-agent harness** runs the model loop and calls mikan tools.
+- **Session orchestration** turns platform events into agent runs, handles top-level/thread scopes, and persists structured context under `sessions/*.jsonl`.
+- **mikan harness** (`src/harness/*`, built on `@earendil-works/pi-agent-core`'s `AgentHarness`) runs the model loop and calls mikan tools.
 - **Sandbox runtime** is where tool commands execute: host, Docker container/image, Firecracker, or Cloudflare bridge.
 - **Vault** provides runtime credentials as env vars and mounted secret files.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.80.2",
         "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-coding-agent": "^0.80.2",
         "@sentry/node": "^10.60.0",
         "@sinclair/typebox": "^0.34.49",
         "@slack/socket-mode": "^2.0.7",
@@ -182,9 +181,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -202,9 +198,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -222,9 +215,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -242,9 +232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,9 +973,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1002,9 +986,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1018,9 +999,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1034,9 +1012,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1300,1839 +1275,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.2.tgz",
-      "integrity": "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A==",
-      "hasShrinkwrap": true,
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.2",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
-        "@silvia-odwyer/photon-node": "0.3.4",
-        "chalk": "5.6.2",
-        "cross-spawn": "7.0.6",
-        "diff": "8.0.4",
-        "glob": "13.0.6",
-        "highlight.js": "10.7.3",
-        "hosted-git-info": "9.0.3",
-        "ignore": "7.0.5",
-        "jiti": "2.7.0",
-        "minimatch": "10.2.5",
-        "proper-lockfile": "4.1.2",
-        "semver": "7.8.0",
-        "typebox": "1.1.38",
-        "undici": "8.5.0",
-        "yaml": "2.9.0"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "0.3.9"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-node": "^3.972.42",
-        "@aws-sdk/eventstream-handler-node": "^3.972.16",
-        "@aws-sdk/middleware-eventstream": "^3.972.12",
-        "@aws-sdk/middleware-websocket": "^3.972.19",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
-      "version": "3.974.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
-      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
-      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
-      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
-      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-login": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
-      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
-      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-ini": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
-      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
-      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
-      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
-      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
-      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.2",
-        "ignore": "7.0.5",
-        "typebox": "1.1.38",
-        "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
-        "@smithy/node-http-handler": "4.7.3",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "./dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "1.6.0",
-        "marked": "18.0.5"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
-      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
-        "@mariozechner/clipboard-darwin-universal": "0.3.9",
-        "@mariozechner/clipboard-darwin-x64": "0.3.9",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
-      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
-      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
-      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
-      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
-      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
-      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
-      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
-      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
-      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
-      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
-      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3797,9 +1939,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3817,9 +1956,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3837,9 +1973,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3857,9 +1990,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3877,9 +2007,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3897,9 +2024,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3917,9 +2041,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3937,9 +2058,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3957,9 +2075,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3983,9 +2098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4009,9 +2121,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4035,9 +2144,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4061,9 +2167,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4087,9 +2190,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4113,9 +2213,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4139,9 +2236,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4596,9 +2690,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4616,9 +2707,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4636,9 +2724,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4656,9 +2741,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4676,9 +2758,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4696,9 +2775,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4716,9 +2792,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4736,9 +2809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4951,9 +3021,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4968,9 +3035,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4985,9 +3049,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5002,9 +3063,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5019,9 +3077,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5036,9 +3091,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5053,9 +3105,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5070,9 +3119,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5290,9 +3336,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5310,9 +3353,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5330,9 +3370,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5350,9 +3387,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5370,9 +3404,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5390,9 +3421,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5410,9 +3438,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5430,9 +3455,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5637,9 +3659,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5657,9 +3676,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5677,9 +3693,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5697,9 +3710,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5717,9 +3727,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5737,9 +3744,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5757,9 +3761,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5777,9 +3778,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6090,9 +4088,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6110,9 +4105,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6130,9 +4122,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6150,9 +4139,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6170,9 +4156,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6190,9 +4173,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9898,9 +7878,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9922,9 +7899,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9946,9 +7920,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9970,9 +7941,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "@earendil-works/pi-agent-core": "^0.80.2",
     "@earendil-works/pi-ai": "^0.80.2",
-    "@earendil-works/pi-coding-agent": "^0.80.2",
     "@sentry/node": "^10.60.0",
     "@sinclair/typebox": "^0.34.49",
     "@slack/socket-mode": "^2.0.7",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,21 +1,21 @@
-import { Agent, type ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { type Api, type ImageContent, type Model } from "@earendil-works/pi-ai";
 import {
-  AgentSession,
-  AuthStorage,
-  convertToLlm,
-  DefaultResourceLoader,
-  formatSkillsForPrompt,
-  getAgentDir,
-  loadSkillsFromDir,
-  ModelRegistry,
-  SessionManager,
-  SettingsManager,
+  AgentHarness,
+  DEFAULT_COMPACTION_SETTINGS,
+  formatSkillsForSystemPrompt,
+  shouldCompact,
+  type Session,
   type Skill,
-} from "@earendil-works/pi-coding-agent";
+  type ThinkingLevel,
+} from "@earendil-works/pi-agent-core";
+import {
+  type Api,
+  type AssistantMessage,
+  type ImageContent,
+  type Model,
+  type Models,
+} from "@earendil-works/pi-ai";
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
-import { homedir } from "os";
 import { join, posix } from "path";
 import type {
   ConversationMessage,
@@ -28,6 +28,10 @@ import type { AgentEventPayload } from "./types.js";
 import type { SessionViewTokenStoreLike } from "./commands/types.js";
 import { resolveConversationSettings } from "./config.js";
 import { ActorExecutionResolver } from "./execution-resolver.js";
+import { createMikanExecutionEnv } from "./harness/env.js";
+import { getMikanExtensionContributions } from "./harness/extensions.js";
+import { createMikanModels } from "./harness/models.js";
+import { loadMikanSkills } from "./harness/skills.js";
 import * as log from "./log.js";
 import { reportUserFacingError } from "./observability/sentry.js";
 import type { DockerContainerManager } from "./provisioner.js";
@@ -113,42 +117,6 @@ async function getMemory(conversationDir: string): Promise<string> {
   }
 
   return parts.join("\n\n");
-}
-
-function loadMikanSkills(conversationDir: string, workspacePath: string): Skill[] {
-  const skillMap = new Map<string, Skill>();
-
-  // conversationDir is the host path (e.g., /Users/.../data/C0A34FL8PMH)
-  // hostWorkspacePath is the parent directory on host
-  // workspacePath is the container path (e.g., /workspace)
-  const hostWorkspacePath = join(conversationDir, "..");
-
-  // Helper to translate host paths to container paths
-  const translatePath = (hostPath: string): string => {
-    if (hostPath.startsWith(hostWorkspacePath)) {
-      return workspacePath + hostPath.slice(hostWorkspacePath.length);
-    }
-    return hostPath;
-  };
-
-  // Load workspace-level skills (global)
-  const workspaceSkillsDir = join(hostWorkspacePath, "skills");
-  for (const skill of loadSkillsFromDir({ dir: workspaceSkillsDir, source: "workspace" }).skills) {
-    // Translate paths to container paths for system prompt
-    skill.filePath = translatePath(skill.filePath);
-    skill.baseDir = translatePath(skill.baseDir);
-    skillMap.set(skill.name, skill);
-  }
-
-  // Load conversation-specific skills (override workspace skills on collision)
-  const conversationSkillsDir = join(conversationDir, "skills");
-  for (const skill of loadSkillsFromDir({ dir: conversationSkillsDir, source: "channel" }).skills) {
-    skill.filePath = translatePath(skill.filePath);
-    skill.baseDir = translatePath(skill.baseDir);
-    skillMap.set(skill.name, skill);
-  }
-
-  return Array.from(skillMap.values());
 }
 
 function buildRuntimePaths(runtimeWorkspaceRoot: string, conversationId: string) {
@@ -330,7 +298,7 @@ Scripts are in: {baseDir}/
 \`name\` and \`description\` are required. Use \`{baseDir}\` as placeholder for the skill's directory path.
 
 ### Available Skills
-${skills.length > 0 ? formatSkillsForPrompt(skills) : "(no skills installed yet)"}
+${skills.length > 0 ? formatSkillsForSystemPrompt(skills) : "(no skills installed yet)"}
 
 ## Events
 Use the \`event\` tool to schedule immediate, one-shot, or periodic follow-ups. It writes to the host-side mikan control plane and fills routing fields for the current conversation automatically.
@@ -443,6 +411,10 @@ interface RunnerSessionState {
   reportedLlmError: boolean;
   finalResponseHandledByTool: boolean;
   triggerAttribution?: string;
+  /** Last assistant message seen this run (any stop reason), for final-response extraction. */
+  lastAssistantMessage: AssistantMessage | undefined;
+  /** Last non-aborted assistant message this run, for context-window/compaction accounting. */
+  lastNonAbortedAssistantMessage: AssistantMessage | undefined;
 }
 
 interface PreparedRunContext {
@@ -451,11 +423,6 @@ interface PreparedRunContext {
   userMessage: string;
   imageAttachments: ImageContent[];
   triggerAttribution?: string;
-}
-
-interface ConfiguredAgentSession {
-  agent: Agent;
-  session: AgentSession;
 }
 
 function createRunnerExecutionContext(
@@ -502,88 +469,27 @@ function createRunnerExecutionContext(
   };
 }
 
-async function createConfiguredAgentSession(params: {
-  conversationId: string;
-  workspaceDir: string;
-  runtimeWorkspaceRoot: string;
-  systemPrompt: string;
+async function createConfiguredAgentHarness(params: {
+  env: ReturnType<typeof createMikanExecutionEnv>;
+  session: Session;
+  models: Models;
+  systemPromptState: { current: string };
   model: Model<Api>;
   thinkingLevel: ThinkingLevel;
   tools: Awaited<ReturnType<typeof createMikanTools>>["tools"];
-  sessionManager: SessionManager;
-  settingsManager: SettingsManager;
-  modelRegistry: ModelRegistry;
-}): Promise<ConfiguredAgentSession> {
-  const {
-    conversationId,
-    workspaceDir,
-    runtimeWorkspaceRoot,
-    systemPrompt,
+  skills: Skill[];
+}): Promise<AgentHarness> {
+  const { env, session, models, systemPromptState, model, thinkingLevel, tools, skills } = params;
+  return new AgentHarness({
+    env,
+    session,
+    models,
+    tools,
+    resources: { skills },
+    systemPrompt: () => systemPromptState.current,
     model,
     thinkingLevel,
-    tools,
-    sessionManager,
-    settingsManager,
-    modelRegistry,
-  } = params;
-  const agent = new Agent({
-    initialState: {
-      systemPrompt,
-      model,
-      thinkingLevel,
-      tools,
-    },
-    convertToLlm,
-    getApiKey: async (provider) => {
-      const key = await modelRegistry.getApiKeyForProvider(provider);
-      if (!key) {
-        throw new Error(
-          `No API key for provider "${provider}". Set the appropriate environment variable or configure via auth.json`,
-        );
-      }
-      return key;
-    },
   });
-
-  const loadedSession = sessionManager.buildSessionContext();
-  if (loadedSession.messages.length > 0) {
-    agent.state.messages = loadedSession.messages;
-    log.logInfo(
-      `[${conversationId}] Reloaded ${loadedSession.messages.length} messages from session context`,
-    );
-  }
-
-  const resourceLoader = new DefaultResourceLoader({
-    cwd: workspaceDir,
-    agentDir: getAgentDir(),
-    systemPrompt,
-  });
-  try {
-    await resourceLoader.reload();
-    const extResult = resourceLoader.getExtensions();
-    if (extResult.errors.length > 0) {
-      for (const err of extResult.errors) {
-        log.logWarning(`[${conversationId}] Extension load error: ${err.path}`, err.error);
-      }
-    }
-    log.logInfo(
-      `[${conversationId}] Loaded ${extResult.extensions.length} extension(s): ${extResult.extensions.map((extension) => extension.path).join(", ")}`,
-    );
-  } catch (error) {
-    log.logWarning(`[${conversationId}] Failed to load resources`, String(error));
-  }
-
-  const baseToolsOverride = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
-  const session = new AgentSession({
-    agent,
-    sessionManager,
-    settingsManager,
-    cwd: runtimeWorkspaceRoot,
-    modelRegistry,
-    resourceLoader,
-    baseToolsOverride,
-  });
-  return { agent, session };
 }
 
 function createEmptyUsageTotals() {
@@ -610,6 +516,8 @@ function createRunState(): RunnerSessionState {
     reportedLlmError: false,
     finalResponseHandledByTool: false,
     triggerAttribution: undefined,
+    lastAssistantMessage: undefined,
+    lastNonAbortedAssistantMessage: undefined,
   };
 }
 
@@ -637,6 +545,8 @@ function resetRunState(
   runState.reportedLlmError = false;
   runState.finalResponseHandledByTool = false;
   runState.triggerAttribution = triggerAttribution;
+  runState.lastAssistantMessage = undefined;
+  runState.lastNonAbortedAssistantMessage = undefined;
 }
 
 function createRunQueue(
@@ -732,13 +642,14 @@ export function buildPromptPayload(
 async function writePromptDebugContext(
   conversationDir: string,
   systemPrompt: string,
-  session: AgentSession,
+  session: Session,
   userMessage: string,
   imageAttachmentCount: number,
 ): Promise<void> {
+  const context = await session.buildContext();
   const debugContext = {
     systemPrompt,
-    messages: session.messages,
+    messages: context.messages,
     newUserMessage: userMessage,
     imageAttachmentCount,
   };
@@ -748,8 +659,8 @@ async function writePromptDebugContext(
   );
 }
 
-function getFinalAssistantText(session: AgentSession): string {
-  const lastAssistant = session.messages.findLast((message) => message.role === "assistant");
+function getFinalAssistantText(runState: RunnerSessionState): string {
+  const lastAssistant = runState.lastAssistantMessage;
   return (
     lastAssistant?.content
       .filter((content): content is { type: "text"; text: string } => content.type === "text")
@@ -809,7 +720,6 @@ async function replaceResponseWithToolProgress(
 
 async function finalizeRunResponse(
   responder: ConversationResponder,
-  session: AgentSession,
   runState: RunnerSessionState,
   options?: {
     triggerAttribution?: string;
@@ -865,7 +775,7 @@ async function finalizeRunResponse(
     return;
   }
 
-  const finalText = getFinalAssistantText(session);
+  const finalText = getFinalAssistantText(runState);
   if (runState.finalResponseHandledByTool) {
     log.logInfo("Final response already handled by tool - skipping final replacement");
     return;
@@ -911,7 +821,6 @@ async function finalizeRunResponse(
 }
 
 interface UsageReportContext {
-  session: AgentSession;
   runState: RunnerSessionState;
   responder: ConversationResponder;
   platform: MessagingInfo;
@@ -922,9 +831,23 @@ interface UsageReportContext {
   waitForQueue: () => Promise<void>;
 }
 
+/** Returns the context-token count and window size, for both usage reporting and auto-compaction. */
+function computeContextUsage(
+  runState: RunnerSessionState,
+  model: Model<Api>,
+): { contextTokens: number; contextWindow: number } {
+  const lastAssistantMessage = runState.lastNonAbortedAssistantMessage;
+  const contextTokens = lastAssistantMessage
+    ? lastAssistantMessage.usage.input +
+      lastAssistantMessage.usage.output +
+      lastAssistantMessage.usage.cacheRead +
+      lastAssistantMessage.usage.cacheWrite
+    : 0;
+  return { contextTokens, contextWindow: model.contextWindow || 200000 };
+}
+
 async function reportUsageSummary(ctx: UsageReportContext): Promise<void> {
   const {
-    session,
     runState,
     responder,
     platform,
@@ -934,21 +857,7 @@ async function reportUsageSummary(ctx: UsageReportContext): Promise<void> {
     sessionUuid,
     waitForQueue,
   } = ctx;
-  const lastAssistantMessage = session.messages
-    .slice()
-    .toReversed()
-    .find(
-      (message): message is Extract<typeof message, { role: "assistant" }> =>
-        message.role === "assistant" && message.stopReason !== "aborted",
-    );
-
-  const contextTokens = lastAssistantMessage
-    ? lastAssistantMessage.usage.input +
-      lastAssistantMessage.usage.output +
-      lastAssistantMessage.usage.cacheRead +
-      lastAssistantMessage.usage.cacheWrite
-    : 0;
-  const contextWindow = model.contextWindow || 200000;
+  const { contextTokens, contextWindow } = computeContextUsage(runState, model);
 
   const { totalUsage } = runState;
   const runMetricAttributes = metricAttributes({
@@ -994,16 +903,30 @@ async function reportUsageSummary(ctx: UsageReportContext): Promise<void> {
   }
 }
 
-function reloadSessionMessages(
-  sessionManager: SessionManager,
-  conversationId: string,
-  agent: Agent,
-): void {
-  const messages = sessionManager.buildSessionContext().messages;
-  if (messages.length > 0) {
-    agent.state.messages = messages;
-    log.logInfo(`[${conversationId}] Reloaded ${messages.length} messages from context`);
+/** Compact the session when context usage crosses the default threshold, mirroring the
+ * automatic compaction pi-coding-agent's AgentSession used to perform. AgentHarness only
+ * exposes the primitive (`compact()`); mikan owns the trigger decision. */
+async function maybeAutoCompact(
+  harness: AgentHarness,
+  runState: RunnerSessionState,
+  model: Model<Api>,
+): Promise<void> {
+  const { contextTokens, contextWindow } = computeContextUsage(runState, model);
+  if (!shouldCompact(contextTokens, contextWindow, DEFAULT_COMPACTION_SETTINGS)) return;
+
+  try {
+    await harness.compact();
+  } catch (error) {
+    log.logWarning(
+      "Auto-compaction failed",
+      error instanceof Error ? error.message : String(error),
+    );
   }
+}
+
+function reloadSessionMessages(): void {
+  // AgentHarness re-reads the session's current context from storage at the
+  // start of every prompt() call, so no manual reload/reassignment is needed.
 }
 
 async function prepareRunContext(params: {
@@ -1018,9 +941,8 @@ async function prepareRunContext(params: {
   executionResolver?: ActorExecutionResolver;
   resolveExecutorForRun: RunnerExecutionContext["resolveExecutorForRun"];
   getPathContext: () => RuntimePathContext;
-  sessionManager: SessionManager;
-  session: AgentSession;
-  agent: Agent;
+  session: Session;
+  systemPromptState: { current: string };
   setEventContext: (context: {
     platform: string;
     conversationId: string;
@@ -1043,9 +965,8 @@ async function prepareRunContext(params: {
     executionResolver,
     resolveExecutorForRun,
     getPathContext,
-    sessionManager,
     session,
-    agent,
+    systemPromptState,
     setEventContext,
     setSandboxContext,
     setUploadFunction,
@@ -1064,10 +985,11 @@ async function prepareRunContext(params: {
     pathContext = getPathContext();
   }
 
-  reloadSessionMessages(sessionManager, conversationId, agent);
+  reloadSessionMessages();
 
   const memory = await getMemory(conversationDir);
-  const skills = loadMikanSkills(conversationDir, pathContext.runtimeWorkspaceRoot);
+  const env = createMikanExecutionEnv(pathContext.runtimeWorkspaceRoot);
+  const skills = await loadMikanSkills(env, conversationDir, pathContext.runtimeWorkspaceRoot);
   const triggerAttribution = resolveTriggerAttribution(message);
   const systemPrompt = buildSystemPrompt(
     pathContext.runtimeWorkspaceRoot,
@@ -1081,7 +1003,7 @@ async function prepareRunContext(params: {
     message.id.startsWith("event:"),
     triggerAttribution,
   );
-  session.agent.state.systemPrompt = systemPrompt;
+  systemPromptState.current = systemPrompt;
 
   setEventContext({
     platform: platform.name,
@@ -1149,13 +1071,13 @@ function sendAgentEvent(payload: {
 
 // ponytail: additive SSE mirror only; keep responder rendering here until another frontend needs the same stream.
 function attachSessionEventHandlers(params: {
-  session: AgentSession;
+  harness: AgentHarness;
   runState: RunnerSessionState;
   model: Model<Api>;
   agentConfig: ReturnType<typeof resolveConversationSettings>;
 }): void {
-  const { session, runState, model, agentConfig } = params;
-  session.subscribe(async (event) => {
+  const { harness, runState, model, agentConfig } = params;
+  harness.subscribe(async (event) => {
     if (!runState.responder || !runState.logCtx || !runState.queue) return;
 
     const { responder, logCtx, queue, pendingTools } = runState;
@@ -1288,6 +1210,10 @@ function attachSessionEventHandlers(params: {
     if (event.type === "message_end") {
       if (event.message.role === "assistant") {
         const assistantMsg = event.message;
+        runState.lastAssistantMessage = assistantMsg;
+        if (assistantMsg.stopReason !== "aborted") {
+          runState.lastNonAbortedAssistantMessage = assistantMsg;
+        }
 
         if (assistantMsg.stopReason) {
           runState.stopReason = assistantMsg.stopReason;
@@ -1396,9 +1322,9 @@ function attachSessionEventHandlers(params: {
       return;
     }
 
-    if (event.type === "compaction_start") {
+    if (event.type === "session_before_compact") {
       const text = "_Compacting context..._";
-      log.logInfo(`Auto-compaction started (reason: ${event.reason})`);
+      log.logInfo("Auto-compaction started");
       sendAgentEvent({
         sessionId: agentEventSessionId,
         actorName: formatAgentActorName(logCtx.userName, logCtx.conversationId),
@@ -1408,29 +1334,11 @@ function attachSessionEventHandlers(params: {
       return;
     }
 
-    if (event.type === "compaction_end") {
-      if (event.result) {
-        log.logInfo(`Auto-compaction complete: ${event.result.tokensBefore} tokens compacted`);
-      } else if (event.aborted) {
-        log.logInfo("Auto-compaction aborted");
-      }
+    if (event.type === "session_compact") {
+      log.logInfo(
+        `Auto-compaction complete: ${event.compactionEntry.tokensBefore} tokens compacted`,
+      );
       return;
-    }
-
-    if (event.type === "auto_retry_start") {
-      log.logWarning(`Retrying (${event.attempt}/${event.maxAttempts})`, event.errorMessage);
-      sendAgentEvent({
-        sessionId: agentEventSessionId,
-        actorName: formatAgentActorName(logCtx.userName, logCtx.conversationId),
-        event: { kind: "sessionStart" },
-      });
-      const text = `_Retrying (${event.attempt}/${event.maxAttempts})..._`;
-      sendAgentEvent({
-        sessionId: agentEventSessionId,
-        actorName: formatAgentActorName(logCtx.userName, logCtx.conversationId),
-        event: { kind: "diagnostic", text },
-      });
-      queue.enqueue(() => responder.respond(text), "retry");
     }
   });
 }
@@ -1496,19 +1404,22 @@ export async function createRunner(
   let pathContext = getUnresolvedSandboxPathContext(sandboxConfig, workspaceBase);
 
   // Create tools (per-runner, with per-runner upload function setter)
-  const { tools, setUploadFunction, setEventContext, setSandboxContext } = createMikanTools(
-    executor,
-    workspaceDir,
-    { sandbox: sandboxConfig, provisioner },
-  );
+  const {
+    tools: builtinTools,
+    setUploadFunction,
+    setEventContext,
+    setSandboxContext,
+  } = createMikanTools(executor, workspaceDir, { sandbox: sandboxConfig, provisioner });
+  const { tools: extensionTools } = await getMikanExtensionContributions();
+  const tools = [...builtinTools, ...extensionTools];
 
-  const authStorage = AuthStorage.create(join(homedir(), ".pi", "mikan", "auth.json"));
-  const modelRegistry = ModelRegistry.create(authStorage);
-  const model = resolveConfiguredModel(modelRegistry, agentConfig.provider, agentConfig.model);
+  const models = createMikanModels();
+  const model = resolveConfiguredModel(models, agentConfig.provider, agentConfig.model);
 
   // Initial system prompt (will be updated each run with fresh memory/channels/users/skills)
   const memory = await getMemory(conversationDir);
-  const skills = loadMikanSkills(conversationDir, pathContext.runtimeWorkspaceRoot);
+  const env = createMikanExecutionEnv(pathContext.runtimeWorkspaceRoot);
+  const skills = await loadMikanSkills(env, conversationDir, pathContext.runtimeWorkspaceRoot);
   const emptyPlatform: MessagingInfo = {
     name: "chat",
     formattingGuide: "",
@@ -1525,48 +1436,41 @@ export async function createRunner(
     emptyPlatform,
     skills,
   );
+  const systemPromptState = { current: systemPrompt };
 
-  // Create session manager and settings manager. Top-level/private sessions
-  // use the conversation's current pointer; scoped sessions use fixed files.
-  // Platform-specific scope behavior is resolved before runner creation.
+  // Create session. Top-level/private sessions use the conversation's current
+  // pointer; scoped sessions use fixed files. Platform-specific scope behavior
+  // is resolved before runner creation.
   const isThread = sessionKey.includes(":");
   const { sessionDir, contextFile, threadRootMessage } = sessionScope;
-  const sessionManager = openManagedSession(
-    contextFile,
-    sessionDir,
-    pathContext.runtimeWorkspaceRoot,
-  );
+  const session = openManagedSession(contextFile, sessionDir, pathContext.runtimeWorkspaceRoot);
   const threadSessionName = buildThreadSessionName(threadRootMessage);
-  if (isThread && threadSessionName && sessionManager.getSessionName() !== threadSessionName) {
-    sessionManager.appendSessionInfo(threadSessionName);
+  if (isThread && threadSessionName && (await session.getSessionName()) !== threadSessionName) {
+    await session.appendSessionName(threadSessionName);
   }
 
   const sessionUuid = extractSessionUuid(contextFile);
-  const chatSessionManager = new AgentMemoryFileManager();
-  const settingsManager = SettingsManager.inMemory();
-  const { agent, session } = await createConfiguredAgentSession({
-    conversationId,
-    workspaceDir,
-    runtimeWorkspaceRoot: pathContext.runtimeWorkspaceRoot,
-    systemPrompt,
+  const harness = await createConfiguredAgentHarness({
+    env,
+    session,
+    models,
+    systemPromptState,
     model,
     thinkingLevel: agentConfig.thinkingLevel,
     tools,
-    sessionManager,
-    settingsManager,
-    modelRegistry,
+    skills,
   });
 
   // Mutable per-run state - event handler references this
   const runState = createRunState();
-  attachSessionEventHandlers({ session, runState, model, agentConfig });
+  attachSessionEventHandlers({ harness, runState, model, agentConfig });
 
   return {
-    syncChatHistory(currentMessageId?: string): void {
-      chatSessionManager.syncSessionManager({
+    async syncChatHistory(currentMessageId?: string): Promise<void> {
+      await new AgentMemoryFileManager().syncSessionManager({
         conversationDir,
         sessionKey,
-        sessionManager,
+        sessionManager: session,
         currentMessageId,
       });
     },
@@ -1588,9 +1492,8 @@ export async function createRunner(
         executionResolver,
         resolveExecutorForRun,
         getPathContext,
-        sessionManager,
         session,
-        agent,
+        systemPromptState,
         setEventContext,
         setSandboxContext,
         setUploadFunction,
@@ -1622,7 +1525,7 @@ export async function createRunner(
         event: { kind: "sessionStart" },
       });
 
-      await session.prompt(
+      await harness.prompt(
         prepared.userMessage,
         prepared.imageAttachments.length > 0 ? { images: prepared.imageAttachments } : undefined,
       );
@@ -1651,7 +1554,7 @@ export async function createRunner(
             }
           : undefined;
 
-      await finalizeRunResponse(responder, session, runState, {
+      await finalizeRunResponse(responder, runState, {
         triggerAttribution: prepared.triggerAttribution,
         triggerSessionLink: isEventTriggerAttribution(prepared.triggerAttribution)
           ? createSessionViewLink?.()
@@ -1664,7 +1567,6 @@ export async function createRunner(
       });
 
       await reportUsageSummary({
-        session,
         runState,
         responder,
         platform,
@@ -1675,6 +1577,8 @@ export async function createRunner(
         waitForQueue: () => prepared.runQueue.wait(),
       });
 
+      await maybeAutoCompact(harness, runState, model);
+
       // Clear run state
       runState.responder = null;
       runState.logCtx = null;
@@ -1684,7 +1588,7 @@ export async function createRunner(
     },
 
     abort(): void {
-      session.abort();
+      void harness.abort();
     },
 
     getCurrentStep(): { toolName?: string; label?: string } | undefined {

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -1,6 +1,5 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { ThinkingLevel as PiAiThinkingLevel } from "@earendil-works/pi-ai";
-import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { Models, ThinkingLevel as PiAiThinkingLevel } from "@earendil-works/pi-ai";
 import { join } from "path";
 import { resolveConversationSettings, updateConversationSettings } from "../config.js";
 import { matchCommand } from "./parse.js";
@@ -69,7 +68,7 @@ function formatModelSpec(provider: string, model: string, thinkingLevel?: Thinki
 }
 
 export class ModelCommandHandler implements CommandHandler {
-  constructor(private readonly modelRegistry: ModelRegistry) {}
+  constructor(private readonly models: Models) {}
   async tryHandle(context: CommandContext): Promise<boolean> {
     const parsed = parseModelCommand(context.commandText);
     if (!parsed) return false;
@@ -90,7 +89,7 @@ export class ModelCommandHandler implements CommandHandler {
       return true;
     }
 
-    if (!this.modelRegistry.find(parsed.provider, parsed.model)) {
+    if (!this.models.getModel(parsed.provider, parsed.model)) {
       await replyDiagnosticWithContext(
         context.responder,
         formatCommandSummary("Model", [

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,6 +1,4 @@
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
-import { homedir } from "os";
-import { join } from "path";
+import { createMikanModels } from "../harness/models.js";
 import { AdminCommandHandler } from "./admin.js";
 import { AutoReplyCommandHandler } from "./auto-reply.js";
 import { LoginCommandHandler } from "./login.js";
@@ -11,14 +9,13 @@ import { SessionViewCommandHandler } from "./session-view.js";
 import type { CommandContext, CommandHandler } from "./types.js";
 
 export function defaultCommandHandlers(): CommandHandler[] {
-  const authStorage = AuthStorage.create(join(homedir(), ".pi", "mikan", "auth.json"));
-  const modelRegistry = ModelRegistry.create(authStorage);
+  const models = createMikanModels();
   return [
     new AdminCommandHandler(),
     new LoginCommandHandler(),
     new SessionViewCommandHandler(),
     new AutoReplyCommandHandler(),
-    new ModelCommandHandler(modelRegistry),
+    new ModelCommandHandler(models),
     new SandboxCommandHandler(),
     new NewCommandHandler(),
   ];

--- a/src/content/docs/architecture.md
+++ b/src/content/docs/architecture.md
@@ -51,7 +51,7 @@ Responsibilities:
 
 - create `PiAgentWrapper`
 - load model, skills, memory, and session context
-- send user messages into `pi-agent-core` / `pi-coding-agent`
+- send user messages into mikan's own harness (`src/harness/*`), built on `pi-agent-core`'s `AgentHarness`
 - connect tool calls to local `read/bash/edit/write/event/attach`
 - write tool results back to the session and return responses through the adapter
 

--- a/src/content/docs/ja/architecture.md
+++ b/src/content/docs/ja/architecture.md
@@ -51,7 +51,7 @@ description: mikan のプラットフォーム接続、セッション、agent�
 
 - `PiAgentWrapper` を作成する
 - モデル、skills、memory、session context を読み込む
-- ユーザーメッセージを `pi-agent-core` / `pi-coding-agent` に渡す
+- ユーザーメッセージを mikan 自前の harness（`src/harness/*`、`pi-agent-core` の `AgentHarness` ベース）に渡す
 - tool calls をローカルの `read/bash/edit/write/event/attach` に接続する
 - tool の結果を session に書き戻し、adapter 経由でプラットフォームへ返す
 

--- a/src/content/docs/ja/sessions.mdx
+++ b/src/content/docs/ja/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: セッション
-description: mikan がプラットフォームのチャット履歴と pi-coding-agent の構造化セッションをどのように分離するか。
+description: mikan がプラットフォームのチャット履歴と自前の harness の構造化セッションをどのように分離するか。
 ---
 
 import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
@@ -10,8 +10,8 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
     `log.jsonl` は、人が読めるプラットフォームメッセージを保持し、thread または reply context の
     bootstrap に使います。
   </Card>
-  <Card title="pi 構造化 context" icon="rocket">
-    `sessions/*.jsonl` は tool results と agent turn を保存し、pi-coding-agent
+  <Card title="構造化 context" icon="rocket">
+    `sessions/*.jsonl` は tool results と agent turn を保存し、mikan 自前の harness
     が作業を継続できるようにします。
   </Card>
   <Card title="固定 scope" icon="lock">
@@ -36,7 +36,7 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   - **log.jsonl** プラットフォームメッセージ履歴
   - sessions/
     - **current** 使用中の top-level session を指します
-    - **\*.jsonl** tool results を含む、構造化 pi-coding-agent context
+    - **\*.jsonl** tool results を含む、構造化 harness context
     - **scope-derived files** thread / reply scopes の固定 session files
 
 </FileTree>

--- a/src/content/docs/sessions.mdx
+++ b/src/content/docs/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sessions
-description: How mikan separates platform chat history from pi-coding-agent structured sessions.
+description: How mikan separates platform chat history from its own harness's structured sessions.
 ---
 
 import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
@@ -9,8 +9,8 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   <Card title="Platform chat history" icon="open-book">
     `log.jsonl` keeps human-readable platform messages used to bootstrap thread or reply context.
   </Card>
-  <Card title="pi structured context" icon="rocket">
-    `sessions/*.jsonl` stores tool results and agent turns so pi-coding-agent can continue work.
+  <Card title="Structured context" icon="rocket">
+    `sessions/*.jsonl` stores tool results and agent turns so mikan's own harness can continue work.
   </Card>
   <Card title="Fixed scope" icon="lock">
     Threads, reply chains, and shared channels map to fixed session files so different conversations
@@ -34,7 +34,7 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   - **log.jsonl** platform message history
   - sessions/
     - **current** points to the active top-level session
-    - **\*.jsonl** structured pi-coding-agent context, including tool results
+    - **\*.jsonl** structured harness context, including tool results
     - **scope-derived files** fixed session files for thread / reply scopes
 
 </FileTree>

--- a/src/content/docs/zh-cn/architecture.md
+++ b/src/content/docs/zh-cn/architecture.md
@@ -51,7 +51,7 @@ description: 了解 mikan 的平台接入、工作阶段、agent、sandbox、vau
 
 - 建立 `PiAgentWrapper`
 - 载入模型、skills、memory、session context
-- 将使用者讯息送入 `pi-agent-core` / `pi-coding-agent`
+- 将使用者讯息送入 mikan 自有的 harness（`src/harness/*`），基于 `pi-agent-core` 的 `AgentHarness` 构建
 - 把 tool calls 接到本地 `read/bash/edit/write/event/attach`
 - 把 tool 结果回写 session，并透过 adapter 回传给平台
 

--- a/src/content/docs/zh-cn/sessions.mdx
+++ b/src/content/docs/zh-cn/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: 会话
-description: mikan 如何分离平台聊天历史与 pi-coding-agent 结构化会话。
+description: mikan 如何分离平台聊天历史与其自有 harness 的结构化会话。
 ---
 
 import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
@@ -9,8 +9,8 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   <Card title="平台聊天历史" icon="open-book">
     `log.jsonl` 保留可供人阅读的平台消息，用于 bootstrap thread 或 reply context。
   </Card>
-  <Card title="pi 结构化 context" icon="rocket">
-    `sessions/*.jsonl` 保存 tool results 与 agent turn，让 pi-coding-agent 可以延续工作。
+  <Card title="结构化 context" icon="rocket">
+    `sessions/*.jsonl` 保存 tool results 与 agent turn，让 mikan 自有的 harness 可以延续工作。
   </Card>
   <Card title="固定 scope" icon="lock">
     Thread、reply chain 与 shared channel 会映射到固定 session files，避免不同对话互相污染。
@@ -33,7 +33,7 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   - **log.jsonl** 平台消息历史
   - sessions/
     - **current** 指向使用中的 top-level session
-    - **\*.jsonl** 结构化 pi-coding-agent context，包含 tool results
+    - **\*.jsonl** 结构化 harness context，包含 tool results
     - **scope-derived files** thread / reply scopes 的固定 session files
 
 </FileTree>

--- a/src/content/docs/zh-tw/architecture.md
+++ b/src/content/docs/zh-tw/architecture.md
@@ -51,7 +51,7 @@ description: 了解 mikan 的平台接入、工作階段、agent、sandbox、vau
 
 - 建立 `PiAgentWrapper`
 - 載入模型、skills、memory、session context
-- 將使用者訊息送入 `pi-agent-core` / `pi-coding-agent`
+- 將使用者訊息送入 mikan 自有的 harness（`src/harness/*`），基於 `pi-agent-core` 的 `AgentHarness` 建構
 - 把 tool calls 接到本地 `read/bash/edit/write/event/attach`
 - 把 tool 結果回寫 session，並透過 adapter 回傳給平台
 

--- a/src/content/docs/zh-tw/sessions.mdx
+++ b/src/content/docs/zh-tw/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: 工作階段
-description: mikan 如何分離平台聊天歷史與 pi-coding-agent 結構化工作階段。
+description: mikan 如何分離平台聊天歷史與其自有 harness 的結構化工作階段。
 ---
 
 import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
@@ -9,8 +9,8 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   <Card title="平台聊天歷史" icon="open-book">
     `log.jsonl` 保留可供人閱讀的平台訊息，用來 bootstrap thread 或 reply context。
   </Card>
-  <Card title="pi 結構化 context" icon="rocket">
-    `sessions/*.jsonl` 保存 tool results 與 agent turn，讓 pi-coding-agent 可以延續工作。
+  <Card title="結構化 context" icon="rocket">
+    `sessions/*.jsonl` 保存 tool results 與 agent turn，讓 mikan 自有的 harness 可以延續工作。
   </Card>
   <Card title="固定 scope" icon="lock">
     Thread、reply chain 與 shared channel 會映射到固定 session files，避免不同對話互相污染。
@@ -33,7 +33,7 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   - **log.jsonl** 平台訊息歷史
   - sessions/
     - **current** 指向使用中的 top-level session
-    - **\*.jsonl** 結構化 pi-coding-agent context，包含 tool results
+    - **\*.jsonl** 結構化 harness context，包含 tool results
     - **scope-derived files** thread / reply scopes 的固定 session files
 
 </FileTree>

--- a/src/harness/credential-store.ts
+++ b/src/harness/credential-store.ts
@@ -1,0 +1,73 @@
+import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
+import { existsSync, mkdirSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+import { atomicWritePrivateFile } from "../utils/fs-atomic.js";
+
+export const MIKAN_AUTH_PATH = join(homedir(), ".pi", "mikan", "auth.json");
+
+type CredentialData = Record<string, Credential>;
+
+/**
+ * File-backed CredentialStore for pi-ai's `Models`, reading/writing the same
+ * `~/.pi/mikan/auth.json` schema previously owned by pi-coding-agent's AuthStorage.
+ */
+export class FileCredentialStore implements CredentialStore {
+  private readonly chains = new Map<string, Promise<unknown>>();
+
+  constructor(private readonly authPath: string = MIKAN_AUTH_PATH) {}
+
+  async read(providerId: string): Promise<Credential | undefined> {
+    return this.readAll()[providerId];
+  }
+
+  async modify(
+    providerId: string,
+    fn: (current: Credential | undefined) => Promise<Credential | undefined>,
+  ): Promise<Credential | undefined> {
+    return this.enqueue(providerId, async () => {
+      const data = this.readAll();
+      const next = await fn(data[providerId]);
+      if (next !== undefined) {
+        data[providerId] = next;
+        this.writeAll(data);
+      }
+      return next;
+    });
+  }
+
+  async delete(providerId: string): Promise<void> {
+    await this.enqueue(providerId, async () => {
+      const data = this.readAll();
+      delete data[providerId];
+      this.writeAll(data);
+    });
+  }
+
+  /** Serialize operations per provider id so concurrent modify()/delete() calls don't race. */
+  private enqueue<T>(providerId: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.chains.get(providerId) ?? Promise.resolve();
+    const next = previous.then(task, task);
+    this.chains.set(
+      providerId,
+      next.catch(() => undefined),
+    );
+    return next;
+  }
+
+  private readAll(): CredentialData {
+    if (!existsSync(this.authPath)) return {};
+    try {
+      const parsed = JSON.parse(readFileSync(this.authPath, "utf-8"));
+      return parsed && typeof parsed === "object" ? (parsed as CredentialData) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private writeAll(data: CredentialData): void {
+    const dir = dirname(this.authPath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+    atomicWritePrivateFile(this.authPath, `${JSON.stringify(data, null, 2)}\n`);
+  }
+}

--- a/src/harness/env.ts
+++ b/src/harness/env.ts
@@ -1,0 +1,11 @@
+import { NodeExecutionEnv, type ExecutionEnv } from "@earendil-works/pi-agent-core/node";
+
+/**
+ * Host filesystem/exec environment for AgentHarness's internal needs (skill
+ * discovery, etc). Mikan's own tools (bash/edit/read/write) route execution
+ * through `src/sandbox/index.ts`'s Executor directly and never go through
+ * this — so a plain host-based env is correct even in sandboxed deployments.
+ */
+export function createMikanExecutionEnv(cwd: string): ExecutionEnv {
+  return new NodeExecutionEnv({ cwd });
+}

--- a/src/harness/extensions.ts
+++ b/src/harness/extensions.ts
@@ -1,0 +1,188 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { TSchema } from "@sinclair/typebox";
+import { existsSync, readdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { pathToFileURL } from "url";
+import type { CommandHandler } from "../commands/types.js";
+import * as log from "../log.js";
+
+export const MIKAN_EXTENSIONS_DIR = join(homedir(), ".pi", "mikan", "extensions");
+
+export interface MikanExtensionContext {
+  log: typeof log;
+}
+
+/**
+ * Contract for a mikan extension module. Deliberately narrow (v1): extensions
+ * contribute additional AgentTools and/or chat CommandHandlers using mikan's
+ * existing types, nothing more (no lifecycle hooks, no UI, no direct
+ * session/model/filesystem access beyond what a tool implementation already has).
+ */
+export interface MikanExtensionModule {
+  /** Display name, used in load logs and error messages. */
+  name: string;
+  /** Additional AgentTools contributed by this extension. */
+  tools?(ctx: MikanExtensionContext): AgentTool<TSchema>[] | Promise<AgentTool<TSchema>[]>;
+  /** Additional chat command handlers, tried after mikan's built-in ones. */
+  commands?(ctx: MikanExtensionContext): CommandHandler[] | Promise<CommandHandler[]>;
+}
+
+export interface LoadedExtension {
+  path: string;
+  module: MikanExtensionModule;
+}
+
+export interface ExtensionLoadResult {
+  extensions: LoadedExtension[];
+  errors: Array<{ path: string; error: string }>;
+}
+
+export interface CollectedExtensionContributions {
+  tools: AgentTool<TSchema>[];
+  commands: CommandHandler[];
+}
+
+function isMikanExtensionModule(value: unknown): value is MikanExtensionModule {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { name?: unknown }).name === "string"
+  );
+}
+
+function listCandidateFiles(dir: string): string[] {
+  const candidates: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".js")) {
+      candidates.push(join(dir, entry.name));
+      continue;
+    }
+    if (entry.isDirectory()) {
+      const indexPath = join(dir, entry.name, "index.js");
+      if (existsSync(indexPath)) candidates.push(indexPath);
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Discover and import extension modules from `dir` (default `~/.pi/mikan/extensions/`).
+ * Flat, non-recursive discovery: `<dir>/*.js` or `<dir>/<name>/index.js`. A missing
+ * directory is not an error (extensions are optional). Every import is isolated —
+ * one broken extension is recorded as an error and never blocks the rest from loading.
+ */
+export async function loadMikanExtensions(
+  dir: string = MIKAN_EXTENSIONS_DIR,
+): Promise<ExtensionLoadResult> {
+  const extensions: LoadedExtension[] = [];
+  const errors: Array<{ path: string; error: string }> = [];
+  if (!existsSync(dir)) return { extensions, errors };
+
+  let candidates: string[];
+  try {
+    candidates = listCandidateFiles(dir);
+  } catch (err) {
+    errors.push({ path: dir, error: err instanceof Error ? err.message : String(err) });
+    return { extensions, errors };
+  }
+
+  for (const path of candidates) {
+    try {
+      const imported = (await import(pathToFileURL(path).href)) as {
+        default?: unknown;
+        mikanExtension?: unknown;
+      };
+      const candidate = imported.default ?? imported.mikanExtension;
+      if (!isMikanExtensionModule(candidate)) {
+        errors.push({
+          path,
+          error: "extension is missing a string `name` export (default or `mikanExtension`)",
+        });
+        continue;
+      }
+      extensions.push({ path, module: candidate });
+    } catch (err) {
+      errors.push({ path, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  return { extensions, errors };
+}
+
+function wrapCommandHandler(extensionName: string, handler: CommandHandler): CommandHandler {
+  return {
+    async tryHandle(context) {
+      try {
+        return await handler.tryHandle(context);
+      } catch (err) {
+        log.logWarning(
+          `Extension "${extensionName}" command handler threw`,
+          err instanceof Error ? err.message : String(err),
+        );
+        return false;
+      }
+    },
+  };
+}
+
+/** Instantiate every loaded extension's tools/commands, isolating failures per extension. */
+export async function collectExtensionContributions(
+  result: ExtensionLoadResult,
+  ctx: MikanExtensionContext,
+): Promise<CollectedExtensionContributions> {
+  const tools: AgentTool<TSchema>[] = [];
+  const commands: CommandHandler[] = [];
+
+  for (const { path, module } of result.extensions) {
+    if (module.tools) {
+      try {
+        tools.push(...(await module.tools(ctx)));
+      } catch (err) {
+        log.logWarning(
+          `Extension "${module.name}" (${path}) failed to provide tools`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+    if (module.commands) {
+      try {
+        const handlers = await module.commands(ctx);
+        commands.push(...handlers.map((handler) => wrapCommandHandler(module.name, handler)));
+      } catch (err) {
+        log.logWarning(
+          `Extension "${module.name}" (${path}) failed to provide commands`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  }
+
+  return { tools, commands };
+}
+
+let cachedContributions: Promise<CollectedExtensionContributions> | undefined;
+
+/**
+ * Load and cache mikan's extensions for the lifetime of the process. Extensions
+ * are loaded once at first use; changing the extensions directory requires a
+ * process restart (no hot-reload in v1).
+ */
+export function getMikanExtensionContributions(
+  dir: string = MIKAN_EXTENSIONS_DIR,
+): Promise<CollectedExtensionContributions> {
+  if (!cachedContributions) {
+    cachedContributions = loadMikanExtensions(dir).then(async (result) => {
+      for (const error of result.errors) {
+        log.logWarning(`Failed to load extension: ${error.path}`, error.error);
+      }
+      if (result.extensions.length > 0) {
+        log.logInfo(
+          `Loaded ${result.extensions.length} extension(s): ${result.extensions.map((e) => e.module.name).join(", ")}`,
+        );
+      }
+      return collectExtensionContributions(result, { log });
+    });
+  }
+  return cachedContributions;
+}

--- a/src/harness/models.ts
+++ b/src/harness/models.ts
@@ -1,0 +1,53 @@
+import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import type { Api, Model, Models, MutableModels, ProviderHeaders } from "@earendil-works/pi-ai";
+import { FileCredentialStore, MIKAN_AUTH_PATH } from "./credential-store.js";
+
+export type { Models } from "@earendil-works/pi-ai";
+
+/** Provider/model catalog + auth resolution, replacing pi-coding-agent's ModelRegistry/AuthStorage. */
+export function createMikanModels(authPath: string = MIKAN_AUTH_PATH): MutableModels {
+  return builtinModels({ credentials: new FileCredentialStore(authPath) });
+}
+
+/** Replaces ModelRegistry.getAvailable() — models with resolvable auth. Now async (getAuth() is async). */
+export async function getAvailableModels(models: Models): Promise<Model<Api>[]> {
+  const all = models.getModels();
+  const withAuth = await Promise.all(
+    all.map(async (model) => ({ model, auth: await models.getAuth(model).catch(() => undefined) })),
+  );
+  return withAuth.filter((entry) => entry.auth !== undefined).map((entry) => entry.model);
+}
+
+/** Replaces ModelRegistry.getApiKeyForProvider(provider). Resolves auth through any model of that provider. */
+export async function getApiKeyForProvider(
+  models: Models,
+  provider: string,
+): Promise<string | undefined> {
+  const providerModels = models.getModels(provider);
+  if (providerModels.length === 0) return undefined;
+  const auth = await models.getAuth(providerModels[0]).catch(() => undefined);
+  return auth?.auth.apiKey;
+}
+
+export type ResolvedRequestAuth =
+  | { ok: true; apiKey?: string; headers?: ProviderHeaders }
+  | { ok: false; error: string };
+
+/** Replaces ModelRegistry.getApiKeyAndHeaders(model). */
+export async function getApiKeyAndHeaders(
+  models: Models,
+  model: Model<Api>,
+): Promise<ResolvedRequestAuth> {
+  try {
+    const auth = await models.getAuth(model);
+    if (!auth) {
+      return {
+        ok: false,
+        error: `No API key for provider "${model.provider}". Set the appropriate environment variable or configure via auth.json`,
+      };
+    }
+    return { ok: true, apiKey: auth.auth.apiKey, headers: auth.auth.headers };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/src/harness/session-storage.ts
+++ b/src/harness/session-storage.ts
@@ -191,7 +191,12 @@ export class MikanSessionStorage implements SessionStorage<MikanSessionMetadata>
    * as a side effect of merely inspecting them.
    */
   static peekHeader(sessionFile: string): RawSessionHeader | null {
-    const raw = readTextFileIfExists(sessionFile);
+    let raw: string | undefined;
+    try {
+      raw = readTextFileIfExists(sessionFile);
+    } catch {
+      return null;
+    }
     if (raw === undefined) return null;
     const firstLine = raw.split("\n").find((line) => line.trim());
     if (!firstLine) return null;

--- a/src/harness/session-storage.ts
+++ b/src/harness/session-storage.ts
@@ -1,0 +1,304 @@
+import {
+  SessionError,
+  uuidv7,
+  type SessionMetadata,
+  type SessionStorage,
+  type SessionTreeEntry,
+} from "@earendil-works/pi-agent-core";
+import { randomUUID } from "crypto";
+import { appendFileSync, existsSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import * as log from "../log.js";
+import { isRecord, readTextFileIfExists } from "../utils/file-guards.js";
+import { atomicWritePrivateFile } from "../utils/fs-atomic.js";
+import type { MikanSessionHeader } from "../sessions/types.js";
+
+const CURRENT_SESSION_VERSION = 3;
+
+export interface MikanSessionMetadata extends SessionMetadata {
+  cwd: string;
+  path: string;
+  parentSessionPath?: string;
+}
+
+export type RawSessionHeader = MikanSessionHeader & {
+  type: "session";
+  id: string;
+  timestamp: string;
+};
+
+function isSessionHeader(value: unknown): value is RawSessionHeader {
+  return (
+    isRecord(value) &&
+    value.type === "session" &&
+    typeof value.id === "string" &&
+    typeof value.timestamp === "string"
+  );
+}
+
+function isSessionTreeEntry(value: unknown): value is SessionTreeEntry {
+  return (
+    isRecord(value) &&
+    typeof value.type === "string" &&
+    typeof value.id === "string" &&
+    "parentId" in value &&
+    typeof value.timestamp === "string"
+  );
+}
+
+function generateEntryId(byId: Map<string, SessionTreeEntry>): string {
+  // randomUUID (v4), not uuidv7: v7's leading bytes are a millisecond timestamp,
+  // so truncating it to 8 hex chars can collide across independently-created
+  // session files generated within the same millisecond (e.g. a channel session
+  // and a thread session bootstrapped back-to-back), corrupting id-based
+  // cross-session matching. v4 is fully random, so an 8-char slice is safe.
+  for (let i = 0; i < 100; i++) {
+    const id = randomUUID().slice(0, 8);
+    if (!byId.has(id)) return id;
+  }
+  return randomUUID();
+}
+
+function leafIdAfterEntry(entry: SessionTreeEntry): string | null {
+  return entry.type === "leaf" ? entry.targetId : entry.id;
+}
+
+function toMetadata(sessionFile: string, header: RawSessionHeader): MikanSessionMetadata {
+  return {
+    id: header.id,
+    createdAt: header.timestamp,
+    cwd: header.cwd ?? "",
+    path: sessionFile,
+    parentSessionPath: header.parentSession,
+  };
+}
+
+interface ParsedSessionFile {
+  header: RawSessionHeader;
+  entries: SessionTreeEntry[];
+}
+
+/**
+ * Parses mikan's existing on-disk session format: a header line followed by
+ * newline-delimited session-tree entries. Returns null when the file has no
+ * usable header (missing, empty, or corrupted first line) so callers can fall
+ * back to starting a fresh session, matching pi-coding-agent's own recovery
+ * behavior — but unlike pi-coding-agent, a corrupted *entry* line (not the
+ * header) is skipped with a warning instead of aborting the whole load, since
+ * this is real chat history and losing only the unreadable line is preferable
+ * to discarding an entire conversation.
+ */
+function parseSessionFile(raw: string, sessionFile: string): ParsedSessionFile | null {
+  const lines = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return null;
+
+  let header: unknown;
+  try {
+    header = JSON.parse(lines[0]);
+  } catch (err) {
+    log.logWarning(
+      `Corrupted session header, starting fresh: ${sessionFile}`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+  if (!isSessionHeader(header)) {
+    log.logWarning(`Missing or invalid session header, starting fresh: ${sessionFile}`);
+    return null;
+  }
+
+  const entries: SessionTreeEntry[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    try {
+      const parsed = JSON.parse(lines[i]);
+      if (!isSessionTreeEntry(parsed)) {
+        throw new Error("not a session entry");
+      }
+      entries.push(parsed);
+    } catch (err) {
+      log.logWarning(
+        `Skipping corrupted session entry (line ${i + 1}): ${sessionFile}`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+  return { header, entries };
+}
+
+/**
+ * mikan-owned SessionStorage implementation, byte-compatible with the JSONL
+ * format previously written/read by pi-coding-agent's SessionManager: a
+ * `{type:"session",version,id,timestamp,cwd,parentSession?}` header line
+ * followed by newline-delimited session-tree entries. Existing production
+ * session files are readable/writable without migration.
+ *
+ * Persists eagerly (no delayed-write gate): by the time this class opens or
+ * creates a file, mikan's own `src/sessions/store.ts` layer has always
+ * already ensured the file exists with a valid header, so there is no
+ * "no assistant reply yet" empty-file case to guard against here.
+ */
+export class MikanSessionStorage implements SessionStorage<MikanSessionMetadata> {
+  private readonly entries: SessionTreeEntry[] = [];
+  private readonly byId = new Map<string, SessionTreeEntry>();
+  private readonly labelsById = new Map<string, string>();
+  private leafId: string | null = null;
+  private readonly metadata: MikanSessionMetadata;
+
+  private constructor(
+    private readonly sessionFile: string,
+    private rawHeader: RawSessionHeader,
+    entries: SessionTreeEntry[],
+  ) {
+    this.metadata = toMetadata(sessionFile, rawHeader);
+    for (const entry of entries) this.indexEntry(entry);
+  }
+
+  /** Open an existing session file, or create a fresh one if missing/corrupted. */
+  static open(sessionFile: string, cwd: string): MikanSessionStorage {
+    const raw = readTextFileIfExists(sessionFile);
+    if (raw !== undefined) {
+      const parsed = parseSessionFile(raw, sessionFile);
+      if (parsed) return new MikanSessionStorage(sessionFile, parsed.header, parsed.entries);
+    }
+    return MikanSessionStorage.create(sessionFile, cwd);
+  }
+
+  /**
+   * Open an existing session file strictly read-only: throws if the file is
+   * missing or has no valid header, and never creates or rewrites anything.
+   * Used by read-only consumers (e.g. the session web viewer) that must not
+   * materialize a fresh session as a side effect of inspecting a bad file.
+   */
+  static openReadOnly(sessionFile: string): MikanSessionStorage {
+    const raw = readTextFileIfExists(sessionFile);
+    if (raw === undefined) {
+      throw new Error(`Session file does not exist: ${sessionFile}`);
+    }
+    const parsed = parseSessionFile(raw, sessionFile);
+    if (!parsed) {
+      throw new Error(`Session file is corrupted: ${sessionFile}`);
+    }
+    return new MikanSessionStorage(sessionFile, parsed.header, parsed.entries);
+  }
+
+  /**
+   * Read-only, side-effect-free peek at a session file's header, or null if the
+   * file is missing/unreadable/has no valid header. Unlike `open()`, never
+   * creates a file — used by metadata checks that must not materialize sessions
+   * as a side effect of merely inspecting them.
+   */
+  static peekHeader(sessionFile: string): RawSessionHeader | null {
+    const raw = readTextFileIfExists(sessionFile);
+    if (raw === undefined) return null;
+    const firstLine = raw.split("\n").find((line) => line.trim());
+    if (!firstLine) return null;
+    try {
+      const header = JSON.parse(firstLine);
+      return isSessionHeader(header) ? header : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Create a brand-new session file with a fresh header, writing it immediately. */
+  static create(
+    sessionFile: string,
+    cwd: string,
+    options?: { sessionId?: string; parentSession?: string },
+  ): MikanSessionStorage {
+    const header: RawSessionHeader = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: options?.sessionId ?? uuidv7(),
+      timestamp: new Date().toISOString(),
+      cwd,
+      parentSession: options?.parentSession,
+    };
+    const dir = dirname(sessionFile);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    atomicWritePrivateFile(sessionFile, `${JSON.stringify(header)}\n`);
+    return new MikanSessionStorage(sessionFile, header, []);
+  }
+
+  /** Raw header fields not modeled by pi-agent-core's SessionMetadata (e.g. `source`). */
+  getRawHeader(): RawSessionHeader {
+    return this.rawHeader;
+  }
+
+  getSessionFile(): string {
+    return this.sessionFile;
+  }
+
+  private indexEntry(entry: SessionTreeEntry): void {
+    this.entries.push(entry);
+    this.byId.set(entry.id, entry);
+    if (entry.type === "label") {
+      const label = entry.label?.trim();
+      if (label) this.labelsById.set(entry.targetId, label);
+      else this.labelsById.delete(entry.targetId);
+    }
+    this.leafId = leafIdAfterEntry(entry);
+  }
+
+  async getMetadata(): Promise<MikanSessionMetadata> {
+    return this.metadata;
+  }
+
+  async getLeafId(): Promise<string | null> {
+    return this.leafId;
+  }
+
+  async setLeafId(leafId: string | null): Promise<void> {
+    if (leafId !== null && !this.byId.has(leafId)) {
+      throw new SessionError("not_found", `Entry ${leafId} not found`);
+    }
+    this.leafId = leafId;
+  }
+
+  async createEntryId(): Promise<string> {
+    return generateEntryId(this.byId);
+  }
+
+  async appendEntry(entry: SessionTreeEntry): Promise<void> {
+    this.indexEntry(entry);
+    appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+  }
+
+  async getEntry(id: string): Promise<SessionTreeEntry | undefined> {
+    return this.byId.get(id);
+  }
+
+  async findEntries<TType extends SessionTreeEntry["type"]>(
+    type: TType,
+  ): Promise<Array<Extract<SessionTreeEntry, { type: TType }>>> {
+    return this.entries.filter(
+      (entry): entry is Extract<SessionTreeEntry, { type: TType }> => entry.type === type,
+    );
+  }
+
+  async getLabel(id: string): Promise<string | undefined> {
+    return this.labelsById.get(id);
+  }
+
+  async getPathToRoot(leafId: string | null): Promise<SessionTreeEntry[]> {
+    if (leafId === null) return [];
+    const path: SessionTreeEntry[] = [];
+    let current = this.byId.get(leafId);
+    if (!current) throw new SessionError("not_found", `Entry ${leafId} not found`);
+    while (current) {
+      path.unshift(current);
+      if (!current.parentId) break;
+      const parent: SessionTreeEntry | undefined = this.byId.get(current.parentId);
+      if (!parent) throw new SessionError("invalid_session", `Entry ${current.parentId} not found`);
+      current = parent;
+    }
+    return path;
+  }
+
+  async getEntries(): Promise<SessionTreeEntry[]> {
+    return [...this.entries];
+  }
+}

--- a/src/harness/skills.ts
+++ b/src/harness/skills.ts
@@ -1,0 +1,34 @@
+import { loadSourcedSkills, type ExecutionEnv, type Skill } from "@earendil-works/pi-agent-core";
+import { join } from "path";
+
+type SkillSource = "workspace" | "channel";
+
+/**
+ * Load workspace-level and conversation-level skills, merged by name with
+ * conversation skills overriding workspace skills on collision (matches
+ * mikan's original semantics). `filePath` is translated from host paths to
+ * the runtime workspace path since it's the only field emitted into the
+ * system prompt (via `<location>`).
+ */
+export async function loadMikanSkills(
+  env: ExecutionEnv,
+  conversationDir: string,
+  workspacePath: string,
+): Promise<Skill[]> {
+  const hostWorkspacePath = join(conversationDir, "..");
+  const translatePath = (hostPath: string): string =>
+    hostPath.startsWith(hostWorkspacePath)
+      ? workspacePath + hostPath.slice(hostWorkspacePath.length)
+      : hostPath;
+
+  const { skills } = await loadSourcedSkills<SkillSource>(env, [
+    { path: join(hostWorkspacePath, "skills"), source: "workspace" },
+    { path: join(conversationDir, "skills"), source: "channel" },
+  ]);
+
+  const skillMap = new Map<string, Skill>();
+  for (const { skill } of skills) {
+    skillMap.set(skill.name, { ...skill, filePath: translatePath(skill.filePath) });
+  }
+  return Array.from(skillMap.values());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,3 +39,14 @@ export type {
   SandboxAdapter,
   SandboxConfig,
 } from "./sandbox/index.js";
+export {
+  MIKAN_EXTENSIONS_DIR,
+  loadMikanExtensions,
+  collectExtensionContributions,
+  getMikanExtensionContributions,
+  type MikanExtensionContext,
+  type MikanExtensionModule,
+  type LoadedExtension,
+  type ExtensionLoadResult,
+  type CollectedExtensionContributions,
+} from "./harness/extensions.js";

--- a/src/model-registry.ts
+++ b/src/model-registry.ts
@@ -1,12 +1,11 @@
-import { type Api, type Model } from "@earendil-works/pi-ai";
-import { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { type Api, type Model, type Models } from "@earendil-works/pi-ai";
 
 export function resolveConfiguredModel(
-  modelRegistry: ModelRegistry,
+  models: Models,
   provider: string,
   modelId: string,
 ): Model<Api> {
-  const model = modelRegistry.find(provider, modelId) as Model<Api> | undefined;
+  const model = models.getModel(provider, modelId);
   if (model) return model;
 
   throw new Error(

--- a/src/runtime/agent-run-controller.ts
+++ b/src/runtime/agent-run-controller.ts
@@ -85,7 +85,7 @@ export class AgentRunController {
         currentMessageId: event.ts,
         conversationKind: event.conversationKind,
       });
-      state.runner.syncChatHistory(event.ts);
+      void state.runner.syncChatHistory(event.ts);
     } catch (err) {
       reportUserFacingError(err, {
         domain: "mikan",

--- a/src/runtime/agent-run-controller.ts
+++ b/src/runtime/agent-run-controller.ts
@@ -85,7 +85,7 @@ export class AgentRunController {
         currentMessageId: event.ts,
         conversationKind: event.conversationKind,
       });
-      void state.runner.syncChatHistory(event.ts);
+      await state.runner.syncChatHistory(event.ts);
     } catch (err) {
       reportUserFacingError(err, {
         domain: "mikan",

--- a/src/sessions/agent-memory-file-manager.ts
+++ b/src/sessions/agent-memory-file-manager.ts
@@ -1,9 +1,8 @@
-import { SessionManager, type SessionEntry } from "@earendil-works/pi-coding-agent";
+import type { AgentMessage, Session, SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import { join } from "path";
 import type { ConversationLogMessage } from "../types.js";
 import { isRecord, parseJsonValue, readTextFileIfExists } from "../utils/file-guards.js";
 import { formatLocalTimestamp } from "../utils/date.js";
-import { atomicWritePrivateFile } from "../utils/fs-atomic.js";
 import * as log from "../log.js";
 import { isPlatformHistorySession } from "./metadata.js";
 import {
@@ -25,8 +24,6 @@ const DEFAULT_MAX_TOP_LEVEL_MESSAGES = 200;
 const CHAT_SYNC_CUSTOM_TYPE = "mikan.chat_sync";
 const BIWEEKLY_ROTATION_ANCHOR = new Date(2026, 0, 4); // Sunday
 const BIWEEKLY_MS = 14 * 24 * 60 * 60 * 1000;
-
-type SessionAppendMessage = Parameters<SessionManager["appendMessage"]>[0];
 
 interface LogRecord {
   message: ConversationLogMessage;
@@ -115,7 +112,7 @@ export class AgentMemoryFileManager {
     const sessionDir = getChannelSessionDir(options.conversationDir);
 
     if (!options.sessionKey.includes(":")) {
-      const contextFile = this.resolveTopLevelSessionFile({
+      const contextFile = await this.resolveTopLevelSessionFile({
         conversationDir: options.conversationDir,
         sessionDir,
         cwd,
@@ -125,7 +122,7 @@ export class AgentMemoryFileManager {
       return { sessionDir, contextFile, threadRootMessage: null };
     }
 
-    return this.resolveThreadSessionScope({
+    return await this.resolveThreadSessionScope({
       conversationDir: options.conversationDir,
       sessionDir,
       sessionKey: options.sessionKey,
@@ -134,9 +131,9 @@ export class AgentMemoryFileManager {
     });
   }
 
-  syncSessionManager(options: SyncAgentMemoryFileManagerOptions): void {
+  async syncSessionManager(options: SyncAgentMemoryFileManagerOptions): Promise<void> {
     const records = readConversationLog(options.conversationDir);
-    syncSessionManagerFromLog(
+    await syncSessionManagerFromLog(
       options.sessionManager,
       selectExistingSessionSyncMessages(records, {
         sessionKey: options.sessionKey.includes(":") ? options.sessionKey : null,
@@ -158,18 +155,18 @@ export class AgentMemoryFileManager {
     return createManagedSessionFile(getChannelSessionDir(options.conversationDir), cwd);
   }
 
-  private resolveTopLevelSessionFile(options: {
+  private async resolveTopLevelSessionFile(options: {
     conversationDir: string;
     sessionDir: string;
     cwd: string;
     currentMessageId?: string;
     rotateTopLevelSession: boolean;
-  }): string {
+  }): Promise<string> {
     const records = readConversationLog(options.conversationDir);
     const existing = tryResolveCurrentSession(options.sessionDir);
     if (existing && !isPlatformHistorySession(existing)) {
       if (!options.rotateTopLevelSession || !shouldRotateTopLevelSession(existing, this.now())) {
-        syncSessionFromLog(
+        await syncSessionFromLog(
           existing,
           options.sessionDir,
           options.cwd,
@@ -190,7 +187,7 @@ export class AgentMemoryFileManager {
       now: this.now(),
       excludeMessageId: options.currentMessageId,
     });
-    bootstrapSessionFromLog(
+    await bootstrapSessionFromLog(
       sessionFile,
       options.sessionDir,
       options.cwd,
@@ -207,20 +204,20 @@ export class AgentMemoryFileManager {
     return { recentDays: this.recentDays, maxMessages: this.maxTopLevelMessages, now: this.now() };
   }
 
-  private resolveThreadSessionScope(options: {
+  private async resolveThreadSessionScope(options: {
     conversationDir: string;
     sessionDir: string;
     sessionKey: string;
     cwd: string;
     currentMessageId?: string;
-  }): ResolvedSessionScope {
+  }): Promise<ResolvedSessionScope> {
     const threadFile = getThreadSessionFile(options.conversationDir, options.sessionKey);
     const threadId = extractSessionSuffix(options.sessionKey);
     const records = readConversationLog(options.conversationDir);
     const threadRootMessage = buildThreadRootSeed(findLogRecordById(records, threadId)?.message);
     const existing = tryResolveThreadSession(threadFile);
     if (existing) {
-      syncSessionFromLog(
+      await syncSessionFromLog(
         existing,
         options.sessionDir,
         options.cwd,
@@ -240,7 +237,7 @@ export class AgentMemoryFileManager {
       now: this.now(),
       excludeMessageId: options.currentMessageId,
     });
-    bootstrapSessionFromLog(
+    await bootstrapSessionFromLog(
       threadFile,
       options.sessionDir,
       options.cwd,
@@ -481,23 +478,22 @@ function sortTime(record: LogRecord): number {
   return record.index;
 }
 
-function bootstrapSessionFromLog(
+async function bootstrapSessionFromLog(
   sessionFile: string,
   sessionDir: string,
   cwd: string,
   records: LogRecord[],
   lastMessageId = records.at(-1)?.message.ts,
-): void {
+): Promise<void> {
   if (records.length === 0 && !lastMessageId) return;
 
-  const sessionManager = openManagedSession(sessionFile, sessionDir, cwd);
-  appendLogRecordsToSession(sessionManager, records);
-  sessionManager.appendCustomEntry(CHAT_SYNC_CUSTOM_TYPE, {
+  const session = openManagedSession(sessionFile, sessionDir, cwd);
+  await appendLogRecordsToSession(session, records);
+  await session.appendCustomEntry(CHAT_SYNC_CUSTOM_TYPE, {
     source: "log.jsonl",
     messageCount: records.length,
     lastMessageId,
   });
-  forceRewriteSession(sessionManager, sessionFile);
 }
 
 interface HistoryWindow {
@@ -506,29 +502,29 @@ interface HistoryWindow {
   now: Date;
 }
 
-function syncSessionFromLog(
+async function syncSessionFromLog(
   sessionFile: string,
   sessionDir: string,
   cwd: string,
   records: LogRecord[],
   historyWindow: HistoryWindow,
-): void {
+): Promise<void> {
   if (records.length === 0) return;
-  syncSessionManagerFromLog(
+  await syncSessionManagerFromLog(
     openManagedSession(sessionFile, sessionDir, cwd),
     records,
     historyWindow,
   );
 }
 
-function syncSessionManagerFromLog(
-  sessionManager: SessionManager,
+async function syncSessionManagerFromLog(
+  session: Session,
   records: LogRecord[],
   historyWindow: HistoryWindow,
-): void {
+): Promise<void> {
   if (records.length === 0) return;
 
-  const existingEntries = sessionManager.getEntries();
+  const existingEntries = await session.getEntries();
   const lastSyncedMessageId = getLatestChatSyncMessageId(existingEntries);
   const lastSyncedIndex = lastSyncedMessageId
     ? records.findIndex((record) => record.message.ts === lastSyncedMessageId)
@@ -544,32 +540,22 @@ function syncSessionManagerFromLog(
   );
   if (newRecords.length === 0) return;
 
-  appendLogRecordsToSession(sessionManager, newRecords);
-  sessionManager.appendCustomEntry(CHAT_SYNC_CUSTOM_TYPE, {
+  await appendLogRecordsToSession(session, newRecords);
+  await session.appendCustomEntry(CHAT_SYNC_CUSTOM_TYPE, {
     source: "log.jsonl",
     messageCount: newRecords.length,
     lastMessageId: syncCandidates.at(-1)?.message.ts,
   });
 }
 
-function appendLogRecordsToSession(sessionManager: SessionManager, records: LogRecord[]): void {
+async function appendLogRecordsToSession(session: Session, records: LogRecord[]): Promise<void> {
   for (const record of records) {
     const message = buildHistorySessionMessage(record.message);
-    if (message) sessionManager.appendMessage(message);
+    if (message) await session.appendMessage(message);
   }
 }
 
-function forceRewriteSession(sessionManager: SessionManager, sessionFile: string): void {
-  const header = sessionManager.getHeader();
-  if (!header) return;
-
-  const content = [header, ...sessionManager.getEntries()]
-    .map((entry) => JSON.stringify(entry))
-    .join("\n");
-  atomicWritePrivateFile(sessionFile, `${content}\n`);
-}
-
-function getLatestChatSyncMessageId(entries: SessionEntry[]): string | undefined {
+function getLatestChatSyncMessageId(entries: SessionTreeEntry[]): string | undefined {
   for (let i = entries.length - 1; i >= 0; i--) {
     const entry = entries[i];
     if (entry.type !== "custom" || entry.customType !== CHAT_SYNC_CUSTOM_TYPE) continue;
@@ -579,7 +565,7 @@ function getLatestChatSyncMessageId(entries: SessionEntry[]): string | undefined
   return undefined;
 }
 
-function buildRepresentedMessageCounts(entries: SessionEntry[]): Map<string, number> {
+function buildRepresentedMessageCounts(entries: SessionTreeEntry[]): Map<string, number> {
   const counts = new Map<string, number>();
   for (const entry of entries) {
     const comparable = comparableSessionMessage(entry);
@@ -599,7 +585,7 @@ function consumeRepresentedLogMessage(record: LogRecord, counts: Map<string, num
   return true;
 }
 
-function comparableSessionMessage(entry: SessionEntry): string | null {
+function comparableSessionMessage(entry: SessionTreeEntry): string | null {
   if (entry.type !== "message") return null;
   const role = entry.message.role;
   if (role !== "user" && role !== "assistant") return null;
@@ -615,7 +601,7 @@ function comparableLogMessage(message: ConversationLogMessage): string | null {
   return `${message.isMessagingBot ? "assistant" : "user"}:${normalizeComparableText(text)}`;
 }
 
-function getSessionMessageText(entry: SessionEntry): string {
+function getSessionMessageText(entry: SessionTreeEntry): string {
   if (entry.type !== "message" || !("content" in entry.message)) return "";
   const content = entry.message.content;
   if (typeof content === "string") return content;
@@ -634,7 +620,7 @@ function normalizeComparableText(text: string): string {
     .trim();
 }
 
-function buildHistorySessionMessage(message: ConversationLogMessage): SessionAppendMessage | null {
+function buildHistorySessionMessage(message: ConversationLogMessage): AgentMessage | null {
   const text = message.text?.trim();
   if (!text) return null;
 
@@ -644,7 +630,7 @@ function buildHistorySessionMessage(message: ConversationLogMessage): SessionApp
       role: "user",
       content: [{ type: "text", text: formatHistoryMessage(message) }],
       ...(timestamp !== undefined ? { timestamp } : {}),
-    } as SessionAppendMessage;
+    } as AgentMessage;
   }
 
   return {
@@ -656,7 +642,7 @@ function buildHistorySessionMessage(message: ConversationLogMessage): SessionApp
     usage: zeroUsage(),
     stopReason: "stop",
     ...(timestamp !== undefined ? { timestamp } : {}),
-  } as SessionAppendMessage;
+  } as AgentMessage;
 }
 
 function buildThreadRootSeed(

--- a/src/sessions/metadata.ts
+++ b/src/sessions/metadata.ts
@@ -1,12 +1,7 @@
-import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { MikanSessionStorage } from "../harness/session-storage.js";
 export type { MikanSessionHeader } from "./types.js";
-import type { MikanSessionHeader } from "./types.js";
 
 export function isPlatformHistorySession(sessionFile: string): boolean {
-  try {
-    const header = SessionManager.open(sessionFile).getHeader() as MikanSessionHeader | null;
-    return header?.source?.kind === "platform-history";
-  } catch {
-    return false;
-  }
+  const header = MikanSessionStorage.peekHeader(sessionFile);
+  return header?.source?.kind === "platform-history";
 }

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "crypto";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { basename, dirname, join } from "path";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { Session } from "@earendil-works/pi-agent-core";
+import { MikanSessionStorage } from "../harness/session-storage.js";
 import { isRecord, parseJsonValue, readTextFileIfExists } from "../utils/file-guards.js";
 import { atomicWritePrivateFile } from "../utils/fs-atomic.js";
 import { isPlatformHistorySession } from "./metadata.js";
@@ -86,18 +87,14 @@ export function createManagedSessionFile(sessionDir: string, cwd: string): strin
 
 /**
  * Open a session file with an explicit cwd, even if the file does not exist yet.
- * This avoids SessionManager.open() falling back to process.cwd() for fresh sessions.
+ * This avoids falling back to process.cwd() for fresh sessions.
  */
-export function openManagedSession(
-  sessionFile: string,
-  sessionDir: string,
-  cwd: string,
-): SessionManager {
+export function openManagedSession(sessionFile: string, sessionDir: string, cwd: string): Session {
   if (shouldRecreatePreinitializedSession(sessionFile)) {
     rmSync(sessionFile, { force: true });
   }
 
-  return SessionManager.open(sessionFile, sessionDir, cwd);
+  return new Session(MikanSessionStorage.open(sessionFile, cwd));
 }
 
 function createSessionFilename(sessionId = randomUUID()): string {

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -64,7 +64,7 @@ export interface ResolveChatSessionScopeOptions {
 export interface SyncAgentMemoryFileManagerOptions {
   conversationDir: string;
   sessionKey: string;
-  sessionManager: import("@earendil-works/pi-coding-agent").SessionManager;
+  sessionManager: import("@earendil-works/pi-agent-core").Session;
   /** The triggering platform message ID. Excluded from sync to avoid duplicate user turns. */
   currentMessageId?: string;
 }

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -1,10 +1,9 @@
 import { completeSimple } from "@earendil-works/pi-ai/compat";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { join } from "path";
 import type { ConversationEvent } from "./adapter.js";
 import { loadAutoReplyJudgeModel, loadConversationAutoReplyConfig } from "./config.js";
+import { createMikanModels, getApiKeyAndHeaders } from "./harness/models.js";
 import * as log from "./log.js";
-import { homedir } from "os";
-import { join } from "path";
 import { resolveConfiguredModel } from "./model-registry.js";
 
 const JUDGE_TIMEOUT_MS = 10_000;
@@ -93,11 +92,9 @@ async function judgeAutoReplyWithLlm(input: {
   conversationDir: string;
 }): Promise<boolean> {
   const judgeConfig = loadAutoReplyJudgeModel(input.conversationDir);
-  const modelRegistry = ModelRegistry.create(
-    AuthStorage.create(join(homedir(), ".pi", "mikan", "auth.json")),
-  );
-  const model = resolveConfiguredModel(modelRegistry, judgeConfig.provider, judgeConfig.model);
-  const auth = await modelRegistry.getApiKeyAndHeaders(model);
+  const models = createMikanModels();
+  const model = resolveConfiguredModel(models, judgeConfig.provider, judgeConfig.model);
+  const auth = await getApiKeyAndHeaders(models, model);
   if (!auth.ok) {
     throw new Error(auth.error);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export interface MessagingEventHandler {
 // ── agent ─────────────────────────────────────────────────────────────────────
 
 export interface PiAgentWrapper {
-  syncChatHistory(currentMessageId?: string): void;
+  syncChatHistory(currentMessageId?: string): Promise<void>;
   run(
     message: ConversationMessage,
     responder: ConversationResponder,

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -1,9 +1,9 @@
 import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "fs";
 import type { IncomingMessage, ServerResponse } from "http";
-import { homedir } from "os";
 import { basename, join, resolve as pathResolve, sep as pathSep } from "path";
-import { AuthStorage, ModelRegistry, SessionManager } from "@earendil-works/pi-coding-agent";
 
+import { createMikanModels, getAvailableModels } from "../../harness/models.js";
+import { MikanSessionStorage } from "../../harness/session-storage.js";
 import {
   loadConversationAutoReplyConfig,
   loadGlobalSettings,
@@ -87,7 +87,7 @@ async function routeApiRequest(
       return;
     }
     if (url.pathname === "/admin/api/session-usage") {
-      serveSessionUsage(res, services);
+      await serveSessionUsage(res, services);
       return;
     }
     if (url.pathname === "/admin/api/conversation-state") {
@@ -331,50 +331,56 @@ interface SessionUsageRow {
   cost: number;
 }
 
-function serveSessionUsage(res: ServerResponse, services: AdminServices): void {
+async function serveSessionUsage(res: ServerResponse, services: AdminServices): Promise<void> {
   const workingDir = requireAdminWorkingDir(res, services);
   if (!workingDir) return;
 
-  const rows = listConversationDirs(workingDir)
-    .flatMap((conversationId) =>
-      listConversationSessionUsage(
-        workingDir,
-        conversationId,
-        conversationDisplayLabel(services, conversationId),
+  const rows = (
+    await Promise.all(
+      listConversationDirs(workingDir).map((conversationId) =>
+        listConversationSessionUsage(
+          workingDir,
+          conversationId,
+          conversationDisplayLabel(services, conversationId),
+        ),
       ),
     )
+  )
+    .flat()
     .toSorted((a, b) => b.total - a.total)
     .slice(0, 20);
 
   jsonRes(res, 200, { sessions: rows });
 }
 
-function listConversationSessionUsage(
+async function listConversationSessionUsage(
   workingDir: string,
   conversationId: string,
   label: string,
-): SessionUsageRow[] {
+): Promise<SessionUsageRow[]> {
   const sessionDir = join(workingDir, conversationId, "sessions");
   try {
-    return readdirSync(sessionDir, { withFileTypes: true })
-      .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
-      .flatMap((entry) => readSessionUsage(join(sessionDir, entry.name), conversationId, label));
+    const rows = await Promise.all(
+      readdirSync(sessionDir, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .map((entry) => readSessionUsage(join(sessionDir, entry.name), conversationId, label)),
+    );
+    return rows.flat();
   } catch {
     return [];
   }
 }
 
-function readSessionUsage(
+async function readSessionUsage(
   sessionFile: string,
   conversationId: string,
   label: string,
-): SessionUsageRow[] {
+): Promise<SessionUsageRow[]> {
   try {
-    const manager = SessionManager.open(sessionFile);
-    const header = manager.getHeader();
-    if (!header) return [];
+    const storage = MikanSessionStorage.openReadOnly(sessionFile);
+    const header = storage.getRawHeader();
 
-    const entries = manager.getEntries();
+    const entries = await storage.getEntries();
     const usage = entries.reduce(
       (sum, entry) => {
         if (entry.type !== "message" || entry.message.role !== "assistant") return sum;
@@ -488,10 +494,9 @@ function serveGlobalSettings(res: ServerResponse): void {
 
 async function serveModelsList(res: ServerResponse): Promise<void> {
   try {
-    const authStorage = AuthStorage.create(join(homedir(), ".pi", "mikan", "auth.json"));
-    const registry = ModelRegistry.create(authStorage);
-    const availableModels = await registry.getAvailable();
-    const statuses = await resolveAdminModelAccessStatuses(registry, availableModels);
+    const modelCatalog = createMikanModels();
+    const availableModels = await getAvailableModels(modelCatalog);
+    const statuses = await resolveAdminModelAccessStatuses(modelCatalog, availableModels);
     const models = availableModels.map((model) => ({
       provider: model.provider,
       id: model.id,

--- a/src/web/admin/provider-models.ts
+++ b/src/web/admin/provider-models.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
-import type { Api, Model } from "@earendil-works/pi-ai";
-import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { Api, Model, Models } from "@earendil-works/pi-ai";
+import { getApiKeyForProvider } from "../../harness/models.js";
 
 type AdminModelStatus = "available" | "unverified";
 
@@ -19,15 +19,15 @@ interface ProviderModelsCacheEntry {
 const providerModelsCache = new Map<string, ProviderModelsCacheEntry>();
 
 export async function resolveAdminModelAccessStatuses(
-  registry: ModelRegistry,
-  models: Model<Api>[],
+  models: Models,
+  modelList: Model<Api>[],
 ): Promise<Map<string, AdminModelAccessStatus>> {
   const result = new Map<string, AdminModelAccessStatus>();
-  const byProvider = groupModelsByProvider(models);
+  const byProvider = groupModelsByProvider(modelList);
 
   await Promise.all(
     [...byProvider.entries()].map(async ([provider, providerModels]) => {
-      const providerModelIds = await fetchProviderModelIds(registry, provider);
+      const providerModelIds = await fetchProviderModelIds(models, provider);
       for (const model of providerModels) {
         result.set(modelKey(model.provider, model.id), {
           status: modelIsListed(providerModelIds, model.id) ? "available" : "unverified",
@@ -54,12 +54,12 @@ function groupModelsByProvider(models: Model<Api>[]): Map<string, Model<Api>[]> 
 }
 
 async function fetchProviderModelIds(
-  registry: ModelRegistry,
+  models: Models,
   provider: string,
 ): Promise<Set<string> | undefined> {
   if (provider !== "openai" && provider !== "anthropic") return new Set<string>();
 
-  const apiKey = await registry.getApiKeyForProvider(provider);
+  const apiKey = await getApiKeyForProvider(models, provider);
   if (!apiKey) return new Set<string>();
 
   const cacheKey = `${provider}:${hashApiKey(apiKey)}`;

--- a/src/web/session-view/portal.ts
+++ b/src/web/session-view/portal.ts
@@ -155,7 +155,7 @@ export async function handleSessionViewRequest(
   }
 
   try {
-    const model = loadSessionViewModel(targetSessionFile);
+    const model = await loadSessionViewModel(targetSessionFile);
     const displayedSessionKey = resolveDisplayedSessionKey(entry, targetSessionFile);
     const isRunning = interactive?.handler.isRunning(displayedSessionKey) ?? false;
     res.writeHead(200, {
@@ -684,12 +684,12 @@ async function handleSessionMessageRequest(
 
   void interactive.handler
     .handleEvent(event, bot, context)
-    .then(() => {
+    .then(async () => {
       if (!targetSessionFile) {
         sessionViewStreamHub.publish(streamKey, { type: "status", running: false });
         return;
       }
-      const model = loadSessionViewModel(targetSessionFile);
+      const model = await loadSessionViewModel(targetSessionFile);
       sessionViewStreamHub.publish(streamKey, {
         type: "refresh",
         timelineHtml: renderTimelineItems(model.items, token),

--- a/src/web/session-view/service.ts
+++ b/src/web/session-view/service.ts
@@ -1,12 +1,12 @@
 import { basename, dirname, join, resolve } from "path";
 import { existsSync, readdirSync } from "fs";
-import {
-  SessionManager,
-  type BranchSummaryEntry as SessionBranchSummaryEntry,
-  type CompactionEntry,
-  type SessionEntry,
-  type SessionMessageEntry,
-} from "@earendil-works/pi-coding-agent";
+import type {
+  BranchSummaryEntry as SessionBranchSummaryEntry,
+  CompactionEntry,
+  MessageEntry as SessionMessageEntry,
+  SessionTreeEntry as SessionEntry,
+} from "@earendil-works/pi-agent-core";
+import { MikanSessionStorage } from "../../harness/session-storage.js";
 import {
   getThreadSessionFile,
   resolveChannelSessionFile,
@@ -30,22 +30,36 @@ export function resolveExistingSessionFile(
   return resolveChannelSessionFile(conversationDir);
 }
 
-export function loadSessionViewModel(sessionFile: string): SessionViewModel {
-  const resolvedFile = resolve(sessionFile);
-  const sm = SessionManager.open(resolvedFile);
-  const header = sm.getHeader();
-  if (!header) throw new Error(`No valid session found: ${sessionFile}`);
+function getSessionName(entries: SessionEntry[]): string | undefined {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.type !== "session_info") continue;
+    const name = entry.name?.trim();
+    if (name) return name;
+  }
+  return undefined;
+}
 
-  const entries = sm.getEntries();
+export async function loadSessionViewModel(sessionFile: string): Promise<SessionViewModel> {
+  const resolvedFile = resolve(sessionFile);
+  const storage = MikanSessionStorage.openReadOnly(resolvedFile);
+  const header = storage.getRawHeader();
+
+  const entries = await storage.getEntries();
   const updatedAt = entries.at(-1)?.timestamp ?? header.timestamp;
-  const title = sm.getSessionName() || `Session ${header.id.slice(0, 8)}`;
+  const title = getSessionName(entries) || `Session ${header.id.slice(0, 8)}`;
 
   const parent = header.parentSession
-    ? buildSessionRelation(resolve(header.parentSession), "parent")
-    : buildInferredThreadParentRelation(resolvedFile);
-  const threads = listRelatedSessionFiles(resolvedFile)
-    .filter((candidate) => candidate !== resolvedFile)
-    .map((candidate) => buildSessionRelation(candidate, "thread", resolvedFile))
+    ? await buildSessionRelation(resolve(header.parentSession), "parent")
+    : await buildInferredThreadParentRelation(resolvedFile);
+  const relatedFiles = listRelatedSessionFiles(resolvedFile).filter(
+    (candidate) => candidate !== resolvedFile,
+  );
+  const threads = (
+    await Promise.all(
+      relatedFiles.map((candidate) => buildSessionRelation(candidate, "thread", resolvedFile)),
+    )
+  )
     .filter((relation): relation is SessionViewRelation => relation !== null)
     .toSorted((a, b) => (a.updatedAt < b.updatedAt ? -1 : a.updatedAt > b.updatedAt ? 1 : 0));
 
@@ -98,20 +112,9 @@ export function resolveRequestedSessionFile(
   const candidate = join(dirname(resolvedBase), fileName);
   if (!existsSync(candidate)) return null;
 
-  let sm: SessionManager;
-  try {
-    sm = SessionManager.open(candidate);
-  } catch (err) {
-    throw new Error(
-      `Session file is corrupted: ${candidate}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      { cause: err },
-    );
-  }
-  if (!sm.getHeader()) {
-    throw new Error(`Session file is missing a valid header: ${candidate}`);
-  }
+  // Validates the file has a readable header; throws (surfaced to the caller)
+  // if the file is corrupted, without ever creating/rewriting it.
+  MikanSessionStorage.openReadOnly(candidate);
   return candidate;
 }
 
@@ -124,14 +127,14 @@ function listRelatedSessionFiles(sessionFile: string): string[] {
     .map((fileName) => join(dir, fileName));
 }
 
-function buildSessionRelation(
+async function buildSessionRelation(
   sessionFile: string,
   kind: "parent" | "thread",
   expectedParent?: string,
-): SessionViewRelation | null {
-  let sm: SessionManager;
+): Promise<SessionViewRelation | null> {
+  let storage: MikanSessionStorage;
   try {
-    sm = SessionManager.open(sessionFile);
+    storage = MikanSessionStorage.openReadOnly(sessionFile);
   } catch (err) {
     log.logWarning(
       `Skipping corrupted session file while building ${kind} relation: ${sessionFile}`,
@@ -139,32 +142,31 @@ function buildSessionRelation(
     );
     return null;
   }
-  const header = sm.getHeader();
-  if (!header) {
-    log.logWarning(
-      `Skipping session file with missing header while building ${kind} relation: ${sessionFile}`,
-    );
-    return null;
-  }
+  const header = storage.getRawHeader();
+
   if (
     kind === "thread" &&
-    !isChildThreadSession(sessionFile, header.parentSession, expectedParent)
+    !(await isChildThreadSession(sessionFile, header.parentSession, expectedParent))
   ) {
     return null;
   }
 
-  const entries = sm.getEntries();
+  const entries = await storage.getEntries();
   const updatedAt = entries.at(-1)?.timestamp ?? header.timestamp;
   const threadId = kind === "thread" ? getFixedThreadSessionId(sessionFile) : null;
   const anchorEntryId =
     kind === "thread" && expectedParent
-      ? findThreadAnchorEntryId(SessionManager.open(expectedParent).getEntries(), entries, threadId)
+      ? findThreadAnchorEntryId(
+          await MikanSessionStorage.openReadOnly(expectedParent).getEntries(),
+          entries,
+          threadId,
+        )
       : undefined;
   return {
     kind,
     fileName: basename(sessionFile),
     sessionId: header.id,
-    title: sm.getSessionName() || `Session ${header.id.slice(0, 8)}`,
+    title: getSessionName(entries) || `Session ${header.id.slice(0, 8)}`,
     updatedAt,
     entryCount: entries.length,
     summary: extractSessionSummary(entries),
@@ -172,20 +174,22 @@ function buildSessionRelation(
   };
 }
 
-function buildInferredThreadParentRelation(sessionFile: string): SessionViewRelation | undefined {
+async function buildInferredThreadParentRelation(
+  sessionFile: string,
+): Promise<SessionViewRelation | undefined> {
   if (!getFixedThreadSessionId(sessionFile)) return undefined;
 
   const parentSession = resolveChannelSessionFile(dirname(dirname(sessionFile)));
   if (!parentSession || parentSession === sessionFile) return undefined;
 
-  return buildSessionRelation(parentSession, "parent") ?? undefined;
+  return (await buildSessionRelation(parentSession, "parent")) ?? undefined;
 }
 
-function isChildThreadSession(
+async function isChildThreadSession(
   sessionFile: string,
   parentSession: string | undefined,
   expectedParent: string | undefined,
-): boolean {
+): Promise<boolean> {
   if (!expectedParent) return false;
 
   if (parentSession) {

--- a/test/chat-session-manager.test.ts
+++ b/test/chat-session-manager.test.ts
@@ -1,7 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   AgentMemoryFileManager,
@@ -35,18 +34,20 @@ function writeLog(entries: object[]): void {
   );
 }
 
-function readContextText(sessionFile: string): string {
-  const session = SessionManager.open(
+async function readContextText(sessionFile: string): Promise<string> {
+  const session = openManagedSession(
     sessionFile,
     getChannelSessionDir(conversationDir),
     conversationDir,
   );
-  return session
-    .buildSessionContext()
-    .messages.map((message) =>
-      typeof message.content === "string"
-        ? message.content
-        : message.content.map((part) => (part.type === "text" ? part.text : "")).join("\n"),
+  const context = await session.buildContext();
+  return context.messages
+    .map((message) =>
+      !("content" in message)
+        ? ""
+        : typeof message.content === "string"
+          ? message.content
+          : message.content.map((part) => (part.type === "text" ? part.text : "")).join("\n"),
     )
     .join("\n---\n");
 }
@@ -111,7 +112,7 @@ describe("AgentMemoryFileManager", () => {
       currentMessageId: "1000.0004",
     });
 
-    const text = readContextText(scope.contextFile);
+    const text = await readContextText(scope.contextFile);
     expect(text).toContain("recent question");
     expect(text).toContain("recent answer");
     expect(text).not.toContain("too old");
@@ -163,7 +164,7 @@ describe("AgentMemoryFileManager", () => {
       cwd: conversationDir,
     });
 
-    const text = readContextText(scope.contextFile);
+    const text = await readContextText(scope.contextFile);
     expect(text).toContain("question");
     expect(text).toContain("One two three");
     expect(countJsonlEntries(scope.contextFile, (entry) => entry.type === "message")).toBe(2);
@@ -221,7 +222,7 @@ describe("AgentMemoryFileManager", () => {
 
     expect(scope.contextFile).toBe(getThreadSessionFile(conversationDir, "C123:2000.0001"));
     expect(scope.threadRootMessage?.text).toBe("thread root");
-    const text = readContextText(scope.contextFile);
+    const text = await readContextText(scope.contextFile);
     expect(text).toContain("top-level context");
     expect(text).toContain("thread root");
     expect(text).toContain("thread bot reply");
@@ -300,7 +301,7 @@ describe("AgentMemoryFileManager", () => {
       currentMessageId: "1000.0007",
     });
 
-    const text = readContextText(scope.contextFile);
+    const text = await readContextText(scope.contextFile);
     expect(text).toContain("thread0");
     expect(text).toContain("thread1");
     expect(text).toContain("thread2");
@@ -394,12 +395,12 @@ describe("AgentMemoryFileManager", () => {
       firstScope.sessionDir,
       conversationDir,
     );
-    session.appendMessage({
+    await session.appendMessage({
       role: "user",
       content: [{ type: "text", text: "[2026-05-01 00:00:02+00:00] [alice]: next one is?" }],
       timestamp: 1,
     });
-    session.appendMessage({
+    await session.appendMessage({
       role: "assistant",
       content: [{ type: "text", text: "k2" }],
       api: "platform-history",
@@ -425,7 +426,7 @@ describe("AgentMemoryFileManager", () => {
       currentMessageId: "1000.0008",
     });
 
-    const text = readContextText(secondScope.contextFile);
+    const text = await readContextText(secondScope.contextFile);
     expect(text).toContain("k0");
     expect(text).toContain("k1");
     expect(text).toContain("k2");
@@ -502,7 +503,7 @@ describe("AgentMemoryFileManager", () => {
     });
 
     expect(secondScope.contextFile).toBe(firstScope.contextFile);
-    const text = readContextText(secondScope.contextFile);
+    const text = await readContextText(secondScope.contextFile);
     expect(text).toContain("seed");
     expect(text).not.toContain("sync0");
     expect(text).toContain("sync1");
@@ -550,7 +551,7 @@ describe("AgentMemoryFileManager", () => {
     });
 
     expect(secondScope.contextFile).toBe(firstScope.contextFile);
-    const text = readContextText(secondScope.contextFile);
+    const text = await readContextText(secondScope.contextFile);
     expect(text).toContain("seed");
     expect(text).not.toContain("would refill from start");
   });
@@ -596,12 +597,12 @@ describe("AgentMemoryFileManager", () => {
     });
 
     const session = openManagedSession(scope.contextFile, scope.sessionDir, conversationDir);
-    session.appendMessage({
+    await session.appendMessage({
       role: "user",
       content: [{ type: "text", text: "[alice]: current message" }],
       timestamp: 1,
     });
-    session.appendMessage({
+    await session.appendMessage({
       role: "assistant",
       content: [{ type: "text", text: "u2" }],
       api: "platform-history",
@@ -671,7 +672,7 @@ describe("AgentMemoryFileManager", () => {
     });
     const session = openManagedSession(scope.contextFile, scope.sessionDir, conversationDir);
 
-    manager.syncSessionManager({
+    await manager.syncSessionManager({
       conversationDir,
       sessionKey: "C123:2000.0001",
       sessionManager: session,

--- a/test/harness-extensions.test.ts
+++ b/test/harness-extensions.test.ts
@@ -1,0 +1,153 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Type } from "@sinclair/typebox";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  collectExtensionContributions,
+  loadMikanExtensions,
+  type ExtensionLoadResult,
+} from "../src/harness/extensions.js";
+import * as log from "../src/log.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = join(
+    tmpdir(),
+    `harness-extensions-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("loadMikanExtensions", () => {
+  test("returns empty result when the directory does not exist", async () => {
+    const result = await loadMikanExtensions(join(dir, "missing"));
+    expect(result.extensions).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("loads a well-formed extension exporting a default with a name", async () => {
+    writeFileSync(join(dir, "good.js"), `export default { name: "good-ext", tools: () => [] };\n`);
+
+    const result = await loadMikanExtensions(dir);
+    expect(result.errors).toEqual([]);
+    expect(result.extensions).toHaveLength(1);
+    expect(result.extensions[0].module.name).toBe("good-ext");
+  });
+
+  test("loads an extension from a directory's index.js", async () => {
+    mkdirSync(join(dir, "nested"), { recursive: true });
+    writeFileSync(join(dir, "nested", "index.js"), `export default { name: "nested-ext" };\n`);
+
+    const result = await loadMikanExtensions(dir);
+    expect(result.extensions).toHaveLength(1);
+    expect(result.extensions[0].module.name).toBe("nested-ext");
+  });
+
+  test("records an error for a module missing a name, without blocking other extensions", async () => {
+    writeFileSync(join(dir, "bad.js"), `export default { tools: () => [] };\n`);
+    writeFileSync(join(dir, "good.js"), `export default { name: "good-ext" };\n`);
+
+    const result = await loadMikanExtensions(dir);
+    expect(result.extensions).toHaveLength(1);
+    expect(result.extensions[0].module.name).toBe("good-ext");
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].path).toContain("bad.js");
+  });
+
+  test("records an error for a module that throws on import, without blocking other extensions", async () => {
+    writeFileSync(join(dir, "throws.js"), `throw new Error("boom during import");\n`);
+    writeFileSync(join(dir, "good.js"), `export default { name: "good-ext" };\n`);
+
+    const result = await loadMikanExtensions(dir);
+    expect(result.extensions).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].error).toContain("boom during import");
+  });
+});
+
+describe("collectExtensionContributions", () => {
+  test("collects tools contributed by a well-behaved extension", async () => {
+    const tool = {
+      name: "noop",
+      label: "noop",
+      description: "does nothing",
+      parameters: Type.Object({}),
+      execute: async (_toolCallId: string, _args: unknown, _signal?: AbortSignal) => ({
+        content: [{ type: "text" as const, text: "ok" }],
+        details: undefined,
+      }),
+    };
+    const result: ExtensionLoadResult = {
+      extensions: [{ path: "/x.js", module: { name: "x", tools: () => [tool] } }],
+      errors: [],
+    };
+
+    const collected = await collectExtensionContributions(result, { log });
+    expect(collected.tools).toHaveLength(1);
+    expect(collected.tools[0].name).toBe("noop");
+    expect(collected.commands).toEqual([]);
+  });
+
+  test("isolates a throwing tools() factory without affecting other extensions", async () => {
+    const goodTool = {
+      name: "noop",
+      label: "noop",
+      description: "does nothing",
+      parameters: Type.Object({}),
+      execute: async (_toolCallId: string, _args: unknown, _signal?: AbortSignal) => ({
+        content: [{ type: "text" as const, text: "ok" }],
+        details: undefined,
+      }),
+    };
+    const result: ExtensionLoadResult = {
+      extensions: [
+        {
+          path: "/broken.js",
+          module: {
+            name: "broken",
+            tools: () => {
+              throw new Error("factory exploded");
+            },
+          },
+        },
+        { path: "/good.js", module: { name: "good", tools: () => [goodTool] } },
+      ],
+      errors: [],
+    };
+
+    const collected = await collectExtensionContributions(result, { log });
+    expect(collected.tools).toHaveLength(1);
+    expect(collected.tools[0].name).toBe("noop");
+  });
+
+  test("wraps a throwing command handler so tryHandle() never throws", async () => {
+    const result: ExtensionLoadResult = {
+      extensions: [
+        {
+          path: "/cmd.js",
+          module: {
+            name: "cmd-ext",
+            commands: () => [
+              {
+                tryHandle: async () => {
+                  throw new Error("handler exploded");
+                },
+              },
+            ],
+          },
+        },
+      ],
+      errors: [],
+    };
+
+    const collected = await collectExtensionContributions(result, { log });
+    expect(collected.commands).toHaveLength(1);
+    await expect(collected.commands[0].tryHandle({} as never)).resolves.toBe(false);
+  });
+});

--- a/test/harness-session-storage.test.ts
+++ b/test/harness-session-storage.test.ts
@@ -1,0 +1,229 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { MikanSessionStorage } from "../src/harness/session-storage.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = join(
+    tmpdir(),
+    `harness-session-storage-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function sessionFile(): string {
+  return join(dir, "session.jsonl");
+}
+
+async function appendMessage(
+  storage: MikanSessionStorage,
+  role: "user" | "assistant",
+  text: string,
+): Promise<string> {
+  const id = await storage.createEntryId();
+  const parentId = await storage.getLeafId();
+  const entry: SessionTreeEntry = {
+    type: "message",
+    id,
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role,
+      content: [{ type: "text", text }],
+      timestamp: Date.now(),
+    } as never,
+  };
+  await storage.appendEntry(entry);
+  return id;
+}
+
+describe("MikanSessionStorage", () => {
+  test("create() writes a version:3 header immediately", async () => {
+    const file = sessionFile();
+    MikanSessionStorage.create(file, "/workspace");
+
+    const raw = readFileSync(file, "utf-8");
+    const lines = raw.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const header = JSON.parse(lines[0]);
+    expect(header).toMatchObject({ type: "session", version: 3, cwd: "/workspace" });
+    expect(typeof header.id).toBe("string");
+  });
+
+  test("appendEntry persists each entry as a JSON line and advances the leaf", async () => {
+    const file = sessionFile();
+    const storage = MikanSessionStorage.create(file, "/workspace");
+
+    const userId = await appendMessage(storage, "user", "hello");
+    expect(await storage.getLeafId()).toBe(userId);
+
+    const assistantId = await appendMessage(storage, "assistant", "hi there");
+    expect(await storage.getLeafId()).toBe(assistantId);
+
+    const entries = await storage.getEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].id).toBe(userId);
+    expect(entries[0].parentId).toBeNull();
+    expect(entries[1].parentId).toBe(userId);
+
+    // Re-read the raw file: header + 2 entries, one JSON object per line.
+    const lines = readFileSync(file, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(3);
+  });
+
+  test("re-opening an existing file reproduces identical bytes and state", async () => {
+    const file = sessionFile();
+    const first = MikanSessionStorage.create(file, "/workspace");
+    await appendMessage(first, "user", "hello");
+    await appendMessage(first, "assistant", "hi there");
+    const before = readFileSync(file, "utf-8");
+
+    const reopened = MikanSessionStorage.open(file, "/workspace");
+    expect(await reopened.getEntries()).toHaveLength(2);
+    expect(await reopened.getLeafId()).toBe((await first.getEntries()).at(-1)!.id);
+
+    // Reopening must not rewrite the file.
+    expect(readFileSync(file, "utf-8")).toBe(before);
+  });
+
+  test("getPathToRoot walks the parentId chain from leaf to root", async () => {
+    const file = sessionFile();
+    const storage = MikanSessionStorage.create(file, "/workspace");
+    const first = await appendMessage(storage, "user", "one");
+    const second = await appendMessage(storage, "assistant", "two");
+    const third = await appendMessage(storage, "user", "three");
+
+    const path = await storage.getPathToRoot(third);
+    expect(path.map((e) => e.id)).toEqual([first, second, third]);
+    expect(await storage.getPathToRoot(null)).toEqual([]);
+  });
+
+  test("getPathToRoot throws SessionError for an unknown leaf id", async () => {
+    const file = sessionFile();
+    const storage = MikanSessionStorage.create(file, "/workspace");
+    await expect(storage.getPathToRoot("missing")).rejects.toThrow(/not found/);
+  });
+
+  test("label entries are tracked and cleared via getLabel", async () => {
+    const file = sessionFile();
+    const storage = MikanSessionStorage.create(file, "/workspace");
+    const messageId = await appendMessage(storage, "user", "hello");
+
+    await storage.appendEntry({
+      type: "label",
+      id: await storage.createEntryId(),
+      parentId: await storage.getLeafId(),
+      timestamp: new Date().toISOString(),
+      targetId: messageId,
+      label: "important",
+    });
+    expect(await storage.getLabel(messageId)).toBe("important");
+
+    await storage.appendEntry({
+      type: "label",
+      id: await storage.createEntryId(),
+      parentId: await storage.getLeafId(),
+      timestamp: new Date().toISOString(),
+      targetId: messageId,
+      label: undefined,
+    });
+    expect(await storage.getLabel(messageId)).toBeUndefined();
+  });
+
+  test("findEntries filters by entry type", async () => {
+    const file = sessionFile();
+    const storage = MikanSessionStorage.create(file, "/workspace");
+    await appendMessage(storage, "user", "hello");
+    await storage.appendEntry({
+      type: "model_change",
+      id: await storage.createEntryId(),
+      parentId: await storage.getLeafId(),
+      timestamp: new Date().toISOString(),
+      provider: "anthropic",
+      modelId: "claude-3-5-haiku-latest",
+    });
+
+    expect(await storage.findEntries("message")).toHaveLength(1);
+    expect(await storage.findEntries("model_change")).toHaveLength(1);
+    expect(await storage.findEntries("compaction")).toHaveLength(0);
+  });
+
+  test("getRawHeader() exposes source.kind for platform-history detection", async () => {
+    const file = sessionFile();
+    const header = {
+      type: "session",
+      version: 3,
+      id: "abc12345",
+      timestamp: new Date().toISOString(),
+      cwd: "/workspace",
+      source: { kind: "platform-history" },
+    };
+    writeFileSync(file, `${JSON.stringify(header)}\n`);
+
+    const storage = MikanSessionStorage.open(file, "/workspace");
+    expect(storage.getRawHeader().source?.kind).toBe("platform-history");
+  });
+
+  test("a corrupted trailing entry line is skipped with a warning, not fatal", async () => {
+    const file = sessionFile();
+    const header = {
+      type: "session",
+      version: 3,
+      id: "abc12345",
+      timestamp: new Date().toISOString(),
+      cwd: "/workspace",
+    };
+    const goodEntry = {
+      type: "message",
+      id: "e1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: [{ type: "text", text: "hi" }], timestamp: 1 },
+    };
+    writeFileSync(
+      file,
+      `${JSON.stringify(header)}\n${JSON.stringify(goodEntry)}\nnot valid json\n`,
+    );
+
+    const storage = MikanSessionStorage.open(file, "/workspace");
+    const entries = await storage.getEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe("e1");
+  });
+
+  test("a missing/corrupted header falls back to starting a fresh session", async () => {
+    const file = sessionFile();
+    writeFileSync(file, "not a header at all\n");
+
+    const storage = MikanSessionStorage.open(file, "/workspace");
+    expect(await storage.getEntries()).toEqual([]);
+    expect(await storage.getLeafId()).toBeNull();
+
+    const header = JSON.parse(readFileSync(file, "utf-8").trim().split("\n")[0]);
+    expect(header.type).toBe("session");
+    expect(header.version).toBe(3);
+  });
+
+  test("entry ids from independently-created sessions never collide, even created in the same instant", async () => {
+    // Regression test: entry ids must not be derived from a truncated
+    // time-ordered id (e.g. uuidv7's leading bytes), since two unrelated
+    // session files created within the same millisecond would then get
+    // colliding first-entry ids, corrupting cross-session id matching
+    // (e.g. session-view's thread-anchor detection).
+    const storageA = MikanSessionStorage.create(join(dir, "a.jsonl"), "/workspace");
+    const storageB = MikanSessionStorage.create(join(dir, "b.jsonl"), "/workspace");
+
+    const idA = await appendMessage(storageA, "user", "hello from a");
+    const idB = await appendMessage(storageB, "user", "hello from b");
+
+    expect(idA).not.toBe(idB);
+  });
+});

--- a/test/model-registry.test.ts
+++ b/test/model-registry.test.ts
@@ -1,63 +1,22 @@
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { describe, expect, test } from "vitest";
 import { resolveConfiguredModel } from "../src/model-registry.js";
 
-function withTempRegistry(config: unknown): ModelRegistry {
-  const dir = mkdtempSync(join(tmpdir(), "mikan-model-registry-"));
-  writeFileSync(join(dir, "models.json"), JSON.stringify(config));
-  const authStorage = AuthStorage.create(join(dir, "auth.json"));
-  return ModelRegistry.create(authStorage, join(dir, "models.json"));
-}
-
 describe("resolveConfiguredModel", () => {
-  test("resolves custom models from models.json", () => {
-    const registry = withTempRegistry({
-      providers: {
-        "agent-model": {
-          api: "openai-completions",
-          apiKey: "dev",
-          baseUrl: "http://localhost:8080/v1",
-          compat: {
-            supportsDeveloperRole: false,
-            maxTokensField: "max_tokens",
-            supportsStore: false,
-          },
-          models: [
-            {
-              id: "claude-opus-4-7",
-              name: "Claude Opus 4.7",
-              input: ["text", "image"],
-              reasoning: true,
-            },
-          ],
-        },
-      },
-    });
+  test("resolves a known built-in model", () => {
+    const models = builtinModels();
 
-    const model = resolveConfiguredModel(registry, "agent-model", "claude-opus-4-7");
+    const model = resolveConfiguredModel(models, "anthropic", "claude-3-5-haiku-latest");
 
-    expect(model.provider).toBe("agent-model");
-    expect(model.id).toBe("claude-opus-4-7");
-    expect(model.api).toBe("openai-completions");
-    expect(model.baseUrl).toBe("http://localhost:8080/v1");
+    expect(model.provider).toBe("anthropic");
+    expect(model.id).toBe("claude-3-5-haiku-latest");
   });
 
   test("throws a clear error for unknown models", () => {
-    const dir = mkdtempSync(join(tmpdir(), "mikan-empty-model-registry-"));
-    try {
-      const registry = ModelRegistry.create(
-        AuthStorage.create(join(dir, "auth.json")),
-        join(dir, "models.json"),
-      );
+    const models = builtinModels();
 
-      expect(() => resolveConfiguredModel(registry, "missing", "model")).toThrow(
-        'Unknown model "missing/model"',
-      );
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    expect(() => resolveConfiguredModel(models, "missing", "model")).toThrow(
+      'Unknown model "missing/model"',
+    );
   });
 });

--- a/test/session-runtime.test.ts
+++ b/test/session-runtime.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { UserMessage } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { registerThreadSession } from "../src/sessions/agent-memory-file-manager.js";
 import { createConversationRuntime } from "../src/runtime/conversation-runtime.js";
@@ -52,12 +53,12 @@ function makeRuntime() {
   } as any);
 }
 
-function makeUserMessage(text: string) {
+function makeUserMessage(text: string): UserMessage {
   return {
     role: "user",
     content: [{ type: "text", text }],
     timestamp: 1,
-  } as const;
+  };
 }
 
 describe("ConversationRuntime chat session scope", () => {
@@ -65,7 +66,7 @@ describe("ConversationRuntime chat session scope", () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const channelFile = createManagedSessionFile(sessionDir, conversationDir);
     const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
-    channelSession.appendMessage(makeUserMessage("channel history should not leak"));
+    await channelSession.appendMessage(makeUserMessage("channel history should not leak"));
 
     const runtime = makeRuntime();
     registerThreadSession({

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -70,16 +70,16 @@ function countSessionHeaders(sessionFile: string): number {
     .filter((entry) => entry.type === "session").length;
 }
 
-function seedManagedSession(
+async function seedManagedSession(
   sessionFile: string,
   sessionDir: string,
   cwd: string,
   text: string,
-): string {
+): Promise<string> {
   createManagedSessionFileAtPath(sessionFile, cwd);
   const sessionManager = openManagedSession(sessionFile, sessionDir, cwd);
-  sessionManager.appendMessage(makeUserMessage(text));
-  sessionManager.appendMessage(makeAssistantMessage(`${text} reply`));
+  await sessionManager.appendMessage(makeUserMessage(text));
+  await sessionManager.appendMessage(makeAssistantMessage(`${text} reply`));
   return sessionFile;
 }
 
@@ -169,10 +169,10 @@ describe("tryResolveThreadSession", () => {
     expect(tryResolveThreadSession(threadFile)).toBeNull();
   });
 
-  test("returns fixed thread file path when a valid session exists", () => {
+  test("returns fixed thread file path when a valid session exists", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
-    const created = seedManagedSession(threadFile, sessionDir, channelDir, "thread msg");
+    const created = await seedManagedSession(threadFile, sessionDir, channelDir, "thread msg");
     expect(tryResolveThreadSession(threadFile)).toBe(created);
     expect(readFileSync(created, "utf-8")).toContain("thread msg");
   });
@@ -200,13 +200,13 @@ describe("managed session initialization", () => {
     expect(suffix).toMatch(/^[0-9a-f]{8}$/);
   });
 
-  test("creates a channel session with the provided cwd", () => {
+  test("creates a channel session with the provided cwd", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const sessionFile = resolveManagedSessionFile(sessionDir, channelDir);
     const sessionManager = openManagedSession(sessionFile, sessionDir, channelDir);
 
-    sessionManager.appendMessage(makeUserMessage("hello"));
-    sessionManager.appendMessage(makeAssistantMessage("hi"));
+    await sessionManager.appendMessage(makeUserMessage("hello"));
+    await sessionManager.appendMessage(makeAssistantMessage("hi"));
 
     const entries = readFileSync(sessionFile, "utf-8")
       .split("\n")
@@ -218,13 +218,13 @@ describe("managed session initialization", () => {
     expect(countSessionHeaders(sessionFile)).toBe(1);
   });
 
-  test("opens a missing managed session file with the provided cwd", () => {
+  test("opens a missing managed session file with the provided cwd", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const sessionFile = join(sessionDir, "missing.jsonl");
     const sessionManager = openManagedSession(sessionFile, sessionDir, channelDir);
 
-    sessionManager.appendMessage(makeUserMessage("hello"));
-    sessionManager.appendMessage(makeAssistantMessage("hi"));
+    await sessionManager.appendMessage(makeUserMessage("hello"));
+    await sessionManager.appendMessage(makeAssistantMessage("hi"));
 
     const entries = parseSessionEntries(sessionFile);
     const header = entries.find((entry) => entry.type === "session") as
@@ -261,14 +261,14 @@ describe("managed session initialization", () => {
     expect(readFileSync(liveFile, "utf-8")).not.toContain("platform-history");
   });
 
-  test("creates a fixed-path thread session with the provided cwd", () => {
+  test("creates a fixed-path thread session with the provided cwd", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
     const sessionManager = openManagedSession(threadFile, sessionDir, channelDir);
 
-    sessionManager.appendMessage(makeUserMessage("hello thread"));
-    sessionManager.appendMessage(makeAssistantMessage("thread reply"));
+    await sessionManager.appendMessage(makeUserMessage("hello thread"));
+    await sessionManager.appendMessage(makeAssistantMessage("thread reply"));
 
     const entries = readFileSync(threadFile, "utf-8")
       .split("\n")
@@ -282,43 +282,43 @@ describe("managed session initialization", () => {
 });
 
 describe("fixed thread sessions", () => {
-  test("thread session has a different session ID than channel session", () => {
+  test("thread session has a different session ID than channel session", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
     const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
-    channelSM.appendMessage(makeUserMessage("hello channel"));
-    channelSM.appendMessage(makeAssistantMessage("hi there"));
-    const channelSessionId = channelSM.getSessionId();
+    await channelSM.appendMessage(makeUserMessage("hello channel"));
+    await channelSM.appendMessage(makeAssistantMessage("hi there"));
+    const channelSessionId = (await channelSM.getMetadata()).id;
 
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
     const threadSM = openManagedSession(threadFile, sessionDir, channelDir);
-    threadSM.appendMessage(makeUserMessage("hello thread"));
-    threadSM.appendMessage(makeAssistantMessage("thread reply"));
+    await threadSM.appendMessage(makeUserMessage("hello thread"));
+    await threadSM.appendMessage(makeAssistantMessage("thread reply"));
 
-    expect(threadSM.getSessionId()).not.toBe(channelSessionId);
+    expect((await threadSM.getMetadata()).id).not.toBe(channelSessionId);
     expect(readFileSync(threadFile, "utf-8")).not.toContain("hello channel");
   });
 
-  test("second thread access reuses the same fixed thread file", () => {
+  test("second thread access reuses the same fixed thread file", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
     const threadSM = openManagedSession(threadFile, sessionDir, channelDir);
-    const threadSessionId = threadSM.getSessionId();
+    const threadSessionId = (await threadSM.getMetadata()).id;
 
-    threadSM.appendMessage(makeUserMessage("thread msg"));
-    threadSM.appendMessage(makeAssistantMessage("thread reply"));
+    await threadSM.appendMessage(makeUserMessage("thread msg"));
+    await threadSM.appendMessage(makeAssistantMessage("thread reply"));
 
     const existing = tryResolveThreadSession(threadFile);
     expect(existing).toBe(threadFile);
 
     const reopened = openManagedSession(existing!, sessionDir, channelDir);
-    expect(reopened.getSessionId()).toBe(threadSessionId);
+    expect((await reopened.getMetadata()).id).toBe(threadSessionId);
     expect(readFileSync(existing!, "utf-8")).toContain("thread msg");
   });
 
-  test("different threads get independent session IDs", () => {
+  test("different threads get independent session IDs", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
     const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
@@ -332,19 +332,20 @@ describe("fixed thread sessions", () => {
     const thread2SM = openManagedSession(thread2File, sessionDir, channelDir);
 
     const ids = new Set([
-      channelSM.getSessionId(),
-      thread1SM.getSessionId(),
-      thread2SM.getSessionId(),
+      (await channelSM.getMetadata()).id,
+      (await thread1SM.getMetadata()).id,
+      (await thread2SM.getMetadata()).id,
     ]);
     expect(ids.size).toBe(3);
   });
 
-  test("fresh thread file can be created without a channel source", () => {
+  test("fresh thread file can be created without a channel source", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
     const threadSM = openManagedSession(threadFile, sessionDir, channelDir);
-    const entries = threadSM.getEntries().filter((e: { type: string }) => e.type === "message");
+    const allEntries = await threadSM.getEntries();
+    const entries = allEntries.filter((e) => e.type === "message");
     expect(entries.length).toBe(0);
   });
 });
@@ -355,7 +356,7 @@ describe("top-level session rotation", () => {
     const oldFile = createManagedSessionFile(sessionDir, channelDir);
     rewriteSessionTimestamp(oldFile, "2026-01-05T12:00:00.000Z");
     const oldSession = openManagedSession(oldFile, sessionDir, channelDir);
-    oldSession.appendMessage(makeUserMessage("stale active context"));
+    await oldSession.appendMessage(makeUserMessage("stale active context"));
 
     appendLogMessage({
       ts: "1771027200.000000",
@@ -421,7 +422,7 @@ describe("top-level session rotation", () => {
   test("does not rotate thread sessions", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
-    seedManagedSession(threadFile, sessionDir, channelDir, "thread context");
+    await seedManagedSession(threadFile, sessionDir, channelDir, "thread context");
     rewriteSessionTimestamp(threadFile, "2026-01-05T12:00:00.000Z");
 
     const manager = new AgentMemoryFileManager({ now: () => new Date("2026-03-01T12:00:00.000Z") });
@@ -509,15 +510,15 @@ describe("top-level session rotation", () => {
 });
 
 describe("session-scoped /new reset", () => {
-  test("channel /new rotates channel current pointer and keeps thread session intact", () => {
+  test("channel /new rotates channel current pointer and keeps thread session intact", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = createManagedSessionFile(sessionDir, channelDir);
     const originalChannel = openManagedSession(channelFile, sessionDir, channelDir);
-    originalChannel.appendMessage(makeUserMessage("channel"));
-    originalChannel.appendMessage(makeAssistantMessage("channel reply"));
+    await originalChannel.appendMessage(makeUserMessage("channel"));
+    await originalChannel.appendMessage(makeAssistantMessage("channel reply"));
 
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
-    seedManagedSession(threadFile, sessionDir, channelDir, "thread");
+    await seedManagedSession(threadFile, sessionDir, channelDir, "thread");
 
     const newChannelFile = createManagedSessionFile(sessionDir, channelDir);
 
@@ -527,17 +528,17 @@ describe("session-scoped /new reset", () => {
     expect(readFileSync(threadFile, "utf-8")).toContain("thread");
   });
 
-  test("thread /new resets the same fixed file and keeps channel plus sibling thread intact", () => {
+  test("thread /new resets the same fixed file and keeps channel plus sibling thread intact", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = createManagedSessionFile(sessionDir, channelDir);
     const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
-    channelSM.appendMessage(makeUserMessage("channel"));
-    channelSM.appendMessage(makeAssistantMessage("channel reply"));
+    await channelSM.appendMessage(makeUserMessage("channel"));
+    await channelSM.appendMessage(makeAssistantMessage("channel reply"));
 
     const thread1File = getThreadSessionFile(channelDir, "C123:1000.0001");
     const thread2File = getThreadSessionFile(channelDir, "C123:1000.0002");
-    seedManagedSession(thread1File, sessionDir, channelDir, "thread1");
-    seedManagedSession(thread2File, sessionDir, channelDir, "thread2");
+    await seedManagedSession(thread1File, sessionDir, channelDir, "thread1");
+    await seedManagedSession(thread2File, sessionDir, channelDir, "thread2");
 
     createManagedSessionFileAtPath(thread1File, channelDir);
 
@@ -552,10 +553,10 @@ describe("session-scoped /new reset", () => {
 });
 
 describe("persistence across restart", () => {
-  test("thread session survives simulated restart via fixed file path", () => {
+  test("thread session survives simulated restart via fixed file path", async () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
-    seedManagedSession(threadFile, sessionDir, channelDir, "thread specific");
+    await seedManagedSession(threadFile, sessionDir, channelDir, "thread specific");
 
     expect(tryResolveThreadSession(threadFile)).toBe(threadFile);
     expect(readFileSync(threadFile, "utf-8")).toContain("thread specific");

--- a/test/session-view.test.ts
+++ b/test/session-view.test.ts
@@ -94,14 +94,14 @@ describe("resolveExistingSessionFile", () => {
 });
 
 describe("loadSessionViewModel", () => {
-  test("maps session entries into a readable timeline", () => {
+  test("maps session entries into a readable timeline", async () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const sessionFile = createManagedSessionFile(sessionDir, conversationDir);
     const sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
 
-    sessionManager.appendMessage(makeUserMessage("請幫我看一下測試結果"));
-    sessionManager.appendMessage(makeAssistantMessage("好的，我正在查看。"));
-    sessionManager.appendMessage({
+    await sessionManager.appendMessage(makeUserMessage("請幫我看一下測試結果"));
+    await sessionManager.appendMessage(makeAssistantMessage("好的，我正在查看。"));
+    await sessionManager.appendMessage({
       role: "bashExecution",
       command: "npm test",
       output: "1 passed",
@@ -111,7 +111,7 @@ describe("loadSessionViewModel", () => {
       timestamp: nextTimestamp++,
     } as any);
 
-    const model = loadSessionViewModel(sessionFile);
+    const model = await loadSessionViewModel(sessionFile);
 
     expect(model.title).toContain("Session");
     expect(model.items.map((item) => item.title)).toEqual(["User", "Assistant", "Bash execution"]);
@@ -122,12 +122,12 @@ describe("loadSessionViewModel", () => {
     expect(model.threads).toEqual([]);
   });
 
-  test("preserves assistant content block order and bash execution status details", () => {
+  test("preserves assistant content block order and bash execution status details", async () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const sessionFile = createManagedSessionFile(sessionDir, conversationDir);
     const sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
 
-    sessionManager.appendMessage({
+    await sessionManager.appendMessage({
       role: "assistant",
       content: [
         { type: "text", text: "before" },
@@ -148,7 +148,7 @@ describe("loadSessionViewModel", () => {
       stopReason: "stop",
       timestamp: nextTimestamp++,
     } as any);
-    sessionManager.appendMessage({
+    await sessionManager.appendMessage({
       role: "bashExecution",
       command: "npm test",
       output: "1 failed",
@@ -158,7 +158,7 @@ describe("loadSessionViewModel", () => {
       timestamp: nextTimestamp++,
     } as any);
 
-    const model = loadSessionViewModel(sessionFile);
+    const model = await loadSessionViewModel(sessionFile);
 
     expect(model.items[0]?.body).toBe('before\n\n[toolCall] search\n{\n  "q": "raw"\n}\n\nafter');
     expect(model.items[1]?.body).toContain("[exitCode] 1");
@@ -166,56 +166,56 @@ describe("loadSessionViewModel", () => {
     expect(model.items[1]?.body).toContain("[truncated] true");
   });
 
-  test("keeps channel and thread sessions on separate pages while linking them", () => {
+  test("keeps channel and thread sessions on separate pages while linking them", async () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const channelFile = createManagedSessionFile(sessionDir, conversationDir);
     const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
-    channelSession.appendMessage({
+    await channelSession.appendMessage({
       ...makeUserMessage("channel root"),
       timestamp: Number("1000.0001") * 1000,
     });
-    channelSession.appendMessage(makeAssistantMessage("channel reply"));
+    await channelSession.appendMessage(makeAssistantMessage("channel reply"));
 
     const threadFile = getThreadSessionFile(conversationDir, "D123:1000.0001");
     createManagedSessionFileAtPath(threadFile, conversationDir);
     const threadSession = openManagedSession(threadFile, sessionDir, conversationDir);
-    threadSession.appendMessage({
+    await threadSession.appendMessage({
       ...makeUserMessage("channel root"),
       timestamp: Number("1000.0001") * 1000,
     });
-    threadSession.appendMessage(makeUserMessage("thread only"));
-    threadSession.appendMessage(makeAssistantMessage("thread reply"));
+    await threadSession.appendMessage(makeUserMessage("thread only"));
+    await threadSession.appendMessage(makeAssistantMessage("thread reply"));
 
-    const channelModel = loadSessionViewModel(channelFile);
+    const channelModel = await loadSessionViewModel(channelFile);
     expect(channelModel.items.some((item) => item.body?.includes("thread only"))).toBe(false);
     expect(channelModel.threads).toHaveLength(1);
     expect(channelModel.threads[0]?.fileName).toBe(basename(threadFile));
     const rootItem = channelModel.items.find((item) => item.body?.includes("channel root"));
     expect(rootItem?.threads?.[0]?.fileName).toBe(basename(threadFile));
 
-    const threadModel = loadSessionViewModel(threadFile);
+    const threadModel = await loadSessionViewModel(threadFile);
     expect(threadModel.parent?.fileName).toBe(basename(channelFile));
     expect(threadModel.items.some((item) => item.body?.includes("thread only"))).toBe(true);
   });
 
-  test("anchors fixed thread links to the root instead of earlier bootstrap context", () => {
+  test("anchors fixed thread links to the root instead of earlier bootstrap context", async () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const channelFile = createManagedSessionFile(sessionDir, conversationDir);
     const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
-    channelSession.appendMessage({ ...makeUserMessage("prior context"), timestamp: 1 });
-    channelSession.appendMessage(makeAssistantMessage("prior reply"));
-    channelSession.appendMessage({ ...makeUserMessage("thread root"), timestamp: 2 });
-    channelSession.appendMessage(makeAssistantMessage("channel reply after root"));
+    await channelSession.appendMessage({ ...makeUserMessage("prior context"), timestamp: 1 });
+    await channelSession.appendMessage(makeAssistantMessage("prior reply"));
+    await channelSession.appendMessage({ ...makeUserMessage("thread root"), timestamp: 2 });
+    await channelSession.appendMessage(makeAssistantMessage("channel reply after root"));
 
     const threadFile = getThreadSessionFile(conversationDir, "D123:1000.0001");
     createManagedSessionFileAtPath(threadFile, conversationDir);
     const threadSession = openManagedSession(threadFile, sessionDir, conversationDir);
-    threadSession.appendMessage({ ...makeUserMessage("prior context"), timestamp: 1 });
-    threadSession.appendMessage(makeAssistantMessage("prior reply"));
-    threadSession.appendMessage({ ...makeUserMessage("thread root"), timestamp: 2 });
-    threadSession.appendMessage(makeAssistantMessage("thread reply"));
+    await threadSession.appendMessage({ ...makeUserMessage("prior context"), timestamp: 1 });
+    await threadSession.appendMessage(makeAssistantMessage("prior reply"));
+    await threadSession.appendMessage({ ...makeUserMessage("thread root"), timestamp: 2 });
+    await threadSession.appendMessage(makeAssistantMessage("thread reply"));
 
-    const channelModel = loadSessionViewModel(channelFile);
+    const channelModel = await loadSessionViewModel(channelFile);
     const contextItem = channelModel.items.find((item) => item.body?.includes("prior context"));
     const rootItem = channelModel.items.find((item) => item.body?.includes("thread root"));
 
@@ -223,24 +223,24 @@ describe("loadSessionViewModel", () => {
     expect(rootItem?.threads?.[0]?.fileName).toBe(basename(threadFile));
   });
 
-  test("anchors non-timestamp thread files by matching the root message", () => {
+  test("anchors non-timestamp thread files by matching the root message", async () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const channelFile = createManagedSessionFile(sessionDir, conversationDir);
     const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
-    channelSession.appendMessage(
+    await channelSession.appendMessage(
       makeUserMessage(
         "[2026-04-28 18:18:59+08:00] [alice]: first\n\n<slack_attachments>\n/tmp/a.txt\n</slack_attachments>",
       ),
     );
-    channelSession.appendMessage(makeAssistantMessage("first reply"));
+    await channelSession.appendMessage(makeAssistantMessage("first reply"));
 
     const threadFile = getThreadSessionFile(conversationDir, "D123:M1");
     createManagedSessionFileAtPath(threadFile, conversationDir);
     const threadSession = openManagedSession(threadFile, sessionDir, conversationDir);
-    threadSession.appendMessage(makeUserMessage("[alice]: first"));
-    threadSession.appendMessage(makeAssistantMessage("thread reply"));
+    await threadSession.appendMessage(makeUserMessage("[alice]: first"));
+    await threadSession.appendMessage(makeAssistantMessage("thread reply"));
 
-    const channelModel = loadSessionViewModel(channelFile);
+    const channelModel = await loadSessionViewModel(channelFile);
     const userAnchor = channelModel.items.find((item) => item.body?.includes("first"));
 
     expect(channelModel.threads).toHaveLength(1);


### PR DESCRIPTION
Removes the @earendil-works/pi-coding-agent dependency (a TUI/CLI coding-agent
package) and builds mikan's own headless harness directly on
@earendil-works/pi-agent-core and @earendil-works/pi-ai:

- src/harness/session-storage.ts: SessionStorage implementation byte-compatible
  with the existing on-disk .jsonl session format (no data migration needed)
- src/harness/credential-store.ts + models.ts: replace ModelRegistry/AuthStorage,
  reusing the same ~/.pi/mikan/auth.json schema
- src/harness/env.ts + skills.ts: execution env and skills loading
- src/harness/extensions.ts: new mikan-owned extension system — modules under
  ~/.pi/mikan/extensions/ can contribute AgentTools and chat CommandHandlers,
  with per-extension error isolation. Public contract re-exported from
  src/index.ts for extension authors.
- src/agent.ts: rewired onto AgentHarness, including a mikan-driven
  auto-compaction trigger (AgentHarness only exposes compact() as a primitive)

Also fixes a real bug found while validating anchor-matching in the session
viewer: entry ids were derived from uuidv7's millisecond-timestamp prefix,
which could collide across independently-created session files generated in
the same millisecond. Switched to full-entropy randomUUID().

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ENRAxPQpoi8BEqjW8uJPNy