### PR TITLE
feat(harness): mikan's own agent harness + extension system, replacing pi-coding-agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 Project: **mikan** (`@geminixiang/mikan`)
 
-mikan is a multi-platform AI coding agent for Slack, Telegram, and Discord. It stores chat logs and session state, runs the `pi-coding-agent` harness, and executes tools in host, Docker, Firecracker, or Cloudflare sandbox modes.
+mikan is a multi-platform AI coding agent for Slack, Telegram, and Discord. It stores chat logs and session state, runs mikan's own agent harness (`src/harness/`, built on `pi-agent-core` and `pi-ai`), and executes tools in host, Docker, Firecracker, or Cloudflare sandbox modes.
 
 Stack:
 
@@ -23,7 +23,8 @@ Stack:
   - `main.ts`: CLI entrypoint; parses args, loads settings, starts vault/sandbox/runtime/platform bots.
   - `types.ts`: root exported type definitions.
   - `adapter.ts`: platform-neutral bot/message/response interfaces.
-  - `agent.ts`: pi-coding-agent runner integration, prompt, tools, memory, sandbox, vault, response flow.
+  - `agent.ts`: agent runner integration, prompt, tools, memory, sandbox, vault, response flow.
+  - `harness/`: mikan's agent harness (session store, model catalog, run loop, skills, extension system) built on `pi-agent-core`/`pi-ai`.
   - `config.ts`: global and per-conversation settings.
   - `runtime/`: conversation/session orchestration.
   - `sessions/`: chat-history sync and persisted session files.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ mikan keeps the chat record, agent session, and execution runtime separate:
 ![mikan architecture](src/content/docs/assets/architecture.png)
 
 - **Chat / conversation data** is the platform-facing record: `log.jsonl`, attachments, and conversation files.
-- **Session orchestration** turns platform events into agent runs, handles top-level/thread scopes, and persists pi-coding-agent structured context under `sessions/*.jsonl`.
-- **pi-coding-agent harness** runs the model loop and calls mikan tools.
+- **Session orchestration** turns platform events into agent runs, handles top-level/thread scopes, and persists structured context under `sessions/*.jsonl`.
+- **mikan agent harness** (`src/harness/`, built on pi-agent-core and pi-ai) runs the model loop, session persistence, compaction, and calls mikan tools.
 - **Sandbox runtime** is where tool commands execute: host, Docker container/image, Firecracker, or Cloudflare bridge.
 - **Vault** provides runtime credentials as env vars and mounted secret files.
 

--- a/examples/extensions/agent-pm/README.md
+++ b/examples/extensions/agent-pm/README.md
@@ -1,0 +1,67 @@
+# agent-pm — mikan extension 範例
+
+一個 follow-up 追蹤器：單一 `index.mjs`（約 200 行）、零 npm 依賴
+（儲存用 Node 內建 `node:sqlite`），示範 extension v1 + v2 的完整介面。
+
+## 它做什麼
+
+- **`followup` 工具**（`registerTool`）：模型可 `add` / `list` / `done` /
+  `cancel` / `note` / `remind`，管理本會話的待辦追蹤項目。
+- **每回合自動注入**（`before_agent_start` hook）：把未結案項目附加到
+  system prompt，agent 每回合開場就知道有哪些 follow-up、哪些已逾期。
+- **每日逾期掃描**（v2 `api.schedules`）：activate 時登錄 cron 排程，
+  變成 mikan 的 event 檔——每天 09:00 觸發一次自主 agent run，沒人發話
+  也會主動追殺逾期項目。
+- **主動發訊**（v2 `api.notify`）：`remind` action 直接把清單貼進頻道，
+  不經過 agent 回覆。
+- **資料目錄**（v2 `api.paths.dataDir`）：sqlite 檔放在
+  `<stateDir>/extension-data/agent-pm/`，host-only、永不進 sandbox。
+- **manifest.json**（v2）：名稱／版本／描述。
+- **skills/**（v2）：`follow-up-triage` SKILL.md 隨 extension 出貨，
+  內容直接內嵌進 system prompt（sandbox 讀不到 host-only 路徑，
+  所以 extension skills 一律 inline）。
+
+## 安裝
+
+```sh
+# 所有會話生效
+cp -r agent-pm ~/.mikan/extensions/global/
+
+# 或只對單一會話生效
+cp -r agent-pm ~/.mikan/extensions/<conversationId>/
+```
+
+新的 harness instance 建立時會重新載入 extension（import 帶 cache-busting），
+編輯後不需重啟整個 mikan。
+
+## Secrets（本範例未用到，但可直接取用）
+
+若 extension 需要外部服務 token（例如同步到 Linear/GitHub），管理員把
+KEY=VALUE 寫進 `<stateDir>/vaults/extensions/agent-pm/env`，程式內以
+`api.secrets.get("LINEAR_TOKEN")` 讀取（唯讀）。
+
+## 使用情境
+
+```
+使用者: 記一下，vendor 報價要在週五前回覆
+agent:  (followup add "回覆 vendor 報價" due=2026-07-10) 好，已加入追蹤。
+
+-- 隔天 09:00，沒有任何人發話 --
+
+mikan:  (排程觸發自主 run → followup list → 發現逾期)
+        ⚠️ 「回覆 vendor 報價」已逾期（due 2026-07-10），請更新狀態。
+```
+
+## Extension API 覆蓋
+
+| 需求                       | 現況                                       |
+| -------------------------- | ------------------------------------------ |
+| 自訂工具                   | ✅ `registerTool`                          |
+| 每回合注入 context         | ✅ `before_agent_start`                    |
+| 會話範圍                   | ✅ `api.context.conversationId`            |
+| 定時主動提醒（無人發話時） | ✅ v2 `api.schedules`（cron / one-shot）   |
+| 主動發訊息到平台           | ✅ v2 `api.notify`                         |
+| 專屬資料目錄               | ✅ v2 `api.paths.dataDir`                  |
+| secrets                    | ✅ v2 `api.secrets`（vault env，唯讀）     |
+| 身分／版本                 | ✅ v2 `manifest.json`                      |
+| 隨附 skills                | ✅ v2 `skills/` 目錄（SKILL.md，自動內嵌） |

--- a/examples/extensions/agent-pm/index.mjs
+++ b/examples/extensions/agent-pm/index.mjs
@@ -1,0 +1,211 @@
+/**
+ * agent-pm — follow-up tracker as a mikan extension.
+ *
+ * Demonstrates the extension surface end to end:
+ *   v1  registerTool          `followup` tool the model calls to manage items
+ *   v1  before_agent_start    open items ride into every turn's system prompt
+ *   v2  api.paths.dataDir     sqlite file in the extension's host-only data dir
+ *   v2  api.schedules         daily overdue sweep as an autonomous agent run
+ *   v2  api.notify            immediate out-of-band reminder ("remind" action)
+ *   v2  manifest.json         name/version/description
+ *   v2  skills/               follow-up-triage SKILL.md, inlined into the prompt
+ *
+ * Zero npm dependencies: storage is node:sqlite (built into Node >= 22.5).
+ *
+ * Install (all conversations):
+ *   cp -r agent-pm ~/.mikan/extensions/global/
+ * Install (one conversation):
+ *   cp -r agent-pm ~/.mikan/extensions/<conversationId>/
+ */
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+function openDb(dataDir) {
+  const db = new DatabaseSync(join(dataDir, "agent-pm.db"));
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS followups (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      conversation_id TEXT NOT NULL,
+      title           TEXT NOT NULL,
+      note            TEXT,
+      due             TEXT,             -- YYYY-MM-DD, optional
+      status          TEXT NOT NULL DEFAULT 'open',  -- open | done | cancelled
+      created_at      TEXT NOT NULL,
+      closed_at       TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_followups_conv_status
+      ON followups (conversation_id, status);
+  `);
+  return db;
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function formatItem(row) {
+  const due = row.due
+    ? row.due < today()
+      ? ` (due ${row.due} — OVERDUE)`
+      : ` (due ${row.due})`
+    : "";
+  const note = row.note ? ` — ${row.note}` : "";
+  return `#${row.id} [${row.status}] ${row.title}${due}${note}`;
+}
+
+/** Plain JSON Schema — no typebox import needed inside an extension. */
+const followupSchema = {
+  type: "object",
+  properties: {
+    action: {
+      type: "string",
+      enum: ["add", "list", "done", "cancel", "note", "remind"],
+      description:
+        "add: create a follow-up · list: show items · done/cancel: close an item · " +
+        "note: append a note · remind: post open items to the channel right now",
+    },
+    title: { type: "string", description: "Item title (add)" },
+    due: { type: "string", description: "Due date YYYY-MM-DD (add, optional)" },
+    id: { type: "integer", description: "Item id (done / cancel / note)" },
+    note: { type: "string", description: "Note text (add optional, note required)" },
+    all: { type: "boolean", description: "list: include closed items (default open only)" },
+  },
+  required: ["action"],
+};
+
+export default async function activate(api) {
+  const db = openDb(api.paths.dataDir);
+  const conversationId = api.context.conversationId;
+
+  const openItems = () =>
+    db
+      .prepare(
+        `SELECT * FROM followups WHERE conversation_id = ? AND status = 'open'
+         ORDER BY due IS NULL, due, id`,
+      )
+      .all(conversationId);
+
+  api.registerTool({
+    name: "followup",
+    label: "Follow-ups",
+    description:
+      "Track follow-up items for this conversation: things promised, blocked, or to be revisited. " +
+      "Add an item whenever the user or you commit to a future action; close it when resolved.",
+    parameters: followupSchema,
+    execute: async (_toolCallId, params) => {
+      switch (params.action) {
+        case "add": {
+          if (!params.title) throw new Error("add requires title");
+          const { lastInsertRowid } = db
+            .prepare(
+              `INSERT INTO followups (conversation_id, title, note, due, created_at)
+               VALUES (?, ?, ?, ?, ?)`,
+            )
+            .run(
+              conversationId,
+              params.title,
+              params.note ?? null,
+              params.due ?? null,
+              new Date().toISOString(),
+            );
+          return {
+            content: [
+              { type: "text", text: `Added follow-up #${lastInsertRowid}: ${params.title}` },
+            ],
+            details: { id: Number(lastInsertRowid) },
+          };
+        }
+        case "list": {
+          const rows = params.all
+            ? db
+                .prepare(
+                  `SELECT * FROM followups WHERE conversation_id = ? ORDER BY status = 'open' DESC, due IS NULL, due, id`,
+                )
+                .all(conversationId)
+            : openItems();
+          const text = rows.length === 0 ? "No follow-ups." : rows.map(formatItem).join("\n");
+          return { content: [{ type: "text", text }], details: { count: rows.length } };
+        }
+        case "done":
+        case "cancel": {
+          if (params.id === undefined) throw new Error(`${params.action} requires id`);
+          const status = params.action === "done" ? "done" : "cancelled";
+          const { changes } = db
+            .prepare(
+              `UPDATE followups SET status = ?, closed_at = ? WHERE id = ? AND conversation_id = ? AND status = 'open'`,
+            )
+            .run(status, new Date().toISOString(), params.id, conversationId);
+          if (changes === 0)
+            throw new Error(`No open follow-up #${params.id} in this conversation`);
+          return {
+            content: [{ type: "text", text: `Follow-up #${params.id} marked ${status}.` }],
+            details: { id: params.id, status },
+          };
+        }
+        case "note": {
+          if (params.id === undefined || !params.note) throw new Error("note requires id and note");
+          const row = db
+            .prepare(`SELECT note FROM followups WHERE id = ? AND conversation_id = ?`)
+            .get(params.id, conversationId);
+          if (!row) throw new Error(`No follow-up #${params.id} in this conversation`);
+          const merged = row.note ? `${row.note}\n${params.note}` : params.note;
+          db.prepare(`UPDATE followups SET note = ? WHERE id = ?`).run(merged, params.id);
+          return {
+            content: [{ type: "text", text: `Note added to follow-up #${params.id}.` }],
+            details: { id: params.id },
+          };
+        }
+        case "remind": {
+          // v2: post directly to the channel, outside the agent's own reply.
+          const rows = openItems();
+          if (rows.length === 0) {
+            return { content: [{ type: "text", text: "No open follow-ups." }], details: {} };
+          }
+          await api.notify(`📌 Open follow-ups:\n${rows.map(formatItem).join("\n")}`);
+          return {
+            content: [{ type: "text", text: `Posted ${rows.length} open follow-up(s).` }],
+            details: { count: rows.length },
+          };
+        }
+        default:
+          throw new Error(`Unknown action: ${params.action}`);
+      }
+    },
+  });
+
+  // Every turn starts with the open items in the system prompt, so the agent
+  // can remind, chase, and close them without being asked.
+  api.on("before_agent_start", (event) => {
+    const rows = openItems();
+    if (rows.length === 0) return undefined;
+    const overdue = rows.filter((row) => row.due && row.due < today()).length;
+    const lines = rows.map(formatItem).join("\n");
+    return {
+      systemPrompt:
+        `${event.systemPrompt}\n\n## Open follow-ups (agent-pm)\n` +
+        `${rows.length} open${overdue > 0 ? `, ${overdue} OVERDUE` : ""} — proactively mention overdue items; ` +
+        `close finished ones with the followup tool.\n${lines}`,
+    };
+  });
+
+  // v2: daily sweep — an autonomous agent run fires even when nobody is
+  // talking, so overdue items get chased without a human prompt.
+  try {
+    await api.schedules.upsert("daily-overdue-sweep", {
+      type: "periodic",
+      schedule: "0 9 * * *",
+      timezone: "Asia/Taipei",
+      text:
+        "You are running a scheduled follow-up sweep. Call the followup tool " +
+        "(action: list). If any items are OVERDUE, post a short reminder that " +
+        "names each overdue item and asks for a status update. If nothing is " +
+        "overdue, do not post anything.",
+    });
+  } catch (err) {
+    // Outside mikan (or in a context without an event store) the sweep is
+    // simply unavailable; the tool and prompt injection still work.
+    api.log(`schedules unavailable, skipping daily sweep: ${err.message}`);
+  }
+
+  api.log(`agent-pm ready (${openItems().length} open follow-ups for ${conversationId})`);
+}

--- a/examples/extensions/agent-pm/manifest.json
+++ b/examples/extensions/agent-pm/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "agent-pm",
+  "version": "0.2.0",
+  "description": "Follow-up tracker: sqlite-backed items, daily overdue sweep, proactive reminders"
+}

--- a/examples/extensions/agent-pm/skills/follow-up-triage/SKILL.md
+++ b/examples/extensions/agent-pm/skills/follow-up-triage/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: follow-up-triage
+description: How to triage follow-up items when the user asks about status or priorities
+---
+
+When asked "what's outstanding" or for a status update:
+
+1. Call `followup list` first — never answer from memory.
+2. Lead with OVERDUE items, then items due within 3 days, then the rest.
+3. For each overdue item, propose one concrete next step, not just the title.
+4. Offer to close items that sound finished; confirm before `done`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "diff": "^9.0.0",
         "discord.js": "^14.26.4",
         "grammy": "^1.44.0",
-        "markdown-it": "^14.2.0"
+        "markdown-it": "^14.2.0",
+        "undici": "^8.5.0"
       },
       "bin": {
         "mikan": "dist/main.js"
@@ -1184,6 +1185,15 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@discordjs/util": {
@@ -6052,6 +6062,15 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/discord.js/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/dom-serializer": {
@@ -11015,12 +11034,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.80.2",
         "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-coding-agent": "^0.80.2",
         "@sentry/node": "^10.60.0",
         "@sinclair/typebox": "^0.34.49",
         "@slack/socket-mode": "^2.0.7",
@@ -182,9 +181,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -202,9 +198,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -222,9 +215,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -242,9 +232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,9 +973,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1002,9 +986,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1018,9 +999,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1034,9 +1012,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1300,1839 +1275,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.2.tgz",
-      "integrity": "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A==",
-      "hasShrinkwrap": true,
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.2",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
-        "@silvia-odwyer/photon-node": "0.3.4",
-        "chalk": "5.6.2",
-        "cross-spawn": "7.0.6",
-        "diff": "8.0.4",
-        "glob": "13.0.6",
-        "highlight.js": "10.7.3",
-        "hosted-git-info": "9.0.3",
-        "ignore": "7.0.5",
-        "jiti": "2.7.0",
-        "minimatch": "10.2.5",
-        "proper-lockfile": "4.1.2",
-        "semver": "7.8.0",
-        "typebox": "1.1.38",
-        "undici": "8.5.0",
-        "yaml": "2.9.0"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "0.3.9"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-node": "^3.972.42",
-        "@aws-sdk/eventstream-handler-node": "^3.972.16",
-        "@aws-sdk/middleware-eventstream": "^3.972.12",
-        "@aws-sdk/middleware-websocket": "^3.972.19",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
-      "version": "3.974.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
-      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
-      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
-      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
-      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-login": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
-      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
-      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-ini": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
-      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
-      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
-      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
-      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
-      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.2",
-        "ignore": "7.0.5",
-        "typebox": "1.1.38",
-        "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
-        "@smithy/node-http-handler": "4.7.3",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "./dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "1.6.0",
-        "marked": "18.0.5"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
-      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
-        "@mariozechner/clipboard-darwin-universal": "0.3.9",
-        "@mariozechner/clipboard-darwin-x64": "0.3.9",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
-      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
-      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
-      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
-      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
-      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
-      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
-      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
-      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
-      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
-      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
-      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3797,9 +1939,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3817,9 +1956,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3837,9 +1973,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3857,9 +1990,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3877,9 +2007,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3897,9 +2024,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3917,9 +2041,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3937,9 +2058,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3957,9 +2075,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3983,9 +2098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4009,9 +2121,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4035,9 +2144,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4061,9 +2167,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4087,9 +2190,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4113,9 +2213,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4139,9 +2236,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4596,9 +2690,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4616,9 +2707,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4636,9 +2724,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4656,9 +2741,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4676,9 +2758,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4696,9 +2775,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4716,9 +2792,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4736,9 +2809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4951,9 +3021,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4968,9 +3035,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4985,9 +3049,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5002,9 +3063,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5019,9 +3077,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5036,9 +3091,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5053,9 +3105,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5070,9 +3119,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5290,9 +3336,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5310,9 +3353,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5330,9 +3370,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5350,9 +3387,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5370,9 +3404,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5390,9 +3421,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5410,9 +3438,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5430,9 +3455,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5637,9 +3659,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5657,9 +3676,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5677,9 +3693,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5697,9 +3710,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5717,9 +3727,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5737,9 +3744,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5757,9 +3761,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5777,9 +3778,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6090,9 +4088,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6110,9 +4105,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6130,9 +4122,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6150,9 +4139,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6170,9 +4156,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6190,9 +4173,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9898,9 +7878,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9922,9 +7899,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9946,9 +7920,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9970,9 +7941,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "diff": "^9.0.0",
     "discord.js": "^14.26.4",
     "grammy": "^1.44.0",
-    "markdown-it": "^14.2.0"
+    "markdown-it": "^14.2.0",
+    "undici": "^8.5.0"
   },
   "devDependencies": {
     "@astrojs/mdx": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "@earendil-works/pi-agent-core": "^0.80.2",
     "@earendil-works/pi-ai": "^0.80.2",
-    "@earendil-works/pi-coding-agent": "^0.80.2",
     "@sentry/node": "^10.60.0",
     "@sinclair/typebox": "^0.34.49",
     "@slack/socket-mode": "^2.0.7",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -10,5 +10,6 @@ export type {
   ConversationKind,
   MessagingInfo,
   PlatformName,
+  PlatformNotifier,
   RunningSession,
 } from "./types.js";

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -3,6 +3,8 @@ import { type Api, type ImageContent, type Model } from "@earendil-works/pi-ai";
 import {
   DEFAULT_EVENT_BUDGET,
   defaultExtensionDirs,
+  type ExtensionHostServices,
+  type ExtensionSchedulePayload,
   formatSkillsForPrompt,
   loadExtensions,
   loadSkillsFromDir,
@@ -21,7 +23,7 @@ import type {
   MessagingInfo,
   PlatformName,
 } from "./adapter.js";
-import type { AgentEventPayload } from "./types.js";
+import type { AgentEventPayload, MikanEvent, PlatformNotifier } from "./types.js";
 import type { SessionViewTokenStoreLike } from "./commands/types.js";
 import { resolveConversationSettings } from "./config.js";
 import { readEnv } from "./utils/env.js";
@@ -49,6 +51,7 @@ import {
   type ResolvedSessionScope,
   type ThreadRootMessage,
 } from "./sessions/store.js";
+import { HostEventStore } from "./tools/event.js";
 import { createMikanTools } from "./tools/index.js";
 import * as Sentry from "@sentry/node";
 import { formatLocalTimestamp } from "./utils/date.js";
@@ -466,6 +469,8 @@ interface PreparedRunContext {
 
 interface ConfiguredAgentSession {
   session: MikanAgentSession;
+  /** Skills contributed by extensions, merged into each run's system prompt. */
+  extensionSkills: MikanSkill[];
 }
 
 function createRunnerExecutionContext(
@@ -512,6 +517,55 @@ function createRunnerExecutionContext(
   };
 }
 
+/**
+ * Extension host services over mikan's runtime infrastructure: schedules
+ * become event files under `<workspaceDir>/events` (picked up live by
+ * EventsWatcher), secrets come from `vaults/extensions/<slug>/env`, and
+ * notify posts through the platform bots when main.ts provides a notifier.
+ */
+function buildExtensionHostServices(params: {
+  workspaceDir: string;
+  vaultManager?: VaultManager;
+  platformNotifier?: PlatformNotifier;
+}): ExtensionHostServices {
+  const { workspaceDir, vaultManager, platformNotifier } = params;
+  const eventStore = HostEventStore.fromWorkspaceDir(workspaceDir);
+  return {
+    stateDir: readEnv("STATE_DIR"),
+    scheduleStore: {
+      write: async (filename, payload) => {
+        // Event files tolerate a missing platform (single-platform default),
+        // so the harness payload is a valid event payload as written.
+        await eventStore.write(filename, payload as unknown as MikanEvent);
+      },
+      delete: async (filename) => (await eventStore.delete(filename)).deleted,
+      list: async () =>
+        (await eventStore.list()).map((entry) => ({
+          filename: entry.filename,
+          payload: entry.payload as unknown as ExtensionSchedulePayload,
+        })),
+    },
+    ...(platformNotifier ? { postMessage: platformNotifier } : {}),
+    ...(vaultManager
+      ? {
+          resolveSecrets: (slug: string) => vaultManager.resolve(`extensions/${slug}`)?.env ?? {},
+        }
+      : {}),
+  };
+}
+
+/**
+ * Local (workspace/conversation) skills override extension skills on name
+ * collision: an admin's on-disk skill always beats an extension's.
+ */
+function mergeExtensionSkills(local: MikanSkill[], extension: MikanSkill[]): MikanSkill[] {
+  if (extension.length === 0) return local;
+  const byName = new Map<string, MikanSkill>();
+  for (const skill of extension) byName.set(skill.name, skill);
+  for (const skill of local) byName.set(skill.name, skill);
+  return [...byName.values()];
+}
+
 async function createConfiguredAgentSession(params: {
   conversationId: string;
   workspaceDir: string;
@@ -521,6 +575,8 @@ async function createConfiguredAgentSession(params: {
   tools: Awaited<ReturnType<typeof createMikanTools>>["tools"];
   sessionStore: SessionStore;
   models: MikanModels;
+  vaultManager?: VaultManager;
+  platformNotifier?: PlatformNotifier;
 }): Promise<ConfiguredAgentSession> {
   const {
     conversationId,
@@ -531,6 +587,8 @@ async function createConfiguredAgentSession(params: {
     tools,
     sessionStore,
     models,
+    vaultManager,
+    platformNotifier,
   } = params;
 
   // Host-only dirs under the state dir: extension code runs in the mikan
@@ -539,6 +597,7 @@ async function createConfiguredAgentSession(params: {
   const extensionsResult = await loadExtensions({
     dirs: defaultExtensionDirs(conversationId, readEnv("STATE_DIR")),
     context: { conversationId, workspaceDir, model, thinkingLevel },
+    services: buildExtensionHostServices({ workspaceDir, vaultManager, platformNotifier }),
   });
   for (const err of extensionsResult.errors) {
     log.logWarning(`[${conversationId}] Extension load error: ${err.path}`, err.error);
@@ -563,7 +622,7 @@ async function createConfiguredAgentSession(params: {
   if (reloaded > 0) {
     log.logInfo(`[${conversationId}] Reloaded ${reloaded} messages from session context`);
   }
-  return { session };
+  return { session, extensionSkills: extensionsResult.skills };
 }
 
 function createEmptyUsageTotals() {
@@ -994,6 +1053,7 @@ async function prepareRunContext(params: {
   resolveExecutorForRun: RunnerExecutionContext["resolveExecutorForRun"];
   getPathContext: () => RuntimePathContext;
   session: MikanAgentSession;
+  extensionSkills?: MikanSkill[];
   setEventContext: (context: {
     platform: string;
     conversationId: string;
@@ -1038,7 +1098,10 @@ async function prepareRunContext(params: {
   reloadSessionMessages(session, conversationId);
 
   const memory = await getMemory(conversationDir);
-  const skills = loadMikanSkills(conversationDir, pathContext.runtimeWorkspaceRoot);
+  const skills = mergeExtensionSkills(
+    loadMikanSkills(conversationDir, pathContext.runtimeWorkspaceRoot),
+    params.extensionSkills ?? [],
+  );
   const triggerAttribution = resolveTriggerAttribution(message);
   const systemPrompt = buildSystemPrompt(
     pathContext.runtimeWorkspaceRoot,
@@ -1470,6 +1533,7 @@ export async function createRunner(
     tokenStore: SessionViewTokenStoreLike;
     portalBaseUrl?: string;
   },
+  platformNotifier?: PlatformNotifier,
 ): Promise<PiAgentWrapper> {
   const agentConfig = resolveConversationSettings(conversationDir);
 
@@ -1530,7 +1594,7 @@ export async function createRunner(
 
   const sessionUuid = extractSessionUuid(contextFile);
   const chatSessionManager = new AgentMemoryFileManager();
-  const { session } = await createConfiguredAgentSession({
+  const { session, extensionSkills } = await createConfiguredAgentSession({
     conversationId,
     workspaceDir,
     systemPrompt,
@@ -1539,6 +1603,8 @@ export async function createRunner(
     tools,
     sessionStore: sessionManager,
     models: modelRegistry,
+    vaultManager,
+    platformNotifier,
   });
 
   // Mutable per-run state - event handler references this
@@ -1573,6 +1639,7 @@ export async function createRunner(
         resolveExecutorForRun,
         getPathContext,
         session,
+        extensionSkills,
         setEventContext,
         setSandboxContext,
         setUploadFunction,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,6 +1,7 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { type Api, type ImageContent, type Model } from "@earendil-works/pi-ai";
 import {
+  DEFAULT_EVENT_BUDGET,
   defaultExtensionDirs,
   formatSkillsForPrompt,
   loadExtensions,
@@ -212,8 +213,6 @@ function buildSystemPrompt(
   sandboxConfig: SandboxConfig,
   platform: MessagingInfo,
   skills: MikanSkill[],
-  isEventTrigger = false,
-  triggerAttribution?: string,
 ): string {
   const { workspaceRoot, conversationPath, scratchPath } = buildRuntimePaths(
     workspacePath,
@@ -236,25 +235,11 @@ function buildSystemPrompt(
       : "(no users loaded)";
 
   const envDescription = buildEnvDescription(sandboxType, workspaceRoot);
-  const eventTriggerInstructions = isEventTrigger
-    ? `
-## Event Trigger Mode
-- You are handling a scheduled/background event, not opening a brand new chat with a stranger.
-- Treat the incoming user message as a self-contained task prepared by an earlier run.
-- Complete the task directly. Avoid generic greetings, self-introductions, or boilerplate offers to help.
-- For reminders/follow-ups, prefer a short direct response that sounds like a continuation of prior intent.
-- If the event text includes tone, brevity, or language instructions, follow them literally.
-`
-    : "";
-  const attributionInstructions = triggerAttribution
-    ? `
-## Attribution
-Always end your final ${platform.name} response and any GitHub issue/PR comments or descriptions you write via tools with:
-_Triggered by ${triggerAttribution}_
-
-Do not add this to \`[SILENT]\` responses.
-`
-    : "";
+  // Per-turn instructions (event-trigger mode, attribution) are delivered with
+  // the user message via buildTurnInstructions(), not baked in here, so this
+  // system prompt stays byte-stable across a conversation's turns and keeps the
+  // provider prompt cache warm (a changing system prefix invalidates the cache
+  // for the whole request, including the far larger conversation history).
   const slackBlockKitInstructions =
     platform.name === "slack"
       ? `
@@ -275,7 +260,6 @@ Do not add this to \`[SILENT]\` responses.
 - Scoped/thread sessions use fixed files at \`${conversationPath}/sessions/<scope_id>.jsonl\` (for example \`${conversationPath}/sessions/1777386320.800769.jsonl\`).
 - If a user asks about something that should exist in conversation history but is not found in the current context window, do not answer "I don't know" or "I don't have that". Instead, search the thread session, top-level session, and \`log.jsonl\` before responding.
 - User messages include a \`[in-thread:TS]\` marker when sent from within a platform thread/reply (TS is the thread or parent message identifier). Without this marker, the message is a top-level conversation message.
-${eventTriggerInstructions}
 ${platform.formattingGuide}${slackBlockKitInstructions}
 
 ## Platform IDs
@@ -363,7 +347,6 @@ Format: \`{"date":"...","ts":"...","user":"...","userName":"...","text":"...","i
 The log contains user messages and your final responses (not tool calls/results).
 Use \`log.jsonl\` for quick grep-style history. Use \`${conversationPath}/sessions/\` when you need structured turns, tool outputs, or thread/session lineage.
 ${isContainerLike || isFirecracker ? "Install jq: apt-get install jq" : ""}
-${attributionInstructions}
 \`\`\`bash
 # Recent messages
 tail -30 log.jsonl | jq -c '{date: .date[0:19], user: (.userName // .user), text}'
@@ -390,6 +373,37 @@ ls -1 sessions/
 
 Each tool requires a "label" parameter (shown to user).
 `;
+}
+
+/**
+ * Instructions that vary per turn (event-trigger mode, response attribution).
+ * These are delivered with the user message rather than baked into the system
+ * prompt, so the system prompt stays cache-stable across a conversation's turns
+ * (in a multi-user channel the attribution line alone changes every turn).
+ * Returns an empty string when the turn needs no special framing.
+ */
+export function buildTurnInstructions(
+  isEventTrigger: boolean,
+  triggerAttribution: string | undefined,
+  platformName: string,
+): string {
+  const parts: string[] = [];
+  if (isEventTrigger) {
+    parts.push(`## Event Trigger Mode
+- You are handling a scheduled/background event, not opening a brand new chat with a stranger.
+- Treat the incoming user message as a self-contained task prepared by an earlier run.
+- Complete the task directly. Avoid generic greetings, self-introductions, or boilerplate offers to help.
+- For reminders/follow-ups, prefer a short direct response that sounds like a continuation of prior intent.
+- If the event text includes tone, brevity, or language instructions, follow them literally.`);
+  }
+  if (triggerAttribution) {
+    parts.push(`## Attribution
+Always end your final ${platformName} response and any GitHub issue/PR comments or descriptions you write via tools with:
+_Triggered by ${triggerAttribution}_
+
+Do not add this to \`[SILENT]\` responses.`);
+  }
+  return parts.join("\n\n");
 }
 
 export function getUnresolvedSandboxPathContext(
@@ -1035,8 +1049,6 @@ async function prepareRunContext(params: {
     executor.getSandboxConfig(),
     platform,
     skills,
-    message.id.startsWith("event:"),
-    triggerAttribution,
   );
   session.agent.state.systemPrompt = systemPrompt;
 
@@ -1074,18 +1086,24 @@ async function prepareRunContext(params: {
     pathContext.runtimeWorkspaceRoot,
     pathContext,
   );
+  const turnInstructions = buildTurnInstructions(
+    message.id.startsWith("event:"),
+    triggerAttribution,
+    platform.name,
+  );
+  const finalUserMessage = turnInstructions ? `${turnInstructions}\n\n${userMessage}` : userMessage;
   await writePromptDebugContext(
     conversationDir,
     systemPrompt,
     session,
-    userMessage,
+    finalUserMessage,
     imageAttachments.length,
   );
 
   return {
     sessionConversation,
     runQueue,
-    userMessage,
+    userMessage: finalUserMessage,
     imageAttachments,
     triggerAttribution,
     pathContext,
@@ -1389,6 +1407,20 @@ function attachSessionEventHandlers(params: {
       });
       queue.enqueue(() => responder.respond(text), "retry");
     }
+
+    if (event.type === "budget_exceeded") {
+      log.logWarning(
+        "Run stopped by budget circuit breaker",
+        `${event.reason} (tokens=${event.tokens}, cost=${event.costUsd.toFixed(2)}, calls=${event.llmCalls}, ${event.durationMs}ms)`,
+      );
+      const text = `_Stopped: run budget exceeded (${event.reason})_`;
+      sendAgentEvent({
+        sessionId: agentEventSessionId,
+        actorName: formatAgentActorName(logCtx.userName, logCtx.conversationId),
+        event: { kind: "diagnostic", text },
+      });
+      queue.enqueue(() => responder.respondDiagnostic(text, { style: "error" }), "budget exceeded");
+    }
   });
 }
 
@@ -1572,10 +1604,13 @@ export async function createRunner(
         event: { kind: "sessionStart" },
       });
 
-      await session.prompt(
-        prepared.userMessage,
-        prepared.imageAttachments.length > 0 ? { images: prepared.imageAttachments } : undefined,
-      );
+      // Autonomous (event/trigger) runs get an explicit resource ceiling since
+      // no human is watching the loop; interactive turns stay human-gated.
+      const isEventRun = message.id.startsWith("event:");
+      await session.prompt(prepared.userMessage, {
+        ...(prepared.imageAttachments.length > 0 ? { images: prepared.imageAttachments } : {}),
+        ...(isEventRun ? { budget: DEFAULT_EVENT_BUDGET } : {}),
+      });
 
       // Wait for queued messages
       await prepared.runQueue.wait();

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -13,6 +13,7 @@ import {
   type MikanSkill,
   type SessionStore,
 } from "./harness/index.js";
+import { createHash } from "crypto";
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join, posix } from "path";
@@ -1114,6 +1115,13 @@ async function prepareRunContext(params: {
     skills,
   );
   session.agent.state.systemPrompt = systemPrompt;
+  // Cache diagnosis: a byte-stable system prompt is the precondition for
+  // provider prompt caching. If this hash changes between turns of one
+  // conversation, something turn-varying leaked into the prompt; if it is
+  // stable and cacheRead stays 0, the miss is provider-side (e.g. OpenRouter
+  // routing the model across upstream hosts).
+  const promptHash = createHash("sha256").update(systemPrompt).digest("hex").slice(0, 8);
+  log.logInfo(`[${conversationId}] System prompt: ${systemPrompt.length} chars, sha ${promptHash}`);
 
   setEventContext({
     platform: platform.name,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,21 +1,16 @@
-import { Agent, type ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { type Api, type ImageContent, type Model } from "@earendil-works/pi-ai";
 import {
-  AgentSession,
-  AuthStorage,
-  convertToLlm,
-  DefaultResourceLoader,
   formatSkillsForPrompt,
-  getAgentDir,
+  loadExtensions,
   loadSkillsFromDir,
-  ModelRegistry,
-  SessionManager,
-  SettingsManager,
-  type Skill,
-} from "@earendil-works/pi-coding-agent";
+  MikanAgentSession,
+  MikanModels,
+  type MikanSkill,
+  type SessionStore,
+} from "./harness/index.js";
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
-import { homedir } from "os";
 import { join, posix } from "path";
 import type {
   ConversationMessage,
@@ -115,8 +110,8 @@ async function getMemory(conversationDir: string): Promise<string> {
   return parts.join("\n\n");
 }
 
-function loadMikanSkills(conversationDir: string, workspacePath: string): Skill[] {
-  const skillMap = new Map<string, Skill>();
+function loadMikanSkills(conversationDir: string, workspacePath: string): MikanSkill[] {
+  const skillMap = new Map<string, MikanSkill>();
 
   // conversationDir is the host path (e.g., /Users/.../data/C0A34FL8PMH)
   // hostWorkspacePath is the parent directory on host
@@ -214,7 +209,7 @@ function buildSystemPrompt(
   memory: string,
   sandboxConfig: SandboxConfig,
   platform: MessagingInfo,
-  skills: Skill[],
+  skills: MikanSkill[],
   isEventTrigger = false,
   triggerAttribution?: string,
 ): string {
@@ -454,8 +449,7 @@ interface PreparedRunContext {
 }
 
 interface ConfiguredAgentSession {
-  agent: Agent;
-  session: AgentSession;
+  session: MikanAgentSession;
 }
 
 function createRunnerExecutionContext(
@@ -504,86 +498,55 @@ function createRunnerExecutionContext(
 
 async function createConfiguredAgentSession(params: {
   conversationId: string;
+  conversationDir: string;
   workspaceDir: string;
-  runtimeWorkspaceRoot: string;
   systemPrompt: string;
   model: Model<Api>;
   thinkingLevel: ThinkingLevel;
   tools: Awaited<ReturnType<typeof createMikanTools>>["tools"];
-  sessionManager: SessionManager;
-  settingsManager: SettingsManager;
-  modelRegistry: ModelRegistry;
+  sessionStore: SessionStore;
+  models: MikanModels;
 }): Promise<ConfiguredAgentSession> {
   const {
     conversationId,
+    conversationDir,
     workspaceDir,
-    runtimeWorkspaceRoot,
     systemPrompt,
     model,
     thinkingLevel,
     tools,
-    sessionManager,
-    settingsManager,
-    modelRegistry,
+    sessionStore,
+    models,
   } = params;
-  const agent = new Agent({
-    initialState: {
-      systemPrompt,
-      model,
-      thinkingLevel,
-      tools,
-    },
-    convertToLlm,
-    getApiKey: async (provider) => {
-      const key = await modelRegistry.getApiKeyForProvider(provider);
-      if (!key) {
-        throw new Error(
-          `No API key for provider "${provider}". Set the appropriate environment variable or configure via auth.json`,
-        );
-      }
-      return key;
-    },
-  });
 
-  const loadedSession = sessionManager.buildSessionContext();
-  if (loadedSession.messages.length > 0) {
-    agent.state.messages = loadedSession.messages;
+  const extensionsResult = await loadExtensions({
+    dirs: [join(conversationDir, "..", "extensions"), join(conversationDir, "extensions")],
+    context: { conversationId, workspaceDir, model, thinkingLevel },
+  });
+  for (const err of extensionsResult.errors) {
+    log.logWarning(`[${conversationId}] Extension load error: ${err.path}`, err.error);
+  }
+  if (extensionsResult.extensions.length > 0) {
     log.logInfo(
-      `[${conversationId}] Reloaded ${loadedSession.messages.length} messages from session context`,
+      `[${conversationId}] Loaded ${extensionsResult.extensions.length} extension(s): ${extensionsResult.extensions.map((extension) => extension.name).join(", ")}`,
     );
   }
 
-  const resourceLoader = new DefaultResourceLoader({
-    cwd: workspaceDir,
-    agentDir: getAgentDir(),
+  const session = new MikanAgentSession({
     systemPrompt,
+    model,
+    thinkingLevel,
+    tools,
+    models,
+    sessionStore,
+    extensions: extensionsResult.registry,
   });
-  try {
-    await resourceLoader.reload();
-    const extResult = resourceLoader.getExtensions();
-    if (extResult.errors.length > 0) {
-      for (const err of extResult.errors) {
-        log.logWarning(`[${conversationId}] Extension load error: ${err.path}`, err.error);
-      }
-    }
-    log.logInfo(
-      `[${conversationId}] Loaded ${extResult.extensions.length} extension(s): ${extResult.extensions.map((extension) => extension.path).join(", ")}`,
-    );
-  } catch (error) {
-    log.logWarning(`[${conversationId}] Failed to load resources`, String(error));
-  }
 
-  const baseToolsOverride = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
-  const session = new AgentSession({
-    agent,
-    sessionManager,
-    settingsManager,
-    cwd: runtimeWorkspaceRoot,
-    modelRegistry,
-    resourceLoader,
-    baseToolsOverride,
-  });
-  return { agent, session };
+  const reloaded = session.reloadFromSession();
+  if (reloaded > 0) {
+    log.logInfo(`[${conversationId}] Reloaded ${reloaded} messages from session context`);
+  }
+  return { session };
 }
 
 function createEmptyUsageTotals() {
@@ -732,7 +695,7 @@ export function buildPromptPayload(
 async function writePromptDebugContext(
   conversationDir: string,
   systemPrompt: string,
-  session: AgentSession,
+  session: MikanAgentSession,
   userMessage: string,
   imageAttachmentCount: number,
 ): Promise<void> {
@@ -748,7 +711,7 @@ async function writePromptDebugContext(
   );
 }
 
-function getFinalAssistantText(session: AgentSession): string {
+function getFinalAssistantText(session: MikanAgentSession): string {
   const lastAssistant = session.messages.findLast((message) => message.role === "assistant");
   return (
     lastAssistant?.content
@@ -809,7 +772,7 @@ async function replaceResponseWithToolProgress(
 
 async function finalizeRunResponse(
   responder: ConversationResponder,
-  session: AgentSession,
+  session: MikanAgentSession,
   runState: RunnerSessionState,
   options?: {
     triggerAttribution?: string;
@@ -911,7 +874,7 @@ async function finalizeRunResponse(
 }
 
 interface UsageReportContext {
-  session: AgentSession;
+  session: MikanAgentSession;
   runState: RunnerSessionState;
   responder: ConversationResponder;
   platform: MessagingInfo;
@@ -994,15 +957,10 @@ async function reportUsageSummary(ctx: UsageReportContext): Promise<void> {
   }
 }
 
-function reloadSessionMessages(
-  sessionManager: SessionManager,
-  conversationId: string,
-  agent: Agent,
-): void {
-  const messages = sessionManager.buildSessionContext().messages;
-  if (messages.length > 0) {
-    agent.state.messages = messages;
-    log.logInfo(`[${conversationId}] Reloaded ${messages.length} messages from context`);
+function reloadSessionMessages(session: MikanAgentSession, conversationId: string): void {
+  const reloaded = session.reloadFromSession();
+  if (reloaded > 0) {
+    log.logInfo(`[${conversationId}] Reloaded ${reloaded} messages from context`);
   }
 }
 
@@ -1018,9 +976,7 @@ async function prepareRunContext(params: {
   executionResolver?: ActorExecutionResolver;
   resolveExecutorForRun: RunnerExecutionContext["resolveExecutorForRun"];
   getPathContext: () => RuntimePathContext;
-  sessionManager: SessionManager;
-  session: AgentSession;
-  agent: Agent;
+  session: MikanAgentSession;
   setEventContext: (context: {
     platform: string;
     conversationId: string;
@@ -1043,9 +999,7 @@ async function prepareRunContext(params: {
     executionResolver,
     resolveExecutorForRun,
     getPathContext,
-    sessionManager,
     session,
-    agent,
     setEventContext,
     setSandboxContext,
     setUploadFunction,
@@ -1064,7 +1018,7 @@ async function prepareRunContext(params: {
     pathContext = getPathContext();
   }
 
-  reloadSessionMessages(sessionManager, conversationId, agent);
+  reloadSessionMessages(session, conversationId);
 
   const memory = await getMemory(conversationDir);
   const skills = loadMikanSkills(conversationDir, pathContext.runtimeWorkspaceRoot);
@@ -1149,7 +1103,7 @@ function sendAgentEvent(payload: {
 
 // ponytail: additive SSE mirror only; keep responder rendering here until another frontend needs the same stream.
 function attachSessionEventHandlers(params: {
-  session: AgentSession;
+  session: MikanAgentSession;
   runState: RunnerSessionState;
   model: Model<Api>;
   agentConfig: ReturnType<typeof resolveConversationSettings>;
@@ -1502,8 +1456,10 @@ export async function createRunner(
     { sandbox: sandboxConfig, provisioner },
   );
 
-  const authStorage = AuthStorage.create(join(homedir(), ".pi", "mikan", "auth.json"));
-  const modelRegistry = ModelRegistry.create(authStorage);
+  const modelRegistry = MikanModels.create();
+  if (modelRegistry.getError()) {
+    log.logWarning("models.json load error", modelRegistry.getError()!);
+  }
   const model = resolveConfiguredModel(modelRegistry, agentConfig.provider, agentConfig.model);
 
   // Initial system prompt (will be updated each run with fresh memory/channels/users/skills)
@@ -1530,12 +1486,8 @@ export async function createRunner(
   // use the conversation's current pointer; scoped sessions use fixed files.
   // Platform-specific scope behavior is resolved before runner creation.
   const isThread = sessionKey.includes(":");
-  const { sessionDir, contextFile, threadRootMessage } = sessionScope;
-  const sessionManager = openManagedSession(
-    contextFile,
-    sessionDir,
-    pathContext.runtimeWorkspaceRoot,
-  );
+  const { contextFile, threadRootMessage } = sessionScope;
+  const sessionManager = openManagedSession(contextFile, pathContext.runtimeWorkspaceRoot);
   const threadSessionName = buildThreadSessionName(threadRootMessage);
   if (isThread && threadSessionName && sessionManager.getSessionName() !== threadSessionName) {
     sessionManager.appendSessionInfo(threadSessionName);
@@ -1543,18 +1495,16 @@ export async function createRunner(
 
   const sessionUuid = extractSessionUuid(contextFile);
   const chatSessionManager = new AgentMemoryFileManager();
-  const settingsManager = SettingsManager.inMemory();
-  const { agent, session } = await createConfiguredAgentSession({
+  const { session } = await createConfiguredAgentSession({
     conversationId,
+    conversationDir,
     workspaceDir,
-    runtimeWorkspaceRoot: pathContext.runtimeWorkspaceRoot,
     systemPrompt,
     model,
     thinkingLevel: agentConfig.thinkingLevel,
     tools,
-    sessionManager,
-    settingsManager,
-    modelRegistry,
+    sessionStore: sessionManager,
+    models: modelRegistry,
   });
 
   // Mutable per-run state - event handler references this
@@ -1588,9 +1538,7 @@ export async function createRunner(
         executionResolver,
         resolveExecutorForRun,
         getPathContext,
-        sessionManager,
         session,
-        agent,
         setEventContext,
         setSandboxContext,
         setUploadFunction,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,6 +1,7 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { type Api, type ImageContent, type Model } from "@earendil-works/pi-ai";
 import {
+  defaultExtensionDirs,
   formatSkillsForPrompt,
   loadExtensions,
   loadSkillsFromDir,
@@ -22,6 +23,7 @@ import type {
 import type { AgentEventPayload } from "./types.js";
 import type { SessionViewTokenStoreLike } from "./commands/types.js";
 import { resolveConversationSettings } from "./config.js";
+import { readEnv } from "./utils/env.js";
 import { ActorExecutionResolver } from "./execution-resolver.js";
 import * as log from "./log.js";
 import { reportUserFacingError } from "./observability/sentry.js";
@@ -498,7 +500,6 @@ function createRunnerExecutionContext(
 
 async function createConfiguredAgentSession(params: {
   conversationId: string;
-  conversationDir: string;
   workspaceDir: string;
   systemPrompt: string;
   model: Model<Api>;
@@ -509,7 +510,6 @@ async function createConfiguredAgentSession(params: {
 }): Promise<ConfiguredAgentSession> {
   const {
     conversationId,
-    conversationDir,
     workspaceDir,
     systemPrompt,
     model,
@@ -519,8 +519,11 @@ async function createConfiguredAgentSession(params: {
     models,
   } = params;
 
+  // Host-only dirs under the state dir: extension code runs in the mikan
+  // process, so it must never load from workspace paths — those are mounted
+  // into sandbox containers and agent-writable (sandbox escape otherwise).
   const extensionsResult = await loadExtensions({
-    dirs: [join(conversationDir, "..", "extensions"), join(conversationDir, "extensions")],
+    dirs: defaultExtensionDirs(conversationId, readEnv("STATE_DIR")),
     context: { conversationId, workspaceDir, model, thinkingLevel },
   });
   for (const err of extensionsResult.errors) {
@@ -1497,7 +1500,6 @@ export async function createRunner(
   const chatSessionManager = new AgentMemoryFileManager();
   const { session } = await createConfiguredAgentSession({
     conversationId,
-    conversationDir,
     workspaceDir,
     systemPrompt,
     model,

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ThinkingLevel as PiAiThinkingLevel } from "@earendil-works/pi-ai";
-import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { MikanModels } from "../harness/index.js";
 import { join } from "path";
 import { resolveConversationSettings, updateConversationSettings } from "../config.js";
 import { matchCommand } from "./parse.js";
@@ -69,7 +69,7 @@ function formatModelSpec(provider: string, model: string, thinkingLevel?: Thinki
 }
 
 export class ModelCommandHandler implements CommandHandler {
-  constructor(private readonly modelRegistry: ModelRegistry) {}
+  constructor(private readonly modelRegistry: MikanModels) {}
   async tryHandle(context: CommandContext): Promise<boolean> {
     const parsed = parseModelCommand(context.commandText);
     if (!parsed) return false;

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,6 +1,4 @@
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
-import { homedir } from "os";
-import { join } from "path";
+import { MikanModels } from "../harness/index.js";
 import { AdminCommandHandler } from "./admin.js";
 import { AutoReplyCommandHandler } from "./auto-reply.js";
 import { LoginCommandHandler } from "./login.js";
@@ -11,8 +9,7 @@ import { SessionViewCommandHandler } from "./session-view.js";
 import type { CommandContext, CommandHandler } from "./types.js";
 
 export function defaultCommandHandlers(): CommandHandler[] {
-  const authStorage = AuthStorage.create(join(homedir(), ".pi", "mikan", "auth.json"));
-  const modelRegistry = ModelRegistry.create(authStorage);
+  const modelRegistry = MikanModels.create();
   return [
     new AdminCommandHandler(),
     new LoginCommandHandler(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,12 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { Type, type Static } from "@sinclair/typebox";
-import { existsSync, readFileSync, renameSync } from "fs";
+import { existsSync, readFileSync, renameSync, rmSync } from "fs";
 import { homedir } from "os";
-import { dirname, join, resolve } from "path";
+import { basename, dirname, join, resolve } from "path";
 import { readEnv } from "./utils/env.js";
 import { ensureDirExists, readJsonSchemaFileIfExists } from "./utils/file-guards.js";
 import { atomicWritePrivateFile } from "./utils/fs-atomic.js";
+import * as log from "./log.js";
 
 export class MissingGlobalSettingsError extends Error {
   constructor(public readonly settingsPath: string) {
@@ -206,10 +207,56 @@ export function loadGlobalSettings(): AgentConfig {
   return toAgentConfig(loadRawGlobalSettings());
 }
 
+/**
+ * Host-authoritative location of a conversation's settings file:
+ * `<stateDir>/conversations/<conversationId>/settings.json`.
+ *
+ * Conversation settings used to live at `<conversationDir>/settings.json`,
+ * but conversation dirs are bind-mounted read-write into sandbox containers
+ * in image mode — code inside the sandbox could edit its own settings.json
+ * and flip `sandbox.image.workspaceMount` to "full", remounting the entire
+ * workspace into its container (cross-conversation access). Settings are an
+ * administrator surface, so they live under the host-only state dir.
+ *
+ * Migration: on first access per conversation, a legacy
+ * `<conversationDir>/settings.json` is moved here. The new file's existence
+ * (an empty `{}` is written when there is nothing to migrate) is the
+ * migration marker — a legacy file (re)appearing later, e.g. planted from
+ * inside the sandbox, is never read again.
+ */
+export function conversationSettingsPath(conversationDir: string): string {
+  const conversationId = basename(resolve(conversationDir));
+  const hostPath = join(getStateDir(), "conversations", conversationId, "settings.json");
+  if (existsSync(hostPath)) return hostPath;
+
+  ensureDirExists(dirname(hostPath));
+  const legacyPath = join(conversationDir, "settings.json");
+  let content = "{}\n";
+  let migrated = false;
+  if (existsSync(legacyPath)) {
+    try {
+      content = readFileSync(legacyPath, "utf-8");
+      migrated = true;
+    } catch (err) {
+      log.logWarning(`Could not read legacy conversation settings: ${legacyPath}`, String(err));
+    }
+  }
+  atomicWritePrivateFile(hostPath, content);
+  if (migrated) {
+    try {
+      rmSync(legacyPath);
+    } catch (err) {
+      log.logWarning(`Could not remove legacy conversation settings: ${legacyPath}`, String(err));
+    }
+    log.logInfo(`Migrated conversation settings to host-only path: ${hostPath}`);
+  }
+  return hostPath;
+}
+
 export function resolveConversationSettings(conversationDir: string): AgentConfig {
   const globalConfig = loadRawGlobalSettings();
   const conversationConfig = normalizeSettingsConfig(
-    loadSettingsFile(join(conversationDir, "settings.json")) ?? {},
+    loadSettingsFile(conversationSettingsPath(conversationDir)) ?? {},
   );
   return toAgentConfig({ ...globalConfig, ...conversationConfig });
 }
@@ -224,7 +271,7 @@ export function resolveConversationSettings(conversationDir: string): AgentConfi
 export function loadAutoReplyJudgeModel(conversationDir?: string): JudgeModelConfig {
   const global = requireGlobalSettings();
   const local = conversationDir
-    ? (loadSettingsFile(join(conversationDir, "settings.json")) ?? {})
+    ? (loadSettingsFile(conversationSettingsPath(conversationDir)) ?? {})
     : {};
   const merged: SettingsFileConfig["llm"] = { ...global.llm, ...local.llm };
   const judge = { ...global.llm?.autoReply, ...local.llm?.autoReply };
@@ -328,6 +375,42 @@ export function resolveStateDirFromArgv(args = process.argv.slice(2)): string {
   }
 
   return join(homedir(), ".mikan");
+}
+
+/**
+ * True when `child` is `parent` or a path inside it. Purely lexical (no
+ * symlink resolution) — used for configuration sanity checks, not as the
+ * final security boundary.
+ */
+export function isPathInside(child: string, parent: string): boolean {
+  const parentPath = resolve(parent);
+  const childPath = resolve(child);
+  return childPath === parentPath || childPath.startsWith(parentPath + "/");
+}
+
+/**
+ * The state dir (extensions code, extension data, vaults, auth.json) must
+ * never live inside the working dir: conversation opt-in "full" mode mounts
+ * the entire working dir read-write into sandbox containers, and a mounted
+ * state dir would let sandboxed code plant extension modules that the host
+ * process later imports — a sandbox escape. Fatal under sandboxed modes;
+ * host mode has no mounts, so only warn about the bad hygiene.
+ */
+export function assertStateDirOutsideWorkspace(
+  stateDir: string,
+  workingDir: string,
+  sandboxType: string,
+): void {
+  if (!isPathInside(stateDir, workingDir)) return;
+  const message =
+    `--state-dir (${stateDir}) must not be inside the working directory (${workingDir}): ` +
+    `sandbox containers mount the working directory, and a mounted state dir ` +
+    `would expose extensions, vaults, and credentials to sandboxed code.`;
+  if (sandboxType === "host") {
+    log.logWarning("Insecure state dir location", message);
+    return;
+  }
+  throw new Error(message);
 }
 
 export function resolveSentryDsn(): string | undefined {
@@ -458,5 +541,5 @@ export function updateConversationSettings(
   conversationDir: string,
   patch: Partial<AgentConfig>,
 ): void {
-  updateSettingsFile(join(conversationDir, "settings.json"), patch, {});
+  updateSettingsFile(conversationSettingsPath(conversationDir), patch, {});
 }

--- a/src/content/docs/architecture.md
+++ b/src/content/docs/architecture.md
@@ -44,6 +44,7 @@ Responsibilities:
 ### C. Agent execution layer
 
 - `src/agent.ts`
+- `src/harness/*`
 - `src/context.ts`
 - `src/tools/*`
 
@@ -51,7 +52,7 @@ Responsibilities:
 
 - create `PiAgentWrapper`
 - load model, skills, memory, and session context
-- send user messages into `pi-agent-core` / `pi-coding-agent`
+- send user messages into mikan's own agent harness (`src/harness/`, built on `pi-agent-core` / `pi-ai`), which runs the turn loop with auto-compaction, auto-retry, and extension hooks
 - connect tool calls to local `read/bash/edit/write/event/attach`
 - write tool results back to the session and return responses through the adapter
 

--- a/src/content/docs/ja/architecture.md
+++ b/src/content/docs/ja/architecture.md
@@ -44,6 +44,7 @@ description: mikan のプラットフォーム接続、セッション、agent�
 ### C. Agent 実行レイヤー
 
 - `src/agent.ts`
+- `src/harness/*`
 - `src/context.ts`
 - `src/tools/*`
 
@@ -51,7 +52,7 @@ description: mikan のプラットフォーム接続、セッション、agent�
 
 - `PiAgentWrapper` を作成する
 - モデル、skills、memory、session context を読み込む
-- ユーザーメッセージを `pi-agent-core` / `pi-coding-agent` に渡す
+- ユーザーメッセージを mikan 自前の agent harness（`src/harness/`、`pi-agent-core` / `pi-ai` の上に構築）に渡し、ターンループ・auto-compaction・auto-retry・extension hooks を実行する
 - tool calls をローカルの `read/bash/edit/write/event/attach` に接続する
 - tool の結果を session に書き戻し、adapter 経由でプラットフォームへ返す
 

--- a/src/content/docs/ja/sessions.mdx
+++ b/src/content/docs/ja/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: セッション
-description: mikan がプラットフォームのチャット履歴と pi-coding-agent の構造化セッションをどのように分離するか。
+description: mikan がプラットフォームのチャット履歴と agent harness の構造化セッションをどのように分離するか。
 ---
 
 import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
@@ -10,8 +10,8 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
     `log.jsonl` は、人が読めるプラットフォームメッセージを保持し、thread または reply context の
     bootstrap に使います。
   </Card>
-  <Card title="pi 構造化 context" icon="rocket">
-    `sessions/*.jsonl` は tool results と agent turn を保存し、pi-coding-agent
+  <Card title="Harness 構造化 context" icon="rocket">
+    `sessions/*.jsonl` は tool results と agent turn を保存し、mikan の agent harness
     が作業を継続できるようにします。
   </Card>
   <Card title="固定 scope" icon="lock">
@@ -36,7 +36,7 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   - **log.jsonl** プラットフォームメッセージ履歴
   - sessions/
     - **current** 使用中の top-level session を指します
-    - **\*.jsonl** tool results を含む、構造化 pi-coding-agent context
+    - **\*.jsonl** tool results を含む、構造化 harness session context
     - **scope-derived files** thread / reply scopes の固定 session files
 
 </FileTree>

--- a/src/content/docs/sessions.mdx
+++ b/src/content/docs/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sessions
-description: How mikan separates platform chat history from pi-coding-agent structured sessions.
+description: How mikan separates platform chat history from the agent harness's structured sessions.
 ---
 
 import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
@@ -9,8 +9,9 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   <Card title="Platform chat history" icon="open-book">
     `log.jsonl` keeps human-readable platform messages used to bootstrap thread or reply context.
   </Card>
-  <Card title="pi structured context" icon="rocket">
-    `sessions/*.jsonl` stores tool results and agent turns so pi-coding-agent can continue work.
+  <Card title="Harness structured context" icon="rocket">
+    `sessions/*.jsonl` stores tool results and agent turns so the mikan agent harness can continue
+    work.
   </Card>
   <Card title="Fixed scope" icon="lock">
     Threads, reply chains, and shared channels map to fixed session files so different conversations
@@ -34,7 +35,7 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   - **log.jsonl** platform message history
   - sessions/
     - **current** points to the active top-level session
-    - **\*.jsonl** structured pi-coding-agent context, including tool results
+    - **\*.jsonl** structured harness session context, including tool results
     - **scope-derived files** fixed session files for thread / reply scopes
 
 </FileTree>

--- a/src/content/docs/zh-cn/architecture.md
+++ b/src/content/docs/zh-cn/architecture.md
@@ -44,6 +44,7 @@ description: 了解 mikan 的平台接入、工作阶段、agent、sandbox、vau
 ### C. Agent 执行层
 
 - `src/agent.ts`
+- `src/harness/*`
 - `src/context.ts`
 - `src/tools/*`
 
@@ -51,7 +52,7 @@ description: 了解 mikan 的平台接入、工作阶段、agent、sandbox、vau
 
 - 建立 `PiAgentWrapper`
 - 载入模型、skills、memory、session context
-- 将使用者讯息送入 `pi-agent-core` / `pi-coding-agent`
+- 将使用者讯息送入 mikan 自有的 agent harness（`src/harness/`，构建于 `pi-agent-core` / `pi-ai` 之上），由它执行回合循环、auto-compaction、auto-retry 与 extension hooks
 - 把 tool calls 接到本地 `read/bash/edit/write/event/attach`
 - 把 tool 结果回写 session，并透过 adapter 回传给平台
 

--- a/src/content/docs/zh-cn/sessions.mdx
+++ b/src/content/docs/zh-cn/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: 会话
-description: mikan 如何分离平台聊天历史与 pi-coding-agent 结构化会话。
+description: mikan 如何分离平台聊天历史与 agent harness 结构化会话。
 ---
 
 import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
@@ -9,8 +9,8 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   <Card title="平台聊天历史" icon="open-book">
     `log.jsonl` 保留可供人阅读的平台消息，用于 bootstrap thread 或 reply context。
   </Card>
-  <Card title="pi 结构化 context" icon="rocket">
-    `sessions/*.jsonl` 保存 tool results 与 agent turn，让 pi-coding-agent 可以延续工作。
+  <Card title="Harness 结构化 context" icon="rocket">
+    `sessions/*.jsonl` 保存 tool results 与 agent turn，让 mikan agent harness 可以延续工作。
   </Card>
   <Card title="固定 scope" icon="lock">
     Thread、reply chain 与 shared channel 会映射到固定 session files，避免不同对话互相污染。
@@ -33,7 +33,7 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   - **log.jsonl** 平台消息历史
   - sessions/
     - **current** 指向使用中的 top-level session
-    - **\*.jsonl** 结构化 pi-coding-agent context，包含 tool results
+    - **\*.jsonl** 结构化 harness session context，包含 tool results
     - **scope-derived files** thread / reply scopes 的固定 session files
 
 </FileTree>

--- a/src/content/docs/zh-tw/architecture.md
+++ b/src/content/docs/zh-tw/architecture.md
@@ -44,6 +44,7 @@ description: 了解 mikan 的平台接入、工作階段、agent、sandbox、vau
 ### C. Agent 執行層
 
 - `src/agent.ts`
+- `src/harness/*`
 - `src/context.ts`
 - `src/tools/*`
 
@@ -51,7 +52,7 @@ description: 了解 mikan 的平台接入、工作階段、agent、sandbox、vau
 
 - 建立 `PiAgentWrapper`
 - 載入模型、skills、memory、session context
-- 將使用者訊息送入 `pi-agent-core` / `pi-coding-agent`
+- 將使用者訊息送入 mikan 自有的 agent harness（`src/harness/`，建構於 `pi-agent-core` / `pi-ai` 之上），由它執行回合迴圈、auto-compaction、auto-retry 與 extension hooks
 - 把 tool calls 接到本地 `read/bash/edit/write/event/attach`
 - 把 tool 結果回寫 session，並透過 adapter 回傳給平台
 

--- a/src/content/docs/zh-tw/sessions.mdx
+++ b/src/content/docs/zh-tw/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: 工作階段
-description: mikan 如何分離平台聊天歷史與 pi-coding-agent 結構化工作階段。
+description: mikan 如何分離平台聊天歷史與 agent harness 結構化工作階段。
 ---
 
 import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
@@ -9,8 +9,8 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   <Card title="平台聊天歷史" icon="open-book">
     `log.jsonl` 保留可供人閱讀的平台訊息，用來 bootstrap thread 或 reply context。
   </Card>
-  <Card title="pi 結構化 context" icon="rocket">
-    `sessions/*.jsonl` 保存 tool results 與 agent turn，讓 pi-coding-agent 可以延續工作。
+  <Card title="Harness 結構化 context" icon="rocket">
+    `sessions/*.jsonl` 保存 tool results 與 agent turn，讓 mikan agent harness 可以延續工作。
   </Card>
   <Card title="固定 scope" icon="lock">
     Thread、reply chain 與 shared channel 會映射到固定 session files，避免不同對話互相污染。
@@ -33,7 +33,7 @@ import { Aside, Card, CardGrid, FileTree } from "@astrojs/starlight/components";
   - **log.jsonl** 平台訊息歷史
   - sessions/
     - **current** 指向使用中的 top-level session
-    - **\*.jsonl** 結構化 pi-coding-agent context，包含 tool results
+    - **\*.jsonl** 結構化 harness session context，包含 tool results
     - **scope-derived files** thread / reply scopes 的固定 session files
 
 </FileTree>

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -1,6 +1,10 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import { loadGlobalSettings, resolveConversationSettings } from "./config.js";
+import {
+  conversationSettingsPath,
+  loadGlobalSettings,
+  resolveConversationSettings,
+} from "./config.js";
 import { ensureDirExists, isRecord, readJsonFileIfExists } from "./utils/file-guards.js";
 import { DockerContainerManager, type ContainerMount } from "./provisioner.js";
 import { createExecutor, type Executor, type SandboxConfig } from "./sandbox/index.js";
@@ -29,8 +33,7 @@ export function readConversationWorkspaceMountMode(
       "Falling back while resolving conversation workspace mount",
       err instanceof Error ? err.message : String(err),
     );
-    const conversationSettingsPath = join(conversationDir, "settings.json");
-    const raw = readConversationSettingsFallback(conversationSettingsPath);
+    const raw = readConversationSettingsFallback(conversationSettingsPath(conversationDir));
     return raw?.sandbox?.image?.workspaceMount ?? globalDefault;
   }
 }

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -48,6 +48,7 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
 | `models.ts` `MikanModels`         | 模型目錄 + auth 解析（含 models.json 自訂供應商）                    | `ModelRegistry`                               |
 | `auth.ts` `FileCredentialStore`   | `~/.mikan/auth.json` 憑證儲存（pi-ai `CredentialStore` 實作）        | `AuthStorage`                                 |
 | `skills.ts`                       | SKILL.md 探索與 system prompt 格式化                                 | `loadSkillsFromDir` / `formatSkillsForPrompt` |
+| `http.ts`                         | 全域 fetch：proxy 支援（`HTTP_PROXY` 等）+ idle timeout              | `http-dispatcher`                             |
 | `settings.ts`                     | compaction / retry 預設值                                            | `SettingsManager`                             |
 | `extensions/`                     | mikan 自有 extension 系統                                            | `DefaultResourceLoader` 的 extension 載入     |
 

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -23,6 +23,7 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
 │    · message persistence on message_end                    │
 │    · auto-compaction (threshold + overflow recovery)       │
 │    · auto-retry with exponential backoff                   │
+│    · budget circuit breakers (token/cost/time/call caps)   │
 │    · extension hook dispatch                               │
 │                                                            │
 │  SessionStore (session-store.ts)   MikanModels (models.ts) │
@@ -43,7 +44,7 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
 
 | 模組                              | 職責                                                                 | 取代的 pi-coding-agent API                    |
 | --------------------------------- | -------------------------------------------------------------------- | --------------------------------------------- |
-| `runner.ts` `MikanAgentSession`   | 回合迴圈：持久化、auto-compaction、auto-retry、事件、extension hooks | `AgentSession`                                |
+| `runner.ts` `MikanAgentSession`   | 回合迴圈：持久化、auto-compaction、auto-retry、預算熔斷、事件、extension hooks | `AgentSession`                                |
 | `session-store.ts` `SessionStore` | v3 JSONL session tree 的同步讀寫                                     | `SessionManager`                              |
 | `models.ts` `MikanModels`         | 模型目錄 + auth 解析（含 models.json 自訂供應商）                    | `ModelRegistry`                               |
 | `auth.ts` `FileCredentialStore`   | `~/.mikan/auth.json` 憑證儲存（pi-ai `CredentialStore` 實作）        | `AuthStorage`                                 |
@@ -66,8 +67,30 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
   azure-openai-responses / google-generative-ai / mistral-conversations）；
   只帶 `baseUrl`/`compat` 的項目覆寫內建供應商模型。
 - **事件面不變。** `MikanAgentSession` 事件 = pi-agent-core `AgentEvent`
-  passthrough + `compaction_start/_end` + `auto_retry_start/_end`，
-  adapters 的渲染程式不需修改。
+  passthrough + `compaction_start/_end` + `auto_retry_start/_end` +
+  `budget_exceeded`，adapters 的渲染程式不需修改（新增的 `budget_exceeded`
+  是額外事件，舊 handler 忽略即可）。
+
+## 預算熔斷（circuit breakers）
+
+LLM 無法可靠地自己決定何時該停（停機問題），所以失控的 run 必須由外部叫停。
+`settings.ts` 的 `BudgetSettings` 定義單次 `prompt()` 的資源上限（token、成本 USD、
+牆鐘時間、LLM 呼叫次數）；任一項超限就 abort 該 run 並發出 `budget_exceeded` 事件。
+
+- **互動回合**逐則由人把關，預設不設上限（`DEFAULT_BUDGET_SETTINGS = {}`）。
+- **自主 run（event / trigger）** 沒有人盯著迴圈，`agent.ts` 會傳入
+  `DEFAULT_EVENT_BUDGET`（10 分鐘、50 次 LLM 呼叫、2 USD）作為 stop-loss。
+
+上限在每次 assistant `message_end` 時累計檢查（可在回合中途 abort），並在
+`handlePostRun` 擋掉「超限後又被 retry/compaction 續跑」的漏洞。
+
+## Prompt cache 友善
+
+pi-ai 對 Anthropic 會在整段 system prompt 結尾放單一 cache breakpoint——只要
+system prompt 有任何位元變動，整個請求（含最貴的對話歷史）就 cache miss。因此
+`agent.ts` 的 `buildSystemPrompt` 只放**同一會話中穩定**的內容；每回合會變的
+內容（event-trigger 模式、attribution，後者在多人頻道會隨發言者每回合改變）改由
+`buildTurnInstructions()` 隨 user message 遞送，讓 system prompt 位元穩定、cache 保溫。
 
 ### 與 pi-coding-agent 的行為差異
 

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -101,13 +101,17 @@ system prompt 有任何位元變動，整個請求（含最貴的對話歷史）
   `src/commands/` 處理）。
 - OAuth 登入流程尚未接線（憑證檔中已有的 OAuth token 仍會被 pi-ai 解析與刷新）。
 
-## Extension 系統 v1
+## Extension 系統
 
 Extension 是 ES module，放在 **state dir**（host-only，永不掛進 sandbox）
 的 `extensions/` 下：
 
 ```
-~/.mikan/extensions/global/audit.mjs        # 所有會話
+~/.mikan/extensions/global/audit.mjs        # 所有會話（單檔形式）
+~/.mikan/extensions/global/agent-pm/        # 所有會話（目錄形式）
+  index.mjs                                 #   進入點
+  manifest.json                             #   選配：name/version/description
+  skills/<name>/SKILL.md                    #   選配：隨附 skills（自動內嵌）
 ~/.mikan/extensions/<conversationId>/       # 單一會話
 ```
 
@@ -116,6 +120,10 @@ Extension 是 ES module，放在 **state dir**（host-only，永不掛進 sandbo
 extension 目錄絕不能放在 workspace 下 — image 模式會把 workspace/會話目錄
 掛進 sandbox container，sandbox 內寫入的程式碼若被 host 載入即構成逃逸。
 `global` 為保留字，平台的 conversation id 不會取此值。
+
+**身分（slug）：** 由安裝路徑決定（目錄名或檔名），不隨 manifest 改變 —
+data dir、secrets、排程的歸屬都以 slug 為鍵。同一 extension 裝在 global
+與單一會話會共用同一個 slug（即共用資料）。
 
 匯出 `activate`（default 或具名皆可）：
 
@@ -144,9 +152,32 @@ export default function activate(api) {
 | `session_compact`    | compaction 寫入後（觀察） | —                                            |
 
 語意：註冊順序執行；有回傳值的 hook 以第一個非 `undefined` 結果為準；handler
-擲錯只記 log，不會中斷回合。v2 計畫：`tool_result` patch、自訂 slash command
-貢獻點、provider 註冊、session entry 貢獻（`appendCustomEntry` 已可由
-`SessionStore` 直接使用）。
+擲錯只記 log，不會中斷回合。
+
+### v2 API：schedules、notify、paths、secrets、manifest、skills
+
+harness 定義 service 介面（`ExtensionHostServices`），由 embedder 注入實作
+（mikan 在 `agent.ts` 組裝）；缺少對應 service 時，該 api 擲出說明性錯誤。
+這讓 harness 保持可獨立內嵌 — 其他宿主可自帶 messaging / 排程實作。
+
+| api                                | 作用                                                         | mikan 的後端                                                                                      |
+| ---------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `api.schedules.upsert/delete/list` | 具名排程（cron `periodic` / `one-shot`），觸發自主 agent run | event 檔（`<workingDir>/events/ext.<slug>.<conv>.<name>.json`），EventsWatcher 熱載入、跨重啟持久 |
+| `api.notify(text)`                 | 直接發訊到本會話，不經 agent run                             | `main.ts` 的 `PlatformNotifier` → 平台 bot `postMessage`                                          |
+| `api.paths.dataDir`                | 每 extension 的 host-only 資料目錄（首次存取時建立）         | `<stateDir>/extension-data/<slug>/`                                                               |
+| `api.secrets.get/list`             | 唯讀 secrets                                                 | vault：`<stateDir>/vaults/extensions/<slug>/env`                                                  |
+| `manifest.json`                    | name / version / description（顯示用；slug 不受影響）        | loader 讀取                                                                                       |
+| `skills/<name>/SKILL.md`           | 隨附 skills                                                  | 自動探索，**內嵌**進 system prompt（sandbox 讀不到 host-only 檔案），本地同名 skill 優先          |
+
+排程的 `text` 是自主 run 的完整任務描述（不繼承對話歷史，需自包含）；
+多平台同時運行時 `notify` / 排程需指明 `platform`，單平台自動推定。
+
+完整範例見 `examples/extensions/agent-pm/`：約 200 行的 follow-up
+追蹤器（sqlite、每日逾期掃描排程、主動提醒、隨附 skill），即 extension
+系統的目標形狀 —— 復用 mikan 的 harness 而非自建整套 agent。
+
+v3 候選：`tool_result` patch、自訂 slash command 貢獻點、provider 註冊、
+install/uninstall 生命週期指令。
 
 ## 測試
 

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -1,0 +1,124 @@
+# mikan agent harness
+
+mikan 自有的 agent harness 層。原先 mikan 依賴 `@earendil-works/pi-coding-agent`
+（`AgentSession`、`SessionManager`、`ModelRegistry`、`AuthStorage`），但那是為單人
+TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的多會話、headless、
+多平台場景與 TUI 的假設漸行漸遠。本模組保留 pi-coding-agent 的核心精神
+（append-only session tree、compaction、skills、extension hooks），改為直接站在
+`@earendil-works/pi-agent-core`（agent loop、compaction 演算法、context 建構）與
+`@earendil-works/pi-ai`（providers、models、auth 解析、串流）之上。
+
+## 架構
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ mikan adapters / runtime / commands / web                  │
+└──────────────────────────┬─────────────────────────────────┘
+                           │
+┌──────────────────────────▼─────────────────────────────────┐
+│ src/harness  (this module)                                 │
+│                                                            │
+│  MikanAgentSession (runner.ts)                             │
+│    · prompt / subscribe / abort / reloadFromSession        │
+│    · message persistence on message_end                    │
+│    · auto-compaction (threshold + overflow recovery)       │
+│    · auto-retry with exponential backoff                   │
+│    · extension hook dispatch                               │
+│                                                            │
+│  SessionStore (session-store.ts)   MikanModels (models.ts) │
+│    · v3 JSONL, append-only tree      · pi-ai Models 集合    │
+│    · buildSessionContext             · models.json 自訂供應 │
+│                                      · auth.json 憑證      │
+│  Skills (skills.ts)                FileCredentialStore     │
+│  Extensions (extensions/)          Settings (settings.ts)  │
+└──────────────────────────┬─────────────────────────────────┘
+                           │
+┌──────────────────────────▼─────────────────────────────────┐
+│ pi-agent-core: Agent loop, compaction, buildSessionContext │
+│ pi-ai: providers, Models, auth resolution, streaming       │
+└────────────────────────────────────────────────────────────┘
+```
+
+### 模組職責
+
+| 模組                              | 職責                                                                 | 取代的 pi-coding-agent API                    |
+| --------------------------------- | -------------------------------------------------------------------- | --------------------------------------------- |
+| `runner.ts` `MikanAgentSession`   | 回合迴圈：持久化、auto-compaction、auto-retry、事件、extension hooks | `AgentSession`                                |
+| `session-store.ts` `SessionStore` | v3 JSONL session tree 的同步讀寫                                     | `SessionManager`                              |
+| `models.ts` `MikanModels`         | 模型目錄 + auth 解析（含 models.json 自訂供應商）                    | `ModelRegistry`                               |
+| `auth.ts` `FileCredentialStore`   | `~/.pi/mikan/auth.json` 憑證儲存（pi-ai `CredentialStore` 實作）     | `AuthStorage`                                 |
+| `skills.ts`                       | SKILL.md 探索與 system prompt 格式化                                 | `loadSkillsFromDir` / `formatSkillsForPrompt` |
+| `settings.ts`                     | compaction / retry 預設值                                            | `SettingsManager`                             |
+| `extensions/`                     | mikan 自有 extension 系統                                            | `DefaultResourceLoader` 的 extension 載入     |
+
+### 相容性
+
+- **Session 檔案格式不變。** `SessionStore` 讀寫既有 v3 JSONL（`session` header 行 +
+  帶 `id`/`parentId` 的 entries）。entry 形狀與 pi-agent-core 的 `SessionTreeEntry`
+  結構相同，因此 pi-agent-core 的 `buildSessionContext` 與 compaction pipeline
+  直接在這些 entries 上運作。舊 mikan 寫出的會話檔可無縫重開。
+- **auth.json 格式不變。** pi-ai 的 `Credential` 型別即為現行 auth.json 的形狀；
+  `FileCredentialStore` 直接沿用 `~/.pi/mikan/auth.json`。
+- **models.json 子集。** `MikanModels` 讀 `~/.pi/mikan/models.json`（否則回退
+  `~/.pi/agent/models.json`）：帶 `models` 陣列的供應商成為自訂供應商
+  （`api` 支援 anthropic-messages / openai-completions / openai-responses /
+  azure-openai-responses / google-generative-ai / mistral-conversations）；
+  只帶 `baseUrl`/`compat` 的項目覆寫內建供應商模型。
+- **事件面不變。** `MikanAgentSession` 事件 = pi-agent-core `AgentEvent`
+  passthrough + `compaction_start/_end` + `auto_retry_start/_end`，
+  adapters 的渲染程式不需修改。
+
+### 與 pi-coding-agent 的行為差異
+
+- pi extension（`.pi/extensions`）不再載入；由 mikan extension 系統取代（見下）。
+- prompt template / `/skill:` 指令展開不在 harness 內（mikan 的指令由
+  `src/commands/` 處理）。
+- OAuth 登入流程尚未接線（憑證檔中已有的 OAuth token 仍會被 pi-ai 解析與刷新）。
+
+## Extension 系統 v1
+
+Extension 是 ES module，放在 workspace 或單一會話目錄的 `extensions/` 下：
+
+```
+<workspace>/extensions/audit.mjs          # 全域
+<workspace>/<conversation>/extensions/    # 單一會話
+```
+
+匯出 `activate`（default 或具名皆可）：
+
+```js
+// extensions/audit.mjs
+export default function activate(api) {
+  api.on("tool_call", ({ toolName, args }) => {
+    if (toolName === "bash" && String(args.command).includes("curl")) {
+      return { block: true, reason: "network access is audited" };
+    }
+  });
+  api.registerTool(myCustomTool);
+  api.log("audit extension ready");
+}
+```
+
+### Hooks（v1）
+
+| Hook                 | 時機                      | 回傳值                                       |
+| -------------------- | ------------------------- | -------------------------------------------- |
+| `before_agent_start` | 使用者 prompt 送出前      | `{ systemPrompt? }` 覆寫本回合 system prompt |
+| `tool_call`          | 工具執行前                | `{ block?, reason? }` 阻擋工具               |
+| `tool_result`        | 工具執行後（觀察）        | —                                            |
+| `message_end`        | 每則訊息完成（觀察）      | —                                            |
+| `turn_end`           | 回合結束（觀察）          | —                                            |
+| `session_compact`    | compaction 寫入後（觀察） | —                                            |
+
+語意：註冊順序執行；有回傳值的 hook 以第一個非 `undefined` 結果為準；handler
+擲錯只記 log，不會中斷回合。v2 計畫：`tool_result` patch、自訂 slash command
+貢獻點、provider 註冊、session entry 貢獻（`appendCustomEntry` 已可由
+`SessionStore` 直接使用）。
+
+## 測試
+
+- `test/harness-session-store.test.ts` — v3 格式相容、tree/branch、compaction 展開
+- `test/harness-runner.test.ts` — faux provider 端對端：持久化、工具、hook 阻擋、auth 預檢
+- `test/harness-extensions.test.ts` — loader 與 hook registry
+- `test/harness-skills.test.ts` — SKILL.md 探索與 prompt 格式化
+- `test/harness-auth.test.ts` — auth.json 讀寫

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -171,6 +171,9 @@ harness 定義 service 介面（`ExtensionHostServices`），由 embedder 注入
 
 排程的 `text` 是自主 run 的完整任務描述（不繼承對話歷史，需自包含）；
 多平台同時運行時 `notify` / 排程需指明 `platform`，單平台自動推定。
+注意：排程檔落在 events 目錄（sandbox 掛載、agent 可寫），slug 前綴的
+歸屬是**合作性**約定而非安全邊界 — 排程 text 對 agent 可見，勿放 secrets。
+完整的 host/sandbox 路徑邊界地圖見 `src/sandbox/README.md`。
 
 完整範例見 `examples/extensions/agent-pm/`：約 200 行的 follow-up
 追蹤器（sqlite、每日逾期掃描排程、主動提醒、隨附 skill），即 extension

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -42,16 +42,16 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
 
 ### 模組職責
 
-| 模組                              | 職責                                                                 | 取代的 pi-coding-agent API                    |
-| --------------------------------- | -------------------------------------------------------------------- | --------------------------------------------- |
+| 模組                              | 職責                                                                           | 取代的 pi-coding-agent API                    |
+| --------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------- |
 | `runner.ts` `MikanAgentSession`   | 回合迴圈：持久化、auto-compaction、auto-retry、預算熔斷、事件、extension hooks | `AgentSession`                                |
-| `session-store.ts` `SessionStore` | v3 JSONL session tree 的同步讀寫                                     | `SessionManager`                              |
-| `models.ts` `MikanModels`         | 模型目錄 + auth 解析（含 models.json 自訂供應商）                    | `ModelRegistry`                               |
-| `auth.ts` `FileCredentialStore`   | `~/.mikan/auth.json` 憑證儲存（pi-ai `CredentialStore` 實作）        | `AuthStorage`                                 |
-| `skills.ts`                       | SKILL.md 探索與 system prompt 格式化                                 | `loadSkillsFromDir` / `formatSkillsForPrompt` |
-| `http.ts`                         | 全域 fetch：proxy 支援（`HTTP_PROXY` 等）+ idle timeout              | `http-dispatcher`                             |
-| `settings.ts`                     | compaction / retry 預設值                                            | `SettingsManager`                             |
-| `extensions/`                     | mikan 自有 extension 系統                                            | `DefaultResourceLoader` 的 extension 載入     |
+| `session-store.ts` `SessionStore` | v3 JSONL session tree 的同步讀寫                                               | `SessionManager`                              |
+| `models.ts` `MikanModels`         | 模型目錄 + auth 解析（含 models.json 自訂供應商）                              | `ModelRegistry`                               |
+| `auth.ts` `FileCredentialStore`   | `~/.mikan/auth.json` 憑證儲存（pi-ai `CredentialStore` 實作）                  | `AuthStorage`                                 |
+| `skills.ts`                       | SKILL.md 探索與 system prompt 格式化                                           | `loadSkillsFromDir` / `formatSkillsForPrompt` |
+| `http.ts`                         | 全域 fetch：proxy 支援（`HTTP_PROXY` 等）+ idle timeout                        | `http-dispatcher`                             |
+| `settings.ts`                     | compaction / retry 預設值                                                      | `SettingsManager`                             |
+| `extensions/`                     | mikan 自有 extension 系統                                                      | `DefaultResourceLoader` 的 extension 載入     |
 
 ### 相容性
 

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -46,7 +46,7 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
 | `runner.ts` `MikanAgentSession`   | 回合迴圈：持久化、auto-compaction、auto-retry、事件、extension hooks | `AgentSession`                                |
 | `session-store.ts` `SessionStore` | v3 JSONL session tree 的同步讀寫                                     | `SessionManager`                              |
 | `models.ts` `MikanModels`         | 模型目錄 + auth 解析（含 models.json 自訂供應商）                    | `ModelRegistry`                               |
-| `auth.ts` `FileCredentialStore`   | `~/.pi/mikan/auth.json` 憑證儲存（pi-ai `CredentialStore` 實作）     | `AuthStorage`                                 |
+| `auth.ts` `FileCredentialStore`   | `~/.mikan/auth.json` 憑證儲存（pi-ai `CredentialStore` 實作）        | `AuthStorage`                                 |
 | `skills.ts`                       | SKILL.md 探索與 system prompt 格式化                                 | `loadSkillsFromDir` / `formatSkillsForPrompt` |
 | `settings.ts`                     | compaction / retry 預設值                                            | `SettingsManager`                             |
 | `extensions/`                     | mikan 自有 extension 系統                                            | `DefaultResourceLoader` 的 extension 載入     |
@@ -57,10 +57,10 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
   帶 `id`/`parentId` 的 entries）。entry 形狀與 pi-agent-core 的 `SessionTreeEntry`
   結構相同，因此 pi-agent-core 的 `buildSessionContext` 與 compaction pipeline
   直接在這些 entries 上運作。舊 mikan 寫出的會話檔可無縫重開。
-- **auth.json 格式不變。** pi-ai 的 `Credential` 型別即為現行 auth.json 的形狀；
-  `FileCredentialStore` 直接沿用 `~/.pi/mikan/auth.json`。
-- **models.json 子集。** `MikanModels` 讀 `~/.pi/mikan/models.json`（否則回退
-  `~/.pi/agent/models.json`）：帶 `models` 陣列的供應商成為自訂供應商
+- **auth.json 格式不變，位置改為 `~/.mikan/auth.json`。** pi-ai 的 `Credential`
+  型別即為現行 auth.json 的形狀；檔案內容可直接沿用，但不再讀 `~/.pi` 下的舊路徑。
+- **models.json 子集。** `MikanModels` 讀 `~/.mikan/models.json`：
+  帶 `models` 陣列的供應商成為自訂供應商
   （`api` 支援 anthropic-messages / openai-completions / openai-responses /
   azure-openai-responses / google-generative-ai / mistral-conversations）；
   只帶 `baseUrl`/`compat` 的項目覆寫內建供應商模型。
@@ -70,6 +70,8 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
 
 ### 與 pi-coding-agent 的行為差異
 
+- 設定與憑證改放 `~/.mikan/`（`auth.json`、`models.json`）；不再讀取
+  `~/.pi/` 下的任何路徑。
 - pi extension（`.pi/extensions`）不再載入；由 mikan extension 系統取代（見下）。
 - prompt template / `/skill:` 指令展開不在 harness 內（mikan 的指令由
   `src/commands/` 處理）。

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -80,12 +80,19 @@ TUI 打造的完整產品；mikan 只用到其中一小部分，且 chat-bot 的
 
 ## Extension 系統 v1
 
-Extension 是 ES module，放在 workspace 或單一會話目錄的 `extensions/` 下：
+Extension 是 ES module，放在 **state dir**（host-only，永不掛進 sandbox）
+的 `extensions/` 下：
 
 ```
-<workspace>/extensions/audit.mjs          # 全域
-<workspace>/<conversation>/extensions/    # 單一會話
+~/.mikan/extensions/global/audit.mjs        # 所有會話
+~/.mikan/extensions/<conversationId>/       # 單一會話
 ```
+
+**安全模型：** extension 程式碼在 mikan 主程序內執行，權限等同 mikan 本體
+（平台 token、vault、host 檔案系統）。安裝 extension 是管理員動作。因此
+extension 目錄絕不能放在 workspace 下 — image 模式會把 workspace/會話目錄
+掛進 sandbox container，sandbox 內寫入的程式碼若被 host 載入即構成逃逸。
+`global` 為保留字，平台的 conversation id 不會取此值。
 
 匯出 `activate`（default 或具名皆可）：
 

--- a/src/harness/auth.ts
+++ b/src/harness/auth.ts
@@ -2,9 +2,8 @@
  * File-backed credential store for the mikan harness.
  *
  * Implements pi-ai's `CredentialStore` over mikan's `auth.json`
- * (`~/.pi/mikan/auth.json` by default). The file maps provider ids to
- * type-tagged credentials — the same shape pi-ai documents for auth.json —
- * so files written by earlier mikan versions keep working.
+ * (`~/.mikan/auth.json` by default). The file maps provider ids to
+ * type-tagged credentials — the same shape pi-ai documents for auth.json.
  *
  * Writes are atomic (temp file + rename, mode 0600) and serialized per
  * provider within the process. mikan runs as a single process, so no
@@ -20,7 +19,7 @@ import * as log from "../log.js";
 
 /** Default location of mikan's credential file. */
 export function defaultAuthPath(): string {
-  return join(homedir(), ".pi", "mikan", "auth.json");
+  return join(homedir(), ".mikan", "auth.json");
 }
 
 function isCredential(value: unknown): value is Credential {

--- a/src/harness/auth.ts
+++ b/src/harness/auth.ts
@@ -1,0 +1,100 @@
+/**
+ * File-backed credential store for the mikan harness.
+ *
+ * Implements pi-ai's `CredentialStore` over mikan's `auth.json`
+ * (`~/.pi/mikan/auth.json` by default). The file maps provider ids to
+ * type-tagged credentials — the same shape pi-ai documents for auth.json —
+ * so files written by earlier mikan versions keep working.
+ *
+ * Writes are atomic (temp file + rename, mode 0600) and serialized per
+ * provider within the process. mikan runs as a single process, so no
+ * cross-process file lock is taken.
+ */
+import { existsSync, readFileSync } from "fs";
+import { mkdirSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
+import { atomicWritePrivateFile } from "../utils/fs-atomic.js";
+import * as log from "../log.js";
+
+/** Default location of mikan's credential file. */
+export function defaultAuthPath(): string {
+  return join(homedir(), ".pi", "mikan", "auth.json");
+}
+
+function isCredential(value: unknown): value is Credential {
+  if (!value || typeof value !== "object") return false;
+  const type = (value as { type?: unknown }).type;
+  return type === "api_key" || type === "oauth";
+}
+
+export class FileCredentialStore implements CredentialStore {
+  private readonly authPath: string;
+  private chain = Promise.resolve();
+
+  constructor(authPath: string = defaultAuthPath()) {
+    this.authPath = authPath;
+  }
+
+  private load(): Record<string, Credential> {
+    if (!existsSync(this.authPath)) return {};
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(this.authPath, "utf-8"));
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+      const data: Record<string, Credential> = {};
+      for (const [provider, credential] of Object.entries(parsed)) {
+        if (isCredential(credential)) data[provider] = credential;
+      }
+      return data;
+    } catch (err) {
+      log.logWarning(
+        `Failed to read credentials from ${this.authPath}`,
+        err instanceof Error ? err.message : String(err),
+      );
+      return {};
+    }
+  }
+
+  private save(data: Record<string, Credential>): void {
+    mkdirSync(dirname(this.authPath), { recursive: true });
+    atomicWritePrivateFile(this.authPath, `${JSON.stringify(data, null, 2)}\n`);
+  }
+
+  /** Serialize read-modify-write cycles so concurrent refreshes cannot clobber each other. */
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.chain.then(task);
+    this.chain = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  read(providerId: string): Promise<Credential | undefined> {
+    return this.enqueue(async () => this.load()[providerId]);
+  }
+
+  modify(
+    providerId: string,
+    fn: (current: Credential | undefined) => Promise<Credential | undefined>,
+  ): Promise<Credential | undefined> {
+    return this.enqueue(async () => {
+      const data = this.load();
+      const next = await fn(data[providerId]);
+      if (next === undefined) return data[providerId];
+      data[providerId] = next;
+      this.save(data);
+      return next;
+    });
+  }
+
+  delete(providerId: string): Promise<void> {
+    return this.enqueue(async () => {
+      const data = this.load();
+      if (!(providerId in data)) return;
+      delete data[providerId];
+      this.save(data);
+    });
+  }
+}

--- a/src/harness/extensions/loader.ts
+++ b/src/harness/extensions/loader.ts
@@ -20,16 +20,22 @@
  * Modules are imported with a cache-busting query so edited extensions are
  * picked up when a new harness instance is created for a conversation.
  */
-import { existsSync, readdirSync, statSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { basename, dirname, join } from "path";
 import { pathToFileURL } from "url";
 import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import * as log from "../../log.js";
+import { loadSkillsFromDir, type MikanSkill } from "../skills.js";
 import { ExtensionRegistry } from "./registry.js";
 import type {
+  ExtensionHostServices,
   ExtensionLoadError,
+  ExtensionManifest,
+  ExtensionSchedulePayload,
+  ExtensionScheduleInfo,
+  ExtensionScheduleSpec,
   LoadedExtension,
   MikanExtensionActivate,
   MikanExtensionApi,
@@ -61,12 +67,16 @@ export interface LoadExtensionsOptions {
     model: Model<Api>;
     thinkingLevel: ThinkingLevel;
   };
+  /** Embedder-provided services backing the v2 api surface. */
+  services?: ExtensionHostServices;
 }
 
 export interface LoadExtensionsResult {
   registry: ExtensionRegistry;
   extensions: LoadedExtension[];
   errors: ExtensionLoadError[];
+  /** Skills contributed by extensions (inline: bodies ride in the prompt). */
+  skills: MikanSkill[];
 }
 
 function discoverExtensionEntrypoints(dir: string): string[] {
@@ -96,6 +106,194 @@ function discoverExtensionEntrypoints(dir: string): string[] {
     }
   }
   return entrypoints;
+}
+
+/**
+ * Filesystem-safe identifier for an extension, derived from its install
+ * location (directory name for `<name>/index.mjs`, file basename otherwise).
+ * The slug keys the extension's data dir, secrets vault, and schedule
+ * ownership — installing the same extension globally and per-conversation
+ * shares one slug and therefore one data dir.
+ */
+export function extensionSlug(entrypoint: string): string {
+  const base = /^index\.(mjs|js)$/.test(basename(entrypoint))
+    ? basename(dirname(entrypoint))
+    : basename(entrypoint).replace(EXTENSION_FILE_PATTERN, "");
+  const slug = base
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return slug || "extension";
+}
+
+/** Sanitize an extension-chosen schedule name into a filename segment. */
+function scheduleNameSegment(name: string): string {
+  const segment = name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  if (!segment) throw new Error(`Invalid schedule name: ${JSON.stringify(name)}`);
+  return segment;
+}
+
+/** Read `manifest.json` next to a directory-form extension's entrypoint. */
+function readManifest(entrypoint: string): ExtensionManifest {
+  if (!/^index\.(mjs|js)$/.test(basename(entrypoint))) return {};
+  const manifestPath = join(dirname(entrypoint), "manifest.json");
+  if (!existsSync(manifestPath)) return {};
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    if (!parsed || typeof parsed !== "object") return {};
+    const record = parsed as Record<string, unknown>;
+    return {
+      name: typeof record.name === "string" ? record.name : undefined,
+      version: typeof record.version === "string" ? record.version : undefined,
+      description: typeof record.description === "string" ? record.description : undefined,
+    };
+  } catch (err) {
+    log.logWarning(`Ignoring malformed extension manifest: ${manifestPath}`, String(err));
+    return {};
+  }
+}
+
+/**
+ * Skills shipped inside a directory-form extension (`<dir>/skills/`).
+ * Marked inline: extension files live under the host-only state dir, which
+ * sandbox containers cannot read, so skill bodies must ride in the prompt.
+ */
+function loadExtensionSkills(entrypoint: string, slug: string): MikanSkill[] {
+  if (!/^index\.(mjs|js)$/.test(basename(entrypoint))) return [];
+  const skillsDir = join(dirname(entrypoint), "skills");
+  if (!existsSync(skillsDir)) return [];
+  const result = loadSkillsFromDir({ dir: skillsDir, source: `extension:${slug}` });
+  for (const diagnostic of result.diagnostics) {
+    log.logWarning(`Extension skill warning (${slug}): ${diagnostic.message}`, diagnostic.path);
+  }
+  for (const skill of result.skills) skill.inline = true;
+  return result.skills;
+}
+
+const SCHEDULE_FILE_SUFFIX = ".json";
+
+function schedulePrefix(slug: string, conversationId: string): string {
+  return `ext.${slug}.${scheduleNameSegment(conversationId)}.`;
+}
+
+function payloadFromSpec(
+  spec: ExtensionScheduleSpec,
+  conversationId: string,
+): ExtensionSchedulePayload {
+  if (spec.type === "periodic") {
+    if (!spec.schedule || !spec.timezone) {
+      throw new Error("periodic schedule requires schedule and timezone");
+    }
+    return {
+      type: "periodic",
+      conversationId,
+      text: spec.text,
+      schedule: spec.schedule,
+      timezone: spec.timezone,
+      ...(spec.platform ? { platform: spec.platform } : {}),
+    };
+  }
+  if (!spec.at) throw new Error("one-shot schedule requires at");
+  return {
+    type: "one-shot",
+    conversationId,
+    text: spec.text,
+    at: spec.at,
+    ...(spec.platform ? { platform: spec.platform } : {}),
+  };
+}
+
+function specFromPayload(payload: ExtensionSchedulePayload): ExtensionScheduleSpec {
+  if (payload.type === "periodic") {
+    return {
+      type: "periodic",
+      schedule: payload.schedule ?? "",
+      timezone: payload.timezone ?? "",
+      text: payload.text,
+      ...(payload.platform ? { platform: payload.platform } : {}),
+    };
+  }
+  return {
+    type: "one-shot",
+    at: payload.at ?? "",
+    text: payload.text,
+    ...(payload.platform ? { platform: payload.platform } : {}),
+  };
+}
+
+/** Build the v2 api surface for one extension over the injected services. */
+function buildExtensionApi(params: {
+  name: string;
+  slug: string;
+  registry: ExtensionRegistry;
+  context: LoadExtensionsOptions["context"];
+  services: ExtensionHostServices;
+}): MikanExtensionApi {
+  const { name, slug, registry, context, services } = params;
+  const stateDir = services.stateDir ?? join(homedir(), ".mikan");
+  const conversationId = context.conversationId;
+
+  const requireScheduleStore = () => {
+    if (!services.scheduleStore) {
+      throw new Error("api.schedules is unavailable: this context provides no schedule store");
+    }
+    return services.scheduleStore;
+  };
+
+  return {
+    on: (hook, handler) => registry.register(name, hook, handler),
+    registerTool: (tool: AgentTool) => registry.registerTool(tool),
+    log: (message: string) => log.logInfo(`[extension:${name}] ${message}`),
+    context,
+    paths: {
+      get dataDir(): string {
+        const dir = join(stateDir, "extension-data", slug);
+        mkdirSync(dir, { recursive: true });
+        return dir;
+      },
+    },
+    secrets: {
+      get: (key: string) => services.resolveSecrets?.(slug)[key],
+      list: () => Object.keys(services.resolveSecrets?.(slug) ?? {}),
+    },
+    schedules: {
+      upsert: async (scheduleName, spec) => {
+        const store = requireScheduleStore();
+        const filename = `${schedulePrefix(slug, conversationId)}${scheduleNameSegment(scheduleName)}${SCHEDULE_FILE_SUFFIX}`;
+        await store.write(filename, payloadFromSpec(spec, conversationId));
+      },
+      delete: async (scheduleName) => {
+        const store = requireScheduleStore();
+        const filename = `${schedulePrefix(slug, conversationId)}${scheduleNameSegment(scheduleName)}${SCHEDULE_FILE_SUFFIX}`;
+        return store.delete(filename);
+      },
+      list: async () => {
+        const store = requireScheduleStore();
+        const prefix = schedulePrefix(slug, conversationId);
+        const infos: ExtensionScheduleInfo[] = [];
+        for (const entry of await store.list()) {
+          if (!entry.filename.startsWith(prefix)) continue;
+          if (!entry.filename.endsWith(SCHEDULE_FILE_SUFFIX)) continue;
+          infos.push({
+            name: entry.filename.slice(prefix.length, -SCHEDULE_FILE_SUFFIX.length),
+            spec: specFromPayload(entry.payload),
+          });
+        }
+        return infos;
+      },
+    },
+    notify: async (text: string) => {
+      if (!services.postMessage) {
+        throw new Error("api.notify is unavailable: this context provides no platform messaging");
+      }
+      await services.postMessage(conversationId, text);
+    },
+  };
 }
 
 function resolveActivate(moduleExports: unknown): MikanExtensionModule | undefined {
@@ -128,6 +326,8 @@ export async function loadExtensions(
   const registry = new ExtensionRegistry();
   const extensions: LoadedExtension[] = [];
   const errors: ExtensionLoadError[] = [];
+  const skills: MikanSkill[] = [];
+  const services = options.services ?? {};
 
   for (const dir of options.dirs) {
     for (const entrypoint of discoverExtensionEntrypoints(dir)) {
@@ -142,15 +342,27 @@ export async function loadExtensions(
           });
           continue;
         }
-        const name = extension.name ?? entrypoint;
-        const api: MikanExtensionApi = {
-          on: (hook, handler) => registry.register(name, hook, handler),
-          registerTool: (tool: AgentTool) => registry.registerTool(tool),
-          log: (message: string) => log.logInfo(`[extension:${name}] ${message}`),
+        const slug = extensionSlug(entrypoint);
+        const manifest = readManifest(entrypoint);
+        const name = manifest.name ?? extension.name ?? slug;
+        const api = buildExtensionApi({
+          name,
+          slug,
+          registry,
           context: options.context,
-        };
+          services,
+        });
         await extension.activate(api);
-        extensions.push({ name, path: entrypoint });
+        const extensionSkills = loadExtensionSkills(entrypoint, slug);
+        skills.push(...extensionSkills);
+        extensions.push({
+          name,
+          path: entrypoint,
+          slug,
+          version: manifest.version,
+          description: manifest.description,
+          skills: extensionSkills,
+        });
       } catch (err) {
         errors.push({
           path: entrypoint,
@@ -160,5 +372,5 @@ export async function loadExtensions(
     }
   }
 
-  return { registry, extensions, errors };
+  return { registry, extensions, errors, skills };
 }

--- a/src/harness/extensions/loader.ts
+++ b/src/harness/extensions/loader.ts
@@ -1,0 +1,140 @@
+/**
+ * Extension discovery and activation.
+ *
+ * Extensions load from `extensions/` directories (workspace-level and
+ * conversation-level, conversation entries later in the list win no special
+ * treatment — all activate). Accepted layouts:
+ *
+ * - `extensions/<name>.mjs` / `extensions/<name>.js`
+ * - `extensions/<name>/index.mjs` / `extensions/<name>/index.js`
+ *
+ * Modules are imported with a cache-busting query so edited extensions are
+ * picked up when a new harness instance is created for a conversation.
+ */
+import { existsSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import { pathToFileURL } from "url";
+import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import * as log from "../../log.js";
+import { ExtensionRegistry } from "./registry.js";
+import type {
+  ExtensionLoadError,
+  LoadedExtension,
+  MikanExtensionActivate,
+  MikanExtensionApi,
+  MikanExtensionModule,
+} from "./types.js";
+
+const EXTENSION_FILE_PATTERN = /\.(mjs|js)$/;
+
+export interface LoadExtensionsOptions {
+  /** Directories to scan for extensions. Missing directories are skipped. */
+  dirs: string[];
+  context: {
+    conversationId: string;
+    workspaceDir: string;
+    model: Model<Api>;
+    thinkingLevel: ThinkingLevel;
+  };
+}
+
+export interface LoadExtensionsResult {
+  registry: ExtensionRegistry;
+  extensions: LoadedExtension[];
+  errors: ExtensionLoadError[];
+}
+
+function discoverExtensionEntrypoints(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const entrypoints: string[] = [];
+  for (const name of readdirSync(dir).toSorted()) {
+    if (name.startsWith(".")) continue;
+    const fullPath = join(dir, name);
+    let stats;
+    try {
+      stats = statSync(fullPath);
+    } catch {
+      continue;
+    }
+    if (stats.isFile() && EXTENSION_FILE_PATTERN.test(name)) {
+      entrypoints.push(fullPath);
+      continue;
+    }
+    if (stats.isDirectory()) {
+      for (const candidate of ["index.mjs", "index.js"]) {
+        const indexPath = join(fullPath, candidate);
+        if (existsSync(indexPath)) {
+          entrypoints.push(indexPath);
+          break;
+        }
+      }
+    }
+  }
+  return entrypoints;
+}
+
+function resolveActivate(moduleExports: unknown): MikanExtensionModule | undefined {
+  if (!moduleExports || typeof moduleExports !== "object") return undefined;
+  const candidates: unknown[] = [(moduleExports as { default?: unknown }).default, moduleExports];
+  for (const candidate of candidates) {
+    if (typeof candidate === "function") {
+      return { activate: candidate as MikanExtensionActivate };
+    }
+    if (candidate && typeof candidate === "object") {
+      const activate = (candidate as { activate?: unknown }).activate;
+      if (typeof activate === "function") {
+        return {
+          name:
+            typeof (candidate as { name?: unknown }).name === "string"
+              ? (candidate as { name: string }).name
+              : undefined,
+          activate: activate as MikanExtensionActivate,
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Load and activate all extensions found in the given directories. */
+export async function loadExtensions(
+  options: LoadExtensionsOptions,
+): Promise<LoadExtensionsResult> {
+  const registry = new ExtensionRegistry();
+  const extensions: LoadedExtension[] = [];
+  const errors: ExtensionLoadError[] = [];
+
+  for (const dir of options.dirs) {
+    for (const entrypoint of discoverExtensionEntrypoints(dir)) {
+      try {
+        const moduleUrl = `${pathToFileURL(entrypoint).href}?t=${Date.now()}`;
+        const moduleExports: unknown = await import(moduleUrl);
+        const extension = resolveActivate(moduleExports);
+        if (!extension) {
+          errors.push({
+            path: entrypoint,
+            error: "extension must export an activate function (default or named)",
+          });
+          continue;
+        }
+        const name = extension.name ?? entrypoint;
+        const api: MikanExtensionApi = {
+          on: (hook, handler) => registry.register(name, hook, handler),
+          registerTool: (tool: AgentTool) => registry.registerTool(tool),
+          log: (message: string) => log.logInfo(`[extension:${name}] ${message}`),
+          context: options.context,
+        };
+        await extension.activate(api);
+        extensions.push({ name, path: entrypoint });
+      } catch (err) {
+        errors.push({
+          path: entrypoint,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  return { registry, extensions, errors };
+}

--- a/src/harness/extensions/loader.ts
+++ b/src/harness/extensions/loader.ts
@@ -1,9 +1,18 @@
 /**
  * Extension discovery and activation.
  *
- * Extensions load from `extensions/` directories (workspace-level and
- * conversation-level, conversation entries later in the list win no special
- * treatment — all activate). Accepted layouts:
+ * Extension modules execute inside the mikan host process with its full
+ * privileges (platform tokens, vault, host filesystem). They must therefore
+ * only ever load from host-controlled directories: installing an extension
+ * is an administrator action. In particular, extension directories must not
+ * live under paths mounted into sandbox containers (workspace and
+ * conversation dirs in image mode), or code written from inside the sandbox
+ * would be imported into the host process — a sandbox escape.
+ * {@link defaultExtensionDirs} returns the canonical host-only locations
+ * under mikan's state dir.
+ *
+ * Directories are scanned in order; all discovered extensions activate.
+ * Accepted layouts:
  *
  * - `extensions/<name>.mjs` / `extensions/<name>.js`
  * - `extensions/<name>/index.mjs` / `extensions/<name>/index.js`
@@ -12,6 +21,7 @@
  * picked up when a new harness instance is created for a conversation.
  */
 import { existsSync, readdirSync, statSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
 import { pathToFileURL } from "url";
 import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
@@ -27,6 +37,20 @@ import type {
 } from "./types.js";
 
 const EXTENSION_FILE_PATTERN = /\.(mjs|js)$/;
+
+/**
+ * Canonical host-only extension directories for a conversation:
+ * `<stateDir>/extensions/global` (all conversations) and
+ * `<stateDir>/extensions/<conversationId>` (that conversation only).
+ * `global` is reserved as a scope name; platform conversation ids never
+ * take that value.
+ */
+export function defaultExtensionDirs(
+  conversationId: string,
+  stateDir: string = join(homedir(), ".mikan"),
+): string[] {
+  return [join(stateDir, "extensions", "global"), join(stateDir, "extensions", conversationId)];
+}
 
 export interface LoadExtensionsOptions {
   /** Directories to scan for extensions. Missing directories are skipped. */

--- a/src/harness/extensions/registry.ts
+++ b/src/harness/extensions/registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Hook registry and dispatch for mikan extensions.
+ *
+ * The registry collects hook handlers and contributed tools from activated
+ * extensions and dispatches events from the harness runner. Handler failures
+ * are logged and swallowed so a broken extension cannot take down a run.
+ */
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import * as log from "../../log.js";
+import type { MikanHookMap, MikanHookName } from "./types.js";
+
+type HookHandlers = {
+  [T in MikanHookName]: Array<{ owner: string; handler: MikanHookMap[T] }>;
+};
+
+export class ExtensionRegistry {
+  private handlers: HookHandlers = {
+    before_agent_start: [],
+    tool_call: [],
+    tool_result: [],
+    message_end: [],
+    turn_end: [],
+    session_compact: [],
+  };
+  private tools: AgentTool[] = [];
+
+  register<T extends MikanHookName>(owner: string, hook: T, handler: MikanHookMap[T]): void {
+    this.handlers[hook].push({ owner, handler });
+  }
+
+  registerTool(tool: AgentTool): void {
+    this.tools.push(tool);
+  }
+
+  getContributedTools(): AgentTool[] {
+    return [...this.tools];
+  }
+
+  hasHandlers(hook: MikanHookName): boolean {
+    return this.handlers[hook].length > 0;
+  }
+
+  /**
+   * Run handlers in registration order. Returns the first non-undefined
+   * result. Handler errors are logged and skipped.
+   */
+  async emit<T extends MikanHookName>(
+    hook: T,
+    event: Parameters<MikanHookMap[T]>[0],
+  ): Promise<Awaited<ReturnType<MikanHookMap[T]>> | undefined> {
+    for (const { owner, handler } of this.handlers[hook]) {
+      try {
+        const result = await (handler as (input: unknown) => unknown)(event);
+        if (result !== undefined) {
+          return result as Awaited<ReturnType<MikanHookMap[T]>>;
+        }
+      } catch (err) {
+        log.logWarning(
+          `Extension hook "${hook}" failed (${owner})`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+    return undefined;
+  }
+}

--- a/src/harness/extensions/types.ts
+++ b/src/harness/extensions/types.ts
@@ -23,6 +23,7 @@
  */
 import type { AgentMessage, AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, ImageContent, Model, TextContent } from "@earendil-works/pi-ai";
+import type { MikanSkill } from "../skills.js";
 import type { CompactionEntry } from "../types.js";
 
 export interface BeforeAgentStartHookEvent {
@@ -89,6 +90,97 @@ export interface MikanHookMap {
 
 export type MikanHookName = keyof MikanHookMap;
 
+// ── v2: schedules ────────────────────────────────────────────────────────────
+
+/**
+ * A schedule contributed by an extension. Fires an autonomous agent run in
+ * this conversation with `text` as the task prompt (the run does not inherit
+ * conversation history — write `text` self-contained).
+ */
+export type ExtensionScheduleSpec =
+  | {
+      type: "periodic";
+      /** Cron expression (croner syntax). */
+      schedule: string;
+      /** IANA timezone, e.g. "Asia/Taipei". */
+      timezone: string;
+      text: string;
+      /** Target platform; optional when only one platform is running. */
+      platform?: string;
+    }
+  | {
+      type: "one-shot";
+      /** ISO 8601 timestamp with offset. */
+      at: string;
+      text: string;
+      platform?: string;
+    };
+
+export interface ExtensionScheduleInfo {
+  /** Extension-chosen schedule name. */
+  name: string;
+  spec: ExtensionScheduleSpec;
+}
+
+/**
+ * Event-file payload the harness hands to the embedder's schedule store.
+ * Mirrors mikan's event-file shape; `platform` may be omitted when the
+ * embedder runs a single platform.
+ */
+export interface ExtensionSchedulePayload {
+  type: "one-shot" | "periodic";
+  conversationId: string;
+  text: string;
+  platform?: string;
+  at?: string;
+  schedule?: string;
+  timezone?: string;
+}
+
+// ── v2: embedder-injected services ───────────────────────────────────────────
+
+/**
+ * Persistence backend for extension schedules, injected by the embedder
+ * (mikan backs this with event files watched by its EventsWatcher).
+ * Filenames are fully qualified by the harness (`ext-<slug>-<name>.json`).
+ */
+export interface ExtensionScheduleStore {
+  write(filename: string, payload: ExtensionSchedulePayload): Promise<void>;
+  delete(filename: string): Promise<boolean>;
+  /** List all schedule files, harness filters by ownership prefix. */
+  list(): Promise<Array<{ filename: string; payload: ExtensionSchedulePayload }>>;
+}
+
+/**
+ * Host services injected into extensions by the embedder. All fields are
+ * optional: the corresponding api surface throws an informative error when
+ * the running context does not provide the service.
+ */
+export interface ExtensionHostServices {
+  /** State dir for per-extension data dirs; defaults to `~/.mikan`. */
+  stateDir?: string;
+  /** Schedule persistence; enables `api.schedules`. */
+  scheduleStore?: ExtensionScheduleStore;
+  /** Post a message to a conversation without an agent run; enables `api.notify`. */
+  postMessage?: (conversationId: string, text: string, platform?: string) => Promise<void>;
+  /** Resolve read-only secrets for an extension slug; enables `api.secrets`. */
+  resolveSecrets?: (slug: string) => Record<string, string>;
+}
+
+// ── v2: manifest ─────────────────────────────────────────────────────────────
+
+/**
+ * Optional `manifest.json` next to a directory-form extension's entrypoint.
+ * `name` is the display name only; the slug (data dir, secrets, schedule
+ * ownership) always derives from the install path so identity is
+ * admin-controlled and stable across manifest edits.
+ */
+export interface ExtensionManifest {
+  name?: string;
+  version?: string;
+  description?: string;
+}
+
 /** API handed to an extension's `activate` function. */
 export interface MikanExtensionApi {
   /** Register a hook handler. */
@@ -104,6 +196,42 @@ export interface MikanExtensionApi {
     readonly model: Model<Api>;
     readonly thinkingLevel: ThinkingLevel;
   };
+  /** Host-only filesystem locations owned by this extension. */
+  readonly paths: {
+    /**
+     * Per-extension data directory under the state dir
+     * (`<stateDir>/extension-data/<slug>`), created on first access.
+     * Host-only: never mounted into sandbox containers.
+     */
+    readonly dataDir: string;
+  };
+  /**
+   * Read-only secrets from the embedder's vault
+   * (mikan: `<stateDir>/vaults/extensions/<slug>/env`).
+   */
+  readonly secrets: {
+    get(key: string): string | undefined;
+    /** Secret names only, never values. */
+    list(): string[];
+  };
+  /**
+   * Named schedules owned by this extension + conversation. Backed by the
+   * embedder's schedule store; in mikan these become event files that fire
+   * autonomous agent runs (hot-reloaded, persisted across restarts).
+   */
+  readonly schedules: {
+    /** Create or replace a named schedule. */
+    upsert(name: string, spec: ExtensionScheduleSpec): Promise<void>;
+    /** Delete a named schedule. Returns false when it did not exist. */
+    delete(name: string): Promise<boolean>;
+    /** Schedules owned by this extension in this conversation. */
+    list(): Promise<ExtensionScheduleInfo[]>;
+  };
+  /**
+   * Post text into this conversation without triggering an agent run.
+   * Available when the embedder provides platform messaging.
+   */
+  notify(text: string): Promise<void>;
 }
 
 export type MikanExtensionActivate = (api: MikanExtensionApi) => void | Promise<void>;
@@ -116,6 +244,12 @@ export interface MikanExtensionModule {
 export interface LoadedExtension {
   name: string;
   path: string;
+  /** Filesystem-safe identifier used for data dirs, secrets, and schedules. */
+  slug: string;
+  version?: string;
+  description?: string;
+  /** Skills discovered under the extension's `skills/` directory. */
+  skills: MikanSkill[];
 }
 
 export interface ExtensionLoadError {

--- a/src/harness/extensions/types.ts
+++ b/src/harness/extensions/types.ts
@@ -1,0 +1,124 @@
+/**
+ * mikan extension system, v1.
+ *
+ * Extensions are ES modules that export an `activate` function (either as
+ * the default export or a named `activate` export, optionally wrapped in an
+ * object that also carries a `name`). `activate` receives a
+ * {@link MikanExtensionApi} and registers hooks and tools.
+ *
+ * ```js
+ * // extensions/audit.mjs
+ * export default function activate(api) {
+ *   api.on("tool_call", ({ toolName, args }) => {
+ *     if (toolName === "bash" && String(args.command).includes("rm -rf /")) {
+ *       return { block: true, reason: "destructive command" };
+ *     }
+ *   });
+ * }
+ * ```
+ *
+ * Hooks run in registration order. For hooks with results, the first
+ * non-undefined result wins (v1 semantics; later versions may merge).
+ * Hook errors are logged and never crash a run.
+ */
+import type { AgentMessage, AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, ImageContent, Model, TextContent } from "@earendil-works/pi-ai";
+import type { CompactionEntry } from "../types.js";
+
+export interface BeforeAgentStartHookEvent {
+  prompt: string;
+  images?: ImageContent[];
+  systemPrompt: string;
+}
+
+export interface BeforeAgentStartHookResult {
+  /** Replace the system prompt for this turn. */
+  systemPrompt?: string;
+}
+
+export interface ToolCallHookEvent {
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+}
+
+export interface ToolCallHookResult {
+  /** Block the tool call; the model receives an error tool result instead. */
+  block?: boolean;
+  reason?: string;
+}
+
+export interface ToolResultHookEvent {
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  content: (TextContent | ImageContent)[];
+  isError: boolean;
+}
+
+export interface MessageEndHookEvent {
+  message: AgentMessage;
+}
+
+export interface TurnEndHookEvent {
+  messages: AgentMessage[];
+}
+
+export interface SessionCompactHookEvent {
+  entry: CompactionEntry;
+  reason: "threshold" | "overflow" | "manual";
+}
+
+/** Map of hook names to handler signatures. */
+export interface MikanHookMap {
+  before_agent_start: (
+    event: BeforeAgentStartHookEvent,
+  ) =>
+    | BeforeAgentStartHookResult
+    | undefined
+    | void
+    | Promise<BeforeAgentStartHookResult | undefined | void>;
+  tool_call: (
+    event: ToolCallHookEvent,
+  ) => ToolCallHookResult | undefined | void | Promise<ToolCallHookResult | undefined | void>;
+  tool_result: (event: ToolResultHookEvent) => void | Promise<void>;
+  message_end: (event: MessageEndHookEvent) => void | Promise<void>;
+  turn_end: (event: TurnEndHookEvent) => void | Promise<void>;
+  session_compact: (event: SessionCompactHookEvent) => void | Promise<void>;
+}
+
+export type MikanHookName = keyof MikanHookMap;
+
+/** API handed to an extension's `activate` function. */
+export interface MikanExtensionApi {
+  /** Register a hook handler. */
+  on<T extends MikanHookName>(hook: T, handler: MikanHookMap[T]): void;
+  /** Contribute an additional agent tool. */
+  registerTool(tool: AgentTool): void;
+  /** Extension-scoped logging that lands in mikan's structured log. */
+  log(message: string): void;
+  /** Context about the conversation this harness instance serves. */
+  readonly context: {
+    readonly conversationId: string;
+    readonly workspaceDir: string;
+    readonly model: Model<Api>;
+    readonly thinkingLevel: ThinkingLevel;
+  };
+}
+
+export type MikanExtensionActivate = (api: MikanExtensionApi) => void | Promise<void>;
+
+export interface MikanExtensionModule {
+  name?: string;
+  activate: MikanExtensionActivate;
+}
+
+export interface LoadedExtension {
+  name: string;
+  path: string;
+}
+
+export interface ExtensionLoadError {
+  path: string;
+  error: string;
+}

--- a/src/harness/http.ts
+++ b/src/harness/http.ts
@@ -68,7 +68,10 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
       ? globalThis.fetch === originalGlobalFetch
       : globalThis.fetch === installedGlobalFetch;
   if (shouldInstallGlobals) {
-    undici.install?.();
+    // `install` swaps global fetch to undici's; it only exists in undici >= 7,
+    // whose types aren't guaranteed here, so access it defensively and no-op
+    // on older undici (runtime behavior unchanged from the original `?.` call).
+    (undici as { install?: () => void }).install?.();
     installedGlobalFetch = globalThis.fetch;
   }
 }

--- a/src/harness/http.ts
+++ b/src/harness/http.ts
@@ -1,0 +1,74 @@
+/**
+ * Global HTTP dispatcher configuration for the mikan harness.
+ *
+ * mikan is a long-running headless process whose LLM traffic goes through
+ * global `fetch`. Node's built-in fetch ignores `HTTP_PROXY`/`HTTPS_PROXY`/
+ * `NO_PROXY` and offers no idle-timeout control, so a proxied deployment
+ * cannot reach providers and a silently stalled streaming response would
+ * hang a session without ever erroring (auto-retry never kicks in).
+ *
+ * `configureHttpDispatcher` installs undici's `EnvHttpProxyAgent` as the
+ * global dispatcher (proxy support via the standard env vars) with
+ * headers/body idle timeouts, and swaps global `fetch` to undici's so both
+ * share one implementation. A caller that deliberately replaced `fetch`
+ * after module load is left alone.
+ *
+ * Design adapted from pi-coding-agent's http-dispatcher.
+ */
+import * as undici from "undici";
+
+/** Idle timeout applied to HTTP headers/body when none is configured. */
+export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 300_000;
+
+const originalGlobalFetch = globalThis.fetch;
+let installedGlobalFetch: typeof globalThis.fetch | undefined;
+
+/**
+ * Parse an idle-timeout setting into milliseconds.
+ *
+ * Accepts a non-negative number of milliseconds or its string form;
+ * `"disabled"` (case-insensitive) yields `0`. Returns `undefined` for
+ * anything unparseable so callers can fall back to the default.
+ */
+export function parseHttpIdleTimeoutMs(value: unknown): number | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.toLowerCase() === "disabled") return 0;
+    if (trimmed.length === 0) return undefined;
+    return parseHttpIdleTimeoutMs(Number(trimmed));
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+/**
+ * Install the global HTTP dispatcher and fetch. A timeout of `0` disables
+ * idle timeouts. Safe to call more than once; the last call wins.
+ */
+export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TIMEOUT_MS): void {
+  const normalizedTimeoutMs = parseHttpIdleTimeoutMs(timeoutMs);
+  if (normalizedTimeoutMs === undefined) {
+    throw new Error(`Invalid HTTP idle timeout: ${String(timeoutMs)}`);
+  }
+
+  undici.setGlobalDispatcher(
+    new undici.EnvHttpProxyAgent({
+      allowH2: false,
+      bodyTimeout: normalizedTimeoutMs,
+      headersTimeout: normalizedTimeoutMs,
+    }),
+  );
+
+  // Node's built-in fetch uses its own bundled undici and never sees the
+  // dispatcher installed above, so global fetch must be swapped to undici's.
+  const shouldInstallGlobals =
+    installedGlobalFetch === undefined
+      ? globalThis.fetch === originalGlobalFetch
+      : globalThis.fetch === installedGlobalFetch;
+  if (shouldInstallGlobals) {
+    undici.install?.();
+    installedGlobalFetch = globalThis.fetch;
+  }
+}

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -1,0 +1,73 @@
+/**
+ * mikan agent harness.
+ *
+ * mikan's own harness engineering layer, built directly on pi-agent-core
+ * (agent loop, compaction, context building) and pi-ai (providers, models,
+ * auth). See `src/harness/README.md` for the architecture.
+ */
+export { FileCredentialStore, defaultAuthPath } from "./auth.js";
+export { MikanModels, defaultModelsJsonPath, type CreateMikanModelsOptions } from "./models.js";
+export {
+  SessionStore,
+  loadSessionFileEntries,
+  parseSessionFileEntries,
+  type SessionStoreOpenOptions,
+} from "./session-store.js";
+export {
+  MikanAgentSession,
+  type CompactionReason,
+  type HarnessEvent,
+  type HarnessEventListener,
+  type MikanAgentSessionOptions,
+} from "./runner.js";
+export {
+  formatSkillsForPrompt,
+  loadSkillsFromDir,
+  parseFrontmatter,
+  type LoadSkillsResult,
+  type MikanSkill,
+  type SkillDiagnostic,
+} from "./skills.js";
+export {
+  DEFAULT_RETRY_SETTINGS,
+  resolveHarnessSettings,
+  type CompactionSettings,
+  type HarnessSettings,
+  type RetrySettings,
+} from "./settings.js";
+export { ExtensionRegistry } from "./extensions/registry.js";
+export {
+  loadExtensions,
+  type LoadExtensionsOptions,
+  type LoadExtensionsResult,
+} from "./extensions/loader.js";
+export type {
+  BeforeAgentStartHookEvent,
+  BeforeAgentStartHookResult,
+  ExtensionLoadError,
+  LoadedExtension,
+  MessageEndHookEvent,
+  MikanExtensionActivate,
+  MikanExtensionApi,
+  MikanExtensionModule,
+  MikanHookMap,
+  MikanHookName,
+  SessionCompactHookEvent,
+  ToolCallHookEvent,
+  ToolCallHookResult,
+  ToolResultHookEvent,
+  TurnEndHookEvent,
+} from "./extensions/types.js";
+export {
+  CURRENT_SESSION_VERSION,
+  type BranchSummaryEntry,
+  type CompactionEntry,
+  type CustomEntry,
+  type CustomMessageEntry,
+  type SessionContext,
+  type SessionEntry,
+  type SessionFileEntry,
+  type SessionHeader,
+  type SessionInfoEntry,
+  type SessionMessageEntry,
+} from "./types.js";

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -34,8 +34,11 @@ export {
   type SkillDiagnostic,
 } from "./skills.js";
 export {
+  DEFAULT_BUDGET_SETTINGS,
+  DEFAULT_EVENT_BUDGET,
   DEFAULT_RETRY_SETTINGS,
   resolveHarnessSettings,
+  type BudgetSettings,
   type CompactionSettings,
   type HarnessSettings,
   type RetrySettings,

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -12,12 +12,7 @@ export {
   parseHttpIdleTimeoutMs,
 } from "./http.js";
 export { MikanModels, defaultModelsJsonPath, type CreateMikanModelsOptions } from "./models.js";
-export {
-  SessionStore,
-  loadSessionFileEntries,
-  parseSessionFileEntries,
-  type SessionStoreOpenOptions,
-} from "./session-store.js";
+export { SessionStore, loadSessionFileEntries, parseSessionFileEntries } from "./session-store.js";
 export {
   MikanAgentSession,
   type CompactionReason,

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -41,6 +41,7 @@ export {
 export { ExtensionRegistry } from "./extensions/registry.js";
 export {
   defaultExtensionDirs,
+  extensionSlug,
   loadExtensions,
   type LoadExtensionsOptions,
   type LoadExtensionsResult,
@@ -48,7 +49,13 @@ export {
 export type {
   BeforeAgentStartHookEvent,
   BeforeAgentStartHookResult,
+  ExtensionHostServices,
   ExtensionLoadError,
+  ExtensionManifest,
+  ExtensionScheduleInfo,
+  ExtensionSchedulePayload,
+  ExtensionScheduleSpec,
+  ExtensionScheduleStore,
   LoadedExtension,
   MessageEndHookEvent,
   MikanExtensionActivate,

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -6,6 +6,11 @@
  * auth). See `src/harness/README.md` for the architecture.
  */
 export { FileCredentialStore, defaultAuthPath } from "./auth.js";
+export {
+  DEFAULT_HTTP_IDLE_TIMEOUT_MS,
+  configureHttpDispatcher,
+  parseHttpIdleTimeoutMs,
+} from "./http.js";
 export { MikanModels, defaultModelsJsonPath, type CreateMikanModelsOptions } from "./models.js";
 export {
   SessionStore,

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -42,6 +42,7 @@ export {
 } from "./settings.js";
 export { ExtensionRegistry } from "./extensions/registry.js";
 export {
+  defaultExtensionDirs,
   loadExtensions,
   type LoadExtensionsOptions,
   type LoadExtensionsResult,

--- a/src/harness/models.ts
+++ b/src/harness/models.ts
@@ -4,8 +4,7 @@
  * Wraps pi-ai's `Models` collection: all built-in providers are registered
  * with credentials resolved through mikan's auth.json, and custom providers
  * or overrides can be added via a `models.json` file
- * (`~/.pi/mikan/models.json` by default, falling back to the pi agent's
- * `~/.pi/agent/models.json` for compatibility with existing setups).
+ * (`~/.mikan/models.json` by default).
  *
  * models.json subset supported by mikan:
  *
@@ -91,9 +90,7 @@ interface ModelsJsonConfig {
 
 /** Default location of mikan's models.json. */
 export function defaultModelsJsonPath(): string {
-  const mikanPath = join(homedir(), ".pi", "mikan", "models.json");
-  if (existsSync(mikanPath)) return mikanPath;
-  return join(homedir(), ".pi", "agent", "models.json");
+  return join(homedir(), ".mikan", "models.json");
 }
 
 function parseModelsJson(path: string): ModelsJsonConfig | undefined {

--- a/src/harness/models.ts
+++ b/src/harness/models.ts
@@ -1,0 +1,307 @@
+/**
+ * Model catalog for the mikan harness.
+ *
+ * Wraps pi-ai's `Models` collection: all built-in providers are registered
+ * with credentials resolved through mikan's auth.json, and custom providers
+ * or overrides can be added via a `models.json` file
+ * (`~/.pi/mikan/models.json` by default, falling back to the pi agent's
+ * `~/.pi/agent/models.json` for compatibility with existing setups).
+ *
+ * models.json subset supported by mikan:
+ *
+ * ```jsonc
+ * {
+ *   "providers": {
+ *     "my-provider": {
+ *       "api": "openai-completions",     // required when models are listed
+ *       "baseUrl": "http://host/v1",
+ *       "apiKey": "literal-key",          // optional; auth.json / MY_PROVIDER_API_KEY otherwise
+ *       "headers": { },
+ *       "compat": { },
+ *       "models": [{ "id": "m", "name": "M", "input": ["text"], "reasoning": false }]
+ *     },
+ *     "anthropic": { "baseUrl": "https://proxy.example/v1" }  // override built-in provider
+ *   }
+ * }
+ * ```
+ */
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import {
+  createProvider,
+  type Api,
+  type AuthResult,
+  type Model,
+  type Models,
+  type MutableModels,
+  type Provider,
+  type ProviderStreams,
+} from "@earendil-works/pi-ai";
+import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import { anthropicMessagesApi } from "@earendil-works/pi-ai/api/anthropic-messages.lazy";
+import { azureOpenAIResponsesApi } from "@earendil-works/pi-ai/api/azure-openai-responses.lazy";
+import { googleGenerativeAIApi } from "@earendil-works/pi-ai/api/google-generative-ai.lazy";
+import { mistralConversationsApi } from "@earendil-works/pi-ai/api/mistral-conversations.lazy";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+import { openAIResponsesApi } from "@earendil-works/pi-ai/api/openai-responses.lazy";
+import { defaultAuthPath, FileCredentialStore } from "./auth.js";
+
+const CUSTOM_API_STREAMS: Record<string, () => ProviderStreams> = {
+  "anthropic-messages": anthropicMessagesApi,
+  "azure-openai-responses": azureOpenAIResponsesApi,
+  "google-generative-ai": googleGenerativeAIApi,
+  "mistral-conversations": mistralConversationsApi,
+  "openai-completions": openAICompletionsApi,
+  "openai-responses": openAIResponsesApi,
+};
+
+const DEFAULT_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+const DEFAULT_CONTEXT_WINDOW = 128000;
+const DEFAULT_MAX_TOKENS = 16384;
+
+interface CustomModelConfig {
+  id: string;
+  name?: string;
+  api?: string;
+  baseUrl?: string;
+  reasoning?: boolean;
+  input?: ("text" | "image")[];
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  contextWindow?: number;
+  maxTokens?: number;
+  thinkingLevelMap?: Model<Api>["thinkingLevelMap"];
+  headers?: Record<string, string>;
+  compat?: unknown;
+}
+
+interface CustomProviderConfig {
+  name?: string;
+  api?: string;
+  baseUrl?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  compat?: unknown;
+  models?: CustomModelConfig[];
+}
+
+interface ModelsJsonConfig {
+  providers: Record<string, CustomProviderConfig>;
+}
+
+/** Default location of mikan's models.json. */
+export function defaultModelsJsonPath(): string {
+  const mikanPath = join(homedir(), ".pi", "mikan", "models.json");
+  if (existsSync(mikanPath)) return mikanPath;
+  return join(homedir(), ".pi", "agent", "models.json");
+}
+
+function parseModelsJson(path: string): ModelsJsonConfig | undefined {
+  const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("models.json must be a JSON object");
+  }
+  const providers = (parsed as { providers?: unknown }).providers;
+  if (providers === undefined) return undefined;
+  if (!providers || typeof providers !== "object" || Array.isArray(providers)) {
+    throw new Error('models.json "providers" must be an object');
+  }
+  for (const [name, config] of Object.entries(providers)) {
+    if (!config || typeof config !== "object") {
+      throw new Error(`models.json provider "${name}" must be an object`);
+    }
+    const models = (config as CustomProviderConfig).models;
+    if (models !== undefined) {
+      if (!Array.isArray(models)) {
+        throw new Error(`models.json provider "${name}" models must be an array`);
+      }
+      const api = (config as CustomProviderConfig).api;
+      if (typeof api !== "string" || !(api in CUSTOM_API_STREAMS)) {
+        throw new Error(
+          `models.json provider "${name}" needs an "api" of: ${Object.keys(CUSTOM_API_STREAMS).join(", ")}`,
+        );
+      }
+      for (const model of models) {
+        if (!model || typeof model !== "object" || typeof model.id !== "string") {
+          throw new Error(`models.json provider "${name}" has a model without a string "id"`);
+        }
+      }
+    }
+  }
+  return parsed as ModelsJsonConfig;
+}
+
+function envVarNameFor(providerName: string): string {
+  return `${providerName.replace(/[^a-zA-Z0-9]+/g, "_").toUpperCase()}_API_KEY`;
+}
+
+function buildCustomProvider(providerName: string, config: CustomProviderConfig): Provider {
+  const api = config.api!;
+  const displayName = config.name ?? providerName;
+  const envVar = envVarNameFor(providerName);
+  const models = (config.models ?? []).map((modelConfig): Model<Api> => {
+    const model: Model<Api> = {
+      id: modelConfig.id,
+      name: modelConfig.name ?? modelConfig.id,
+      api: (modelConfig.api ?? api) as Api,
+      provider: providerName,
+      baseUrl: modelConfig.baseUrl ?? config.baseUrl ?? "",
+      reasoning: modelConfig.reasoning ?? false,
+      input: modelConfig.input ?? ["text"],
+      cost: modelConfig.cost ?? DEFAULT_COST,
+      contextWindow: modelConfig.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+      maxTokens: modelConfig.maxTokens ?? DEFAULT_MAX_TOKENS,
+    };
+    if (modelConfig.thinkingLevelMap) model.thinkingLevelMap = modelConfig.thinkingLevelMap;
+    if (modelConfig.headers ?? config.headers) {
+      model.headers = { ...config.headers, ...modelConfig.headers };
+    }
+    const compat = modelConfig.compat ?? config.compat;
+    if (compat) model.compat = compat as Model<Api>["compat"];
+    return model;
+  });
+
+  return createProvider({
+    id: providerName,
+    name: displayName,
+    baseUrl: config.baseUrl,
+    headers: config.headers,
+    auth: {
+      apiKey: {
+        name: `${displayName} API key`,
+        resolve: async ({ ctx, credential }) => {
+          const key =
+            (credential?.type === "api_key" ? credential.key : undefined) ??
+            config.apiKey ??
+            (await ctx.env(envVar));
+          if (!key) return undefined;
+          const source =
+            credential?.type === "api_key" && credential.key
+              ? "auth.json"
+              : config.apiKey
+                ? "models.json"
+                : envVar;
+          return { auth: { apiKey: key }, source };
+        },
+      },
+    },
+    models,
+    api: CUSTOM_API_STREAMS[api](),
+  });
+}
+
+/** Rebuild a built-in provider with overridden model base URLs / compat. */
+function overrideBuiltinProvider(provider: Provider, config: CustomProviderConfig): Provider {
+  const models = provider.getModels().map((model): Model<Api> => {
+    const overridden: Model<Api> = Object.assign({}, model);
+    if (config.baseUrl) overridden.baseUrl = config.baseUrl;
+    if (config.compat) overridden.compat = config.compat as Model<Api>["compat"];
+    return overridden;
+  });
+  return {
+    ...provider,
+    getModels: () => models,
+  };
+}
+
+export interface CreateMikanModelsOptions {
+  authPath?: string;
+  modelsJsonPath?: string;
+}
+
+/**
+ * Model catalog backed by pi-ai's `Models`. Exposes the lookup and auth
+ * operations mikan needs; streaming goes through {@link MikanModels.models}.
+ */
+export class MikanModels {
+  /** Underlying pi-ai collection, for streaming/completion calls. */
+  readonly models: Models;
+  private loadError: string | undefined;
+
+  private constructor(models: MutableModels, loadError: string | undefined) {
+    this.models = models;
+    this.loadError = loadError;
+  }
+
+  static create(options: CreateMikanModelsOptions = {}): MikanModels {
+    const authPath = options.authPath ?? defaultAuthPath();
+    const modelsJsonPath = options.modelsJsonPath ?? defaultModelsJsonPath();
+    const models = builtinModels({ credentials: new FileCredentialStore(authPath) });
+
+    let loadError: string | undefined;
+    if (existsSync(modelsJsonPath)) {
+      try {
+        const config = parseModelsJson(modelsJsonPath);
+        for (const [providerName, providerConfig] of Object.entries(config?.providers ?? {})) {
+          if (providerConfig.models && providerConfig.models.length > 0) {
+            models.setProvider(buildCustomProvider(providerName, providerConfig));
+          } else if (providerConfig.baseUrl || providerConfig.compat) {
+            const builtin = models.getProvider(providerName);
+            if (builtin) {
+              models.setProvider(overrideBuiltinProvider(builtin, providerConfig));
+            }
+          }
+        }
+      } catch (err) {
+        loadError = `Failed to load ${modelsJsonPath}: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    }
+    return new MikanModels(models, loadError);
+  }
+
+  /** Error from loading models.json, if any. Built-in models stay available. */
+  getError(): string | undefined {
+    return this.loadError;
+  }
+
+  /** All known models (built-in plus custom). */
+  getAll(): Model<Api>[] {
+    return [...this.models.getModels()];
+  }
+
+  /** Find a model by provider and id. */
+  find(provider: string, modelId: string): Model<Api> | undefined {
+    return this.models.getModel(provider, modelId);
+  }
+
+  /** Models whose provider auth currently resolves (API key, OAuth, or ambient). */
+  async getAvailable(): Promise<Model<Api>[]> {
+    const byProvider = new Map<string, Model<Api>[]>();
+    for (const model of this.models.getModels()) {
+      const group = byProvider.get(model.provider) ?? [];
+      group.push(model);
+      byProvider.set(model.provider, group);
+    }
+
+    const available: Model<Api>[] = [];
+    for (const group of byProvider.values()) {
+      try {
+        const auth = await this.models.getAuth(group[0]);
+        if (auth) available.push(...group);
+      } catch {
+        // Auth resolution failure (e.g. expired OAuth) — treat as unavailable.
+      }
+    }
+    return available;
+  }
+
+  /** Resolve request auth for a model. Undefined when unconfigured. */
+  getAuth(model: Model<Api>): Promise<AuthResult | undefined> {
+    return this.models.getAuth(model);
+  }
+
+  /**
+   * Resolve an API key for a provider. Convenience for call sites that only
+   * need a bearer key (for example pi-agent-core's compat stream function).
+   */
+  async getApiKeyForProvider(provider: string): Promise<string | undefined> {
+    const model = this.models.getModels(provider)[0];
+    if (!model) return undefined;
+    try {
+      const auth = await this.models.getAuth(model);
+      return auth?.auth.apiKey;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -39,11 +39,19 @@ import {
 import * as log from "../log.js";
 import type { ExtensionRegistry } from "./extensions/registry.js";
 import type { MikanModels } from "./models.js";
-import { resolveHarnessSettings, type HarnessSettings } from "./settings.js";
+import { resolveHarnessSettings, type BudgetSettings, type HarnessSettings } from "./settings.js";
 import type { SessionStore } from "./session-store.js";
 import type { CompactionEntry } from "./types.js";
 
 export type CompactionReason = "threshold" | "overflow" | "manual";
+
+/** Running resource tally for the current `prompt()` call, matched against the budget. */
+interface RunTally {
+  tokens: number;
+  costUsd: number;
+  llmCalls: number;
+  startedAt: number;
+}
 
 interface CompactionResultSummary {
   summary: string;
@@ -68,7 +76,16 @@ export type HarnessEvent =
       delayMs: number;
       errorMessage: string;
     }
-  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+  | {
+      type: "budget_exceeded";
+      /** Which cap was hit, e.g. "cost 2.01 USD > 2 USD limit". */
+      reason: string;
+      tokens: number;
+      costUsd: number;
+      llmCalls: number;
+      durationMs: number;
+    };
 
 export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
 
@@ -117,6 +134,9 @@ export class MikanAgentSession {
   private overflowRecoveryAttempted = false;
   private retryAbortController: AbortController | undefined;
   private compactionAbortController: AbortController | undefined;
+  private tally: RunTally = { tokens: 0, costUsd: 0, llmCalls: 0, startedAt: 0 };
+  private runBudget: BudgetSettings = {};
+  private budgetExceededReason: string | undefined;
 
   constructor(options: MikanAgentSessionOptions) {
     this.models = options.models;
@@ -190,8 +210,15 @@ export class MikanAgentSession {
    * Send a user prompt and run the agent loop to completion, including
    * automatic retries and compaction. Resolves when the turn (and any
    * recovery continuations) settles.
+   *
+   * @param options.budget Per-run resource ceilings that override the session
+   *   defaults. Autonomous (event / trigger) runs should pass a budget so a
+   *   runaway loop is stopped even with no human watching.
    */
-  async prompt(text: string, options?: { images?: ImageContent[] }): Promise<void> {
+  async prompt(
+    text: string,
+    options?: { images?: ImageContent[]; budget?: BudgetSettings },
+  ): Promise<void> {
     if (this.agent.state.isStreaming) {
       throw new Error("Agent is already processing a prompt");
     }
@@ -201,6 +228,9 @@ export class MikanAgentSession {
 
     this.retryAttempt = 0;
     this.overflowRecoveryAttempted = false;
+    this.runBudget = { ...this.settings.budget, ...options?.budget };
+    this.budgetExceededReason = undefined;
+    this.tally = { tokens: 0, costUsd: 0, llmCalls: 0, startedAt: Date.now() };
 
     // A previous turn may have ended over the threshold (for example after an
     // abort); compact before adding new context on top.
@@ -289,13 +319,62 @@ export class MikanAgentSession {
       await this.extensions.emit("message_end", { message });
     }
 
-    if (message.role === "assistant" && message.stopReason !== "error") {
-      this.overflowRecoveryAttempted = false;
-      if (this.retryAttempt > 0) {
-        await this.emit({ type: "auto_retry_end", success: true, attempt: this.retryAttempt });
-        this.retryAttempt = 0;
+    if (message.role === "assistant") {
+      this.recordUsage(message);
+      await this.enforceBudget();
+      if (message.stopReason !== "error") {
+        this.overflowRecoveryAttempted = false;
+        if (this.retryAttempt > 0) {
+          await this.emit({ type: "auto_retry_end", success: true, attempt: this.retryAttempt });
+          this.retryAttempt = 0;
+        }
       }
     }
+  }
+
+  /** Fold one assistant turn's usage into the running per-run tally. */
+  private recordUsage(message: AssistantMessage): void {
+    this.tally.llmCalls += 1;
+    const usage = message.usage;
+    if (!usage) return;
+    this.tally.tokens += usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+    this.tally.costUsd += usage.cost?.total ?? 0;
+  }
+
+  /** Compare the tally against the run budget; abort the run when a cap is exceeded. */
+  private async enforceBudget(): Promise<void> {
+    if (this.budgetExceededReason) return;
+    const reason = this.overBudgetReason();
+    if (!reason) return;
+
+    this.budgetExceededReason = reason;
+    await this.emit({
+      type: "budget_exceeded",
+      reason,
+      tokens: this.tally.tokens,
+      costUsd: this.tally.costUsd,
+      llmCalls: this.tally.llmCalls,
+      durationMs: Date.now() - this.tally.startedAt,
+    });
+    log.logWarning("Run budget exceeded — aborting", reason);
+    this.agent.abort();
+  }
+
+  private overBudgetReason(): string | undefined {
+    const { maxTokens, maxCostUsd, maxDurationMs, maxLlmCalls } = this.runBudget;
+    if (maxLlmCalls !== undefined && this.tally.llmCalls >= maxLlmCalls) {
+      return `${this.tally.llmCalls} LLM calls >= ${maxLlmCalls} limit`;
+    }
+    if (maxTokens !== undefined && this.tally.tokens >= maxTokens) {
+      return `${this.tally.tokens} tokens >= ${maxTokens} limit`;
+    }
+    if (maxCostUsd !== undefined && this.tally.costUsd >= maxCostUsd) {
+      return `cost ${this.tally.costUsd.toFixed(2)} USD >= ${maxCostUsd} USD limit`;
+    }
+    if (maxDurationMs !== undefined && Date.now() - this.tally.startedAt >= maxDurationMs) {
+      return `${Date.now() - this.tally.startedAt}ms >= ${maxDurationMs}ms limit`;
+    }
+    return undefined;
   }
 
   private findLastAssistantMessage(): AssistantMessage | undefined {
@@ -309,6 +388,10 @@ export class MikanAgentSession {
 
   /** Decide what to do after a run settles. Returns true when the agent should continue. */
   private async handlePostRun(): Promise<boolean> {
+    // A run stopped for going over budget must not be retried or compacted back
+    // into another continuation — that would defeat the circuit breaker.
+    if (this.budgetExceededReason) return false;
+
     const lastAssistant = this.findLastAssistantMessage();
     if (!lastAssistant) return false;
 

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -1,0 +1,503 @@
+/**
+ * MikanAgentSession — mikan's agent run loop.
+ *
+ * Owns a pi-agent-core `Agent` and layers on the behaviors mikan needs for
+ * long-lived chat conversations:
+ *
+ * - message persistence into the conversation's {@link SessionStore}
+ * - automatic context compaction (threshold and overflow recovery), using
+ *   pi-agent-core's compaction pipeline over the session tree
+ * - automatic retry with exponential backoff on transient provider errors
+ * - extension hook dispatch ({@link ExtensionRegistry})
+ *
+ * Events mirror the agent's lifecycle events plus `compaction_start/_end`
+ * and `auto_retry_start/_end`, preserving the event surface mikan's
+ * platform adapters already render.
+ */
+import {
+  Agent,
+  calculateContextTokens,
+  compact,
+  convertToLlm,
+  estimateContextTokens,
+  getOrThrow,
+  prepareCompaction,
+  shouldCompact,
+  type AgentEvent,
+  type AgentMessage,
+  type AgentTool,
+  type CustomMessage,
+  type ThinkingLevel,
+} from "@earendil-works/pi-agent-core";
+import {
+  isContextOverflow,
+  type Api,
+  type AssistantMessage,
+  type ImageContent,
+  type Model,
+} from "@earendil-works/pi-ai";
+import * as log from "../log.js";
+import type { ExtensionRegistry } from "./extensions/registry.js";
+import type { MikanModels } from "./models.js";
+import { resolveHarnessSettings, type HarnessSettings } from "./settings.js";
+import type { SessionStore } from "./session-store.js";
+import type { CompactionEntry } from "./types.js";
+
+export type CompactionReason = "threshold" | "overflow" | "manual";
+
+interface CompactionResultSummary {
+  summary: string;
+  firstKeptEntryId: string;
+  tokensBefore: number;
+}
+
+export type HarnessEvent =
+  | AgentEvent
+  | { type: "compaction_start"; reason: CompactionReason }
+  | {
+      type: "compaction_end";
+      reason: CompactionReason;
+      result?: CompactionResultSummary;
+      aborted: boolean;
+      errorMessage?: string;
+    }
+  | {
+      type: "auto_retry_start";
+      attempt: number;
+      maxAttempts: number;
+      delayMs: number;
+      errorMessage: string;
+    }
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
+
+export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
+
+// Transient provider failures worth retrying: overload/rate-limit responses,
+// 5xx statuses, and network/stream interruptions.
+const RETRYABLE_ERROR_PATTERN =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export interface MikanAgentSessionOptions {
+  systemPrompt: string;
+  model: Model<Api>;
+  thinkingLevel: ThinkingLevel;
+  tools: AgentTool[];
+  models: MikanModels;
+  sessionStore: SessionStore;
+  settings?: Parameters<typeof resolveHarnessSettings>[0];
+  extensions?: ExtensionRegistry;
+}
+
+export class MikanAgentSession {
+  readonly agent: Agent;
+  readonly sessionStore: SessionStore;
+  private readonly models: MikanModels;
+  private readonly settings: HarnessSettings;
+  private readonly extensions: ExtensionRegistry | undefined;
+  private listeners = new Set<HarnessEventListener>();
+  private retryAttempt = 0;
+  private overflowRecoveryAttempted = false;
+  private retryAbortController: AbortController | undefined;
+  private compactionAbortController: AbortController | undefined;
+
+  constructor(options: MikanAgentSessionOptions) {
+    this.models = options.models;
+    this.sessionStore = options.sessionStore;
+    this.settings = resolveHarnessSettings(options.settings);
+    this.extensions = options.extensions;
+
+    const tools = [...options.tools, ...(options.extensions?.getContributedTools() ?? [])];
+    this.agent = new Agent({
+      initialState: {
+        systemPrompt: options.systemPrompt,
+        model: options.model,
+        thinkingLevel: options.thinkingLevel,
+        tools,
+      },
+      convertToLlm,
+      streamFn: (model, context, streamOptions) =>
+        this.models.models.streamSimple(model, context, streamOptions),
+      beforeToolCall: async ({ toolCall, args }) => {
+        if (!this.extensions?.hasHandlers("tool_call")) return undefined;
+        const result = await this.extensions.emit("tool_call", {
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          args,
+        });
+        return result ?? undefined;
+      },
+      afterToolCall: async ({ toolCall, args, result, isError }) => {
+        if (this.extensions?.hasHandlers("tool_result")) {
+          await this.extensions.emit("tool_result", {
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            args,
+            content: result.content,
+            isError,
+          });
+        }
+        return undefined;
+      },
+    });
+
+    this.agent.subscribe(async (event) => {
+      await this.handleAgentEvent(event);
+    });
+  }
+
+  /** Conversation transcript currently held by the agent. */
+  get messages(): AgentMessage[] {
+    return this.agent.state.messages;
+  }
+
+  get model(): Model<Api> {
+    return this.agent.state.model;
+  }
+
+  subscribe(listener: HarnessEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Replace the agent transcript from the persisted session tree. */
+  reloadFromSession(): number {
+    const context = this.sessionStore.buildSessionContext();
+    if (context.messages.length > 0) {
+      this.agent.state.messages = context.messages;
+    }
+    return context.messages.length;
+  }
+
+  /**
+   * Send a user prompt and run the agent loop to completion, including
+   * automatic retries and compaction. Resolves when the turn (and any
+   * recovery continuations) settles.
+   */
+  async prompt(text: string, options?: { images?: ImageContent[] }): Promise<void> {
+    if (this.agent.state.isStreaming) {
+      throw new Error("Agent is already processing a prompt");
+    }
+
+    const model = this.agent.state.model;
+    await this.ensureAuthConfigured(model);
+
+    this.retryAttempt = 0;
+    this.overflowRecoveryAttempted = false;
+
+    // A previous turn may have ended over the threshold (for example after an
+    // abort); compact before adding new context on top.
+    const lastAssistant = this.findLastAssistantMessage();
+    if (lastAssistant && lastAssistant.stopReason !== "error") {
+      await this.checkThresholdCompaction(lastAssistant);
+    }
+
+    let systemPrompt = this.agent.state.systemPrompt;
+    if (this.extensions?.hasHandlers("before_agent_start")) {
+      const result = await this.extensions.emit("before_agent_start", {
+        prompt: text,
+        images: options?.images,
+        systemPrompt,
+      });
+      if (result?.systemPrompt) {
+        systemPrompt = result.systemPrompt;
+        this.agent.state.systemPrompt = systemPrompt;
+      }
+    }
+
+    const userMessage: AgentMessage = {
+      role: "user",
+      content: [{ type: "text", text }, ...(options?.images ?? [])],
+      timestamp: Date.now(),
+    };
+
+    await this.agent.prompt([userMessage]);
+    while (await this.handlePostRun()) {
+      await this.agent.continue();
+    }
+
+    if (this.extensions?.hasHandlers("turn_end")) {
+      await this.extensions.emit("turn_end", { messages: this.agent.state.messages });
+    }
+  }
+
+  /** Abort the active run, pending retry backoff, and in-flight compaction. */
+  abort(): void {
+    this.retryAbortController?.abort();
+    this.compactionAbortController?.abort();
+    this.agent.abort();
+  }
+
+  private async ensureAuthConfigured(model: Model<Api>): Promise<void> {
+    const auth = await this.models.getAuth(model);
+    if (!auth) {
+      throw new Error(
+        `No credentials for provider "${model.provider}". Set the provider API key environment variable or add it to auth.json.`,
+      );
+    }
+  }
+
+  private async emit(event: HarnessEvent): Promise<void> {
+    for (const listener of this.listeners) {
+      try {
+        await listener(event);
+      } catch (err) {
+        log.logWarning(
+          "Harness event listener failed",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  }
+
+  private async handleAgentEvent(event: AgentEvent): Promise<void> {
+    await this.emit(event);
+
+    if (event.type !== "message_end") return;
+    const message = event.message;
+
+    if (message.role === "user" || message.role === "assistant" || message.role === "toolResult") {
+      this.sessionStore.appendMessage(message);
+    } else if (message.role === "custom") {
+      const custom = message as CustomMessage;
+      this.sessionStore.appendCustomMessageEntry(
+        custom.customType,
+        custom.content,
+        custom.display,
+        custom.details,
+      );
+    }
+
+    if (this.extensions?.hasHandlers("message_end")) {
+      await this.extensions.emit("message_end", { message });
+    }
+
+    if (message.role === "assistant" && message.stopReason !== "error") {
+      this.overflowRecoveryAttempted = false;
+      if (this.retryAttempt > 0) {
+        await this.emit({ type: "auto_retry_end", success: true, attempt: this.retryAttempt });
+        this.retryAttempt = 0;
+      }
+    }
+  }
+
+  private findLastAssistantMessage(): AssistantMessage | undefined {
+    const messages = this.agent.state.messages;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.role === "assistant") return message;
+    }
+    return undefined;
+  }
+
+  /** Decide what to do after a run settles. Returns true when the agent should continue. */
+  private async handlePostRun(): Promise<boolean> {
+    const lastAssistant = this.findLastAssistantMessage();
+    if (!lastAssistant) return false;
+
+    if (lastAssistant.stopReason === "error") {
+      const contextWindow = this.agent.state.model.contextWindow || 0;
+      if (isContextOverflow(lastAssistant, contextWindow)) {
+        return this.handleOverflow();
+      }
+      if (this.isRetryableError(lastAssistant)) {
+        return this.prepareRetry(lastAssistant);
+      }
+      return false;
+    }
+
+    return this.checkThresholdCompaction(lastAssistant);
+  }
+
+  private async handleOverflow(): Promise<boolean> {
+    if (this.overflowRecoveryAttempted) {
+      await this.emit({
+        type: "compaction_end",
+        reason: "overflow",
+        aborted: false,
+        errorMessage:
+          "Context overflow recovery failed after one compact-and-retry attempt. Try /new or a larger-context model.",
+      });
+      return false;
+    }
+    this.overflowRecoveryAttempted = true;
+    this.dropTrailingErrorMessage();
+    return this.runCompaction("overflow", true);
+  }
+
+  private async checkThresholdCompaction(lastAssistant: AssistantMessage): Promise<boolean> {
+    const settings = this.settings.compaction;
+    if (!settings.enabled) return false;
+    const contextWindow = this.agent.state.model.contextWindow || 0;
+    if (contextWindow <= 0) return false;
+
+    let contextTokens = lastAssistant.usage ? calculateContextTokens(lastAssistant.usage) : 0;
+    if (contextTokens === 0) {
+      const estimate = estimateContextTokens(this.agent.state.messages);
+      if (estimate.lastUsageIndex === null) return false;
+      contextTokens = estimate.tokens;
+    }
+
+    if (!shouldCompact(contextTokens, contextWindow, settings)) return false;
+    return this.runCompaction("threshold", false);
+  }
+
+  private async runCompaction(reason: CompactionReason, willRetry: boolean): Promise<boolean> {
+    let started = false;
+    try {
+      const pathEntries = this.sessionStore.getBranch();
+      const preparation = getOrThrow(prepareCompaction(pathEntries, this.settings.compaction));
+      if (!preparation) return false;
+
+      await this.emit({ type: "compaction_start", reason });
+      started = true;
+      this.compactionAbortController = new AbortController();
+      const signal = this.compactionAbortController.signal;
+
+      const result = getOrThrow(
+        await compact(
+          preparation,
+          this.models.models,
+          this.agent.state.model,
+          undefined,
+          signal,
+          this.agent.state.thinkingLevel,
+        ),
+      );
+      if (signal.aborted) {
+        await this.emit({ type: "compaction_end", reason, aborted: true });
+        return false;
+      }
+
+      const entryId = this.sessionStore.appendCompaction(
+        result.summary,
+        result.firstKeptEntryId,
+        result.tokensBefore,
+        result.details,
+      );
+      const context = this.sessionStore.buildSessionContext();
+      this.agent.state.messages = context.messages;
+
+      if (this.extensions?.hasHandlers("session_compact")) {
+        const entry = this.sessionStore.getEntry(entryId);
+        if (entry?.type === "compaction") {
+          await this.extensions.emit("session_compact", {
+            entry: entry as CompactionEntry,
+            reason,
+          });
+        }
+      }
+
+      await this.emit({
+        type: "compaction_end",
+        reason,
+        result: {
+          summary: result.summary,
+          firstKeptEntryId: result.firstKeptEntryId,
+          tokensBefore: result.tokensBefore,
+        },
+        aborted: false,
+      });
+
+      if (willRetry) {
+        this.dropTrailingErrorMessage();
+        return true;
+      }
+      return this.agent.hasQueuedMessages();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "compaction failed";
+      if (started) {
+        await this.emit({
+          type: "compaction_end",
+          reason,
+          aborted: false,
+          errorMessage:
+            reason === "overflow"
+              ? `Context overflow recovery failed: ${errorMessage}`
+              : `Auto-compaction failed: ${errorMessage}`,
+        });
+      } else {
+        log.logWarning("Compaction preparation failed", errorMessage);
+      }
+      return false;
+    } finally {
+      this.compactionAbortController = undefined;
+    }
+  }
+
+  private isRetryableError(message: AssistantMessage): boolean {
+    if (message.stopReason !== "error" || !message.errorMessage) return false;
+    return RETRYABLE_ERROR_PATTERN.test(message.errorMessage);
+  }
+
+  private async prepareRetry(message: AssistantMessage): Promise<boolean> {
+    const settings = this.settings.retry;
+    if (!settings.enabled) return false;
+
+    this.retryAttempt++;
+    if (this.retryAttempt > settings.maxRetries) {
+      this.retryAttempt--;
+      await this.emit({
+        type: "auto_retry_end",
+        success: false,
+        attempt: this.retryAttempt,
+        finalError: message.errorMessage,
+      });
+      this.retryAttempt = 0;
+      return false;
+    }
+
+    const delayMs = settings.baseDelayMs * 2 ** (this.retryAttempt - 1);
+    await this.emit({
+      type: "auto_retry_start",
+      attempt: this.retryAttempt,
+      maxAttempts: settings.maxRetries,
+      delayMs,
+      errorMessage: message.errorMessage || "Unknown error",
+    });
+
+    this.dropTrailingErrorMessage();
+
+    this.retryAbortController = new AbortController();
+    try {
+      await sleep(delayMs, this.retryAbortController.signal);
+    } catch {
+      const attempt = this.retryAttempt;
+      this.retryAttempt = 0;
+      await this.emit({
+        type: "auto_retry_end",
+        success: false,
+        attempt,
+        finalError: "Retry cancelled",
+      });
+      return false;
+    } finally {
+      this.retryAbortController = undefined;
+    }
+    return true;
+  }
+
+  private dropTrailingErrorMessage(): void {
+    const messages = this.agent.state.messages;
+    if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+      this.agent.state.messages = messages.slice(0, -1);
+    }
+  }
+}

--- a/src/harness/session-store.ts
+++ b/src/harness/session-store.ts
@@ -81,9 +81,10 @@ export function loadSessionFileEntries(filePath: string): SessionFileEntry[] {
   return entries;
 }
 
-export interface SessionStoreOpenOptions {
-  /** Working directory recorded for the session when the header is missing. */
-  cwd?: string;
+/** True when the file exists and holds any non-whitespace content on disk. */
+function hasSessionFileContent(filePath: string): boolean {
+  if (!existsSync(filePath)) return false;
+  return readFileSync(filePath, "utf-8").trim().length > 0;
 }
 
 /**
@@ -123,12 +124,21 @@ export class SessionStore {
   }
 
   /**
-   * Open a session file. The file may be missing or headerless; in that case
-   * the session starts empty and a header is written on the first append.
+   * Open a session file. A missing or empty file starts an empty session
+   * whose header is written on the first append. A file that has content but
+   * no leading session header is treated as corrupted and throws, rather than
+   * being silently overwritten on the next append (which would erase the
+   * existing history). Callers on read paths already wrap this in try/catch.
    * @param cwdOverride Working directory override; defaults to the header cwd.
    */
   static open(path: string, cwdOverride?: string): SessionStore {
     const fileEntries = loadSessionFileEntries(path);
+    if (fileEntries.length === 0 && hasSessionFileContent(path)) {
+      throw new Error(
+        `Session file is corrupted (no valid session header): ${path}. ` +
+          `Refusing to open to avoid overwriting existing content.`,
+      );
+    }
     const header = fileEntries.find(isSessionHeader);
     const cwd = cwdOverride ?? header?.cwd ?? process.cwd();
     return new SessionStore(path, cwd, fileEntries);

--- a/src/harness/session-store.ts
+++ b/src/harness/session-store.ts
@@ -1,0 +1,288 @@
+/**
+ * mikan-owned session storage.
+ *
+ * Sessions are append-only trees stored as JSONL files: a `session` header
+ * line followed by entries that carry `id`/`parentId` links. The format is
+ * the v3 layout mikan has always written, and entry shapes are structurally
+ * identical to pi-agent-core's `SessionTreeEntry`, so pi-agent-core's
+ * context-building and compaction helpers operate on these entries directly.
+ *
+ * The store is synchronous by design: every mikan call site (session scope
+ * resolution, chat-history sync, session view, admin portal) reads and
+ * writes sessions inside synchronous flows.
+ */
+import { randomUUID } from "crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { buildSessionContext as buildContextFromEntries } from "@earendil-works/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
+import { atomicWritePrivateFile } from "../utils/fs-atomic.js";
+import {
+  CURRENT_SESSION_VERSION,
+  type SessionContext,
+  type SessionEntry,
+  type SessionFileEntry,
+  type SessionHeader,
+} from "./types.js";
+
+/** Distributive omit so each entry variant keeps its own fields. */
+type PendingSessionEntry = SessionEntry extends infer TEntry
+  ? TEntry extends SessionEntry
+    ? Omit<TEntry, "id" | "parentId" | "timestamp">
+    : never
+  : never;
+
+/** Generate a unique short entry id (8 hex chars, collision-checked). */
+function generateEntryId(byId: Map<string, SessionEntry>): string {
+  for (let i = 0; i < 100; i++) {
+    const id = randomUUID().slice(0, 8);
+    if (!byId.has(id)) return id;
+  }
+  return randomUUID();
+}
+
+/** Parse JSONL content tolerantly: malformed lines are skipped. */
+export function parseSessionFileEntries(content: string): SessionFileEntry[] {
+  const entries: SessionFileEntry[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        typeof (parsed as { type?: unknown }).type === "string"
+      ) {
+        entries.push(parsed as SessionFileEntry);
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+  return entries;
+}
+
+function isSessionHeader(entry: SessionFileEntry): entry is SessionHeader {
+  return entry.type === "session" && typeof (entry as SessionHeader).id === "string";
+}
+
+/**
+ * Load a session file. Returns no entries when the file is missing or its
+ * first parseable line is not a valid session header (mirrors the tolerant
+ * read behavior mikan has relied on). Throws only on I/O errors.
+ */
+export function loadSessionFileEntries(filePath: string): SessionFileEntry[] {
+  if (!existsSync(filePath)) return [];
+  const entries = parseSessionFileEntries(readFileSync(filePath, "utf-8"));
+  if (entries.length === 0) return entries;
+  if (!isSessionHeader(entries[0])) return [];
+  return entries;
+}
+
+export interface SessionStoreOpenOptions {
+  /** Working directory recorded for the session when the header is missing. */
+  cwd?: string;
+}
+
+/**
+ * Append-oriented session store over one v3 JSONL file.
+ *
+ * Reading is tolerant (missing files and malformed lines yield an empty
+ * session); appends persist immediately. A session opened from a file
+ * without a valid header gets its header materialized on the first append.
+ */
+export class SessionStore {
+  private readonly sessionFile: string;
+  private readonly cwd: string;
+  private readonly sessionId: string;
+  private header: SessionHeader | null;
+  private headerOnDisk: boolean;
+  private entries: SessionEntry[] = [];
+  private byId = new Map<string, SessionEntry>();
+  private leafId: string | null = null;
+
+  private constructor(sessionFile: string, cwd: string, fileEntries: SessionFileEntry[]) {
+    this.sessionFile = resolve(sessionFile);
+    this.header = fileEntries.length > 0 && isSessionHeader(fileEntries[0]) ? fileEntries[0] : null;
+    this.headerOnDisk = this.header !== null;
+    this.sessionId = this.header?.id ?? randomUUID();
+    this.cwd = cwd;
+    for (const entry of fileEntries) {
+      if (isSessionHeader(entry)) continue;
+      if (entry.type === "leaf") {
+        // Written by pi-agent-core JSONL sessions; mikan tracks the leaf implicitly.
+        this.leafId = entry.targetId;
+        continue;
+      }
+      this.entries.push(entry);
+      this.byId.set(entry.id, entry);
+      this.leafId = entry.id;
+    }
+  }
+
+  /**
+   * Open a session file. The file may be missing or headerless; in that case
+   * the session starts empty and a header is written on the first append.
+   * @param cwdOverride Working directory override; defaults to the header cwd.
+   */
+  static open(path: string, cwdOverride?: string): SessionStore {
+    const fileEntries = loadSessionFileEntries(path);
+    const header = fileEntries.find(isSessionHeader);
+    const cwd = cwdOverride ?? header?.cwd ?? process.cwd();
+    return new SessionStore(path, cwd, fileEntries);
+  }
+
+  /** Create a new session file with a fresh header, replacing any existing file. */
+  static create(path: string, cwd: string, options?: { id?: string }): SessionStore {
+    const header: SessionHeader = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: options?.id ?? randomUUID(),
+      timestamp: new Date().toISOString(),
+      cwd,
+    };
+    atomicWritePrivateFile(path, `${JSON.stringify(header)}\n`);
+    return new SessionStore(path, cwd, [header]);
+  }
+
+  getSessionFile(): string {
+    return this.sessionFile;
+  }
+
+  getCwd(): string {
+    return this.cwd;
+  }
+
+  /** Session header as read from disk, or null when the file had none. */
+  getHeader(): SessionHeader | null {
+    return this.header;
+  }
+
+  /** Stable session id: the header id, or a generated id for fresh sessions. */
+  getSessionId(): string {
+    return this.sessionId;
+  }
+
+  getLeafId(): string | null {
+    return this.leafId;
+  }
+
+  getEntry(id: string): SessionEntry | undefined {
+    return this.byId.get(id);
+  }
+
+  /** All session entries (header excluded). Returns a shallow copy. */
+  getEntries(): SessionEntry[] {
+    return [...this.entries];
+  }
+
+  /** Latest user-assigned session name, if any. */
+  getSessionName(): string | undefined {
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      const entry = this.entries[i];
+      if (entry.type === "session_info") return entry.name?.trim() || undefined;
+    }
+    return undefined;
+  }
+
+  /**
+   * Walk from an entry to the root, returning entries in path order
+   * (root first). Defaults to the current leaf.
+   */
+  getBranch(fromId?: string): SessionEntry[] {
+    const path: SessionEntry[] = [];
+    let currentId = fromId ?? this.leafId;
+    while (currentId) {
+      const entry = this.byId.get(currentId);
+      if (!entry) break;
+      path.push(entry);
+      currentId = entry.parentId;
+    }
+    return path.toReversed();
+  }
+
+  /**
+   * Build the LLM context (messages, thinking level, model) from the current
+   * branch, resolving compaction and branch summaries along the path.
+   */
+  buildSessionContext(): SessionContext {
+    return buildContextFromEntries(this.getBranch());
+  }
+
+  /** Append a chat message as a child of the current leaf. Returns the entry id. */
+  appendMessage(message: AgentMessage): string {
+    return this.appendEntry({ type: "message", message });
+  }
+
+  /** Append an extension/application data entry (never sent to the LLM). */
+  appendCustomEntry(customType: string, data?: unknown): string {
+    return this.appendEntry({ type: "custom", customType, data });
+  }
+
+  /** Append a custom message entry that participates in LLM context. */
+  appendCustomMessageEntry(
+    customType: string,
+    content: string | (TextContent | ImageContent)[],
+    display: boolean,
+    details?: unknown,
+  ): string {
+    return this.appendEntry({ type: "custom_message", customType, content, display, details });
+  }
+
+  /** Record a user-visible session name. */
+  appendSessionInfo(name: string): string {
+    return this.appendEntry({ type: "session_info", name });
+  }
+
+  /** Persist a compaction summary produced for this session. */
+  appendCompaction(
+    summary: string,
+    firstKeptEntryId: string,
+    tokensBefore: number,
+    details?: unknown,
+    fromHook?: boolean,
+  ): string {
+    return this.appendEntry({
+      type: "compaction",
+      summary,
+      firstKeptEntryId,
+      tokensBefore,
+      ...(details !== undefined ? { details } : {}),
+      ...(fromHook !== undefined ? { fromHook } : {}),
+    });
+  }
+
+  private appendEntry(partial: PendingSessionEntry): string {
+    const entry = {
+      ...partial,
+      id: generateEntryId(this.byId),
+      parentId: this.leafId,
+      timestamp: new Date().toISOString(),
+    } as SessionEntry;
+    this.entries.push(entry);
+    this.byId.set(entry.id, entry);
+    this.leafId = entry.id;
+    this.persist(entry);
+    return entry.id;
+  }
+
+  private persist(entry: SessionEntry): void {
+    if (!this.headerOnDisk) {
+      this.header ??= {
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: this.sessionId,
+        timestamp: new Date().toISOString(),
+        cwd: this.cwd,
+      };
+      const lines = [this.header, ...this.entries].map((line) => JSON.stringify(line));
+      mkdirSync(dirname(this.sessionFile), { recursive: true });
+      atomicWritePrivateFile(this.sessionFile, `${lines.join("\n")}\n`);
+      this.headerOnDisk = true;
+      return;
+    }
+    appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+  }
+}

--- a/src/harness/settings.ts
+++ b/src/harness/settings.ts
@@ -19,17 +19,55 @@ export const DEFAULT_RETRY_SETTINGS: RetrySettings = {
   baseDelayMs: 2000,
 };
 
+/**
+ * Per-run resource ceilings — the harness's external circuit breakers.
+ *
+ * An LLM cannot reliably decide on its own when to stop (the halting problem),
+ * so a runaway run has to be stopped from the outside. When any populated cap
+ * is exceeded, the run is aborted and a `budget_exceeded` event is emitted.
+ * Every field is a cap on a single `prompt()` call; an undefined field means
+ * "no cap on that axis". Interactive runs are gated turn-by-turn by a human,
+ * so they default to uncapped; autonomous runs (scheduled events, triggers)
+ * pass {@link DEFAULT_EVENT_BUDGET}, where nobody is watching the loop.
+ */
+export interface BudgetSettings {
+  /** Max cumulative tokens processed this run (input + output + cache read/write). */
+  maxTokens?: number;
+  /** Max cumulative provider cost (USD) this run. Requires a populated model cost table. */
+  maxCostUsd?: number;
+  /** Max wall-clock duration for the run, in milliseconds. */
+  maxDurationMs?: number;
+  /** Max number of LLM calls (assistant turns) this run. */
+  maxLlmCalls?: number;
+}
+
+/** Interactive runs are human-gated per turn — no automatic ceiling by default. */
+export const DEFAULT_BUDGET_SETTINGS: BudgetSettings = {};
+
+/**
+ * Ceiling for autonomous (event / trigger) runs, where no human is watching
+ * the loop. Deliberately generous — it is a stop-loss, not a target.
+ */
+export const DEFAULT_EVENT_BUDGET: BudgetSettings = {
+  maxDurationMs: 10 * 60 * 1000,
+  maxLlmCalls: 50,
+  maxCostUsd: 2,
+};
+
 export interface HarnessSettings {
   compaction: CompactionSettings;
   retry: RetrySettings;
+  budget: BudgetSettings;
 }
 
 export function resolveHarnessSettings(overrides?: {
   compaction?: Partial<CompactionSettings>;
   retry?: Partial<RetrySettings>;
+  budget?: Partial<BudgetSettings>;
 }): HarnessSettings {
   return {
     compaction: { ...DEFAULT_COMPACTION_SETTINGS, ...overrides?.compaction },
     retry: { ...DEFAULT_RETRY_SETTINGS, ...overrides?.retry },
+    budget: { ...DEFAULT_BUDGET_SETTINGS, ...overrides?.budget },
   };
 }

--- a/src/harness/settings.ts
+++ b/src/harness/settings.ts
@@ -1,0 +1,35 @@
+/**
+ * Runtime settings for the mikan harness. mikan runs headless, so these are
+ * plain values with defaults matching the behavior mikan shipped with.
+ */
+import { DEFAULT_COMPACTION_SETTINGS } from "@earendil-works/pi-agent-core";
+import type { CompactionSettings } from "@earendil-works/pi-agent-core";
+
+export type { CompactionSettings };
+
+export interface RetrySettings {
+  enabled: boolean;
+  maxRetries: number;
+  baseDelayMs: number;
+}
+
+export const DEFAULT_RETRY_SETTINGS: RetrySettings = {
+  enabled: true,
+  maxRetries: 3,
+  baseDelayMs: 2000,
+};
+
+export interface HarnessSettings {
+  compaction: CompactionSettings;
+  retry: RetrySettings;
+}
+
+export function resolveHarnessSettings(overrides?: {
+  compaction?: Partial<CompactionSettings>;
+  retry?: Partial<RetrySettings>;
+}): HarnessSettings {
+  return {
+    compaction: { ...DEFAULT_COMPACTION_SETTINGS, ...overrides?.compaction },
+    retry: { ...DEFAULT_RETRY_SETTINGS, ...overrides?.retry },
+  };
+}

--- a/src/harness/skills.ts
+++ b/src/harness/skills.ts
@@ -1,0 +1,248 @@
+/**
+ * Skill loading for the mikan harness.
+ *
+ * Skills follow the Agent Skills layout: a directory containing a `SKILL.md`
+ * with YAML frontmatter (`name`, `description`), or standalone `.md` files in
+ * the root of a skills directory. Discovery mirrors the behavior mikan's
+ * system prompt documents: a directory with a `SKILL.md` is a skill root
+ * (no further recursion), other directories are traversed.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { basename, dirname, join } from "path";
+
+const MAX_NAME_LENGTH = 64;
+const MAX_DESCRIPTION_LENGTH = 1024;
+
+/** A loaded skill. `baseDir` is the directory containing the skill file. */
+export interface MikanSkill {
+  name: string;
+  description: string;
+  /** Full skill instructions (file content without frontmatter). */
+  content: string;
+  filePath: string;
+  baseDir: string;
+  /** Where the skill was loaded from (e.g. "workspace", "channel"). */
+  source: string;
+  /** Exclude from model-visible skill lists. */
+  disableModelInvocation?: boolean;
+}
+
+export interface SkillDiagnostic {
+  type: "warning";
+  message: string;
+  path: string;
+}
+
+export interface LoadSkillsResult {
+  skills: MikanSkill[];
+  diagnostics: SkillDiagnostic[];
+}
+
+interface Frontmatter {
+  values: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Parse simple `key: value` YAML frontmatter delimited by `---` lines.
+ * Quoted values are unquoted; nested structures are not supported.
+ */
+export function parseFrontmatter(content: string): Frontmatter {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return { values: {}, body: content };
+
+  const values: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    if (!key) continue;
+    let value = line.slice(separator + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    values[key] = value;
+  }
+  return { values, body: content.slice(match[0].length) };
+}
+
+function validateSkill(name: string, description: string): string[] {
+  const errors: string[] = [];
+  if (name.length > MAX_NAME_LENGTH) {
+    errors.push(`name exceeds ${MAX_NAME_LENGTH} characters (${name.length})`);
+  }
+  if (
+    !/^[a-z0-9-]+$/.test(name) ||
+    name.startsWith("-") ||
+    name.endsWith("-") ||
+    name.includes("--")
+  ) {
+    errors.push("name must be lowercase a-z, 0-9 and single hyphens, not at the edges");
+  }
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    errors.push(`description exceeds ${MAX_DESCRIPTION_LENGTH} characters (${description.length})`);
+  }
+  return errors;
+}
+
+function loadSkillFromFile(
+  filePath: string,
+  source: string,
+): {
+  skill: MikanSkill | null;
+  diagnostics: SkillDiagnostic[];
+} {
+  const diagnostics: SkillDiagnostic[] = [];
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const { values, body } = parseFrontmatter(raw);
+    const skillDir = dirname(filePath);
+    const name = values.name || basename(skillDir);
+    const description = values.description ?? "";
+
+    if (!description.trim()) {
+      diagnostics.push({ type: "warning", message: "description is required", path: filePath });
+      return { skill: null, diagnostics };
+    }
+    for (const error of validateSkill(name, description)) {
+      diagnostics.push({ type: "warning", message: error, path: filePath });
+    }
+
+    return {
+      skill: {
+        name,
+        description,
+        content: body.trim(),
+        filePath,
+        baseDir: skillDir,
+        source,
+        disableModelInvocation: values["disable-model-invocation"] === "true",
+      },
+      diagnostics,
+    };
+  } catch (error) {
+    diagnostics.push({
+      type: "warning",
+      message: error instanceof Error ? error.message : "failed to parse skill file",
+      path: filePath,
+    });
+    return { skill: null, diagnostics };
+  }
+}
+
+/**
+ * Load skills from a directory tree.
+ * - A directory containing `SKILL.md` is a skill root; no further recursion.
+ * - Direct `.md` children of the top-level directory load as skills.
+ * - Dot-directories and `node_modules` are skipped.
+ */
+export function loadSkillsFromDir(options: { dir: string; source: string }): LoadSkillsResult {
+  return loadSkillsFromDirInternal(options.dir, options.source, true);
+}
+
+function loadSkillsFromDirInternal(
+  dir: string,
+  source: string,
+  includeRootFiles: boolean,
+): LoadSkillsResult {
+  const skills: MikanSkill[] = [];
+  const diagnostics: SkillDiagnostic[] = [];
+  if (!existsSync(dir)) return { skills, diagnostics };
+
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return { skills, diagnostics };
+  }
+
+  const skillFile = entries.find((entry) => entry.name === "SKILL.md" && isFileLike(dir, entry));
+  if (skillFile) {
+    const result = loadSkillFromFile(join(dir, skillFile.name), source);
+    if (result.skill) skills.push(result.skill);
+    diagnostics.push(...result.diagnostics);
+    return { skills, diagnostics };
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+    const fullPath = join(dir, entry.name);
+
+    if (isDirectoryLike(dir, entry)) {
+      const subResult = loadSkillsFromDirInternal(fullPath, source, false);
+      skills.push(...subResult.skills);
+      diagnostics.push(...subResult.diagnostics);
+      continue;
+    }
+    if (!includeRootFiles || !entry.name.endsWith(".md") || !isFileLike(dir, entry)) continue;
+
+    const result = loadSkillFromFile(fullPath, source);
+    if (result.skill) skills.push(result.skill);
+    diagnostics.push(...result.diagnostics);
+  }
+  return { skills, diagnostics };
+}
+
+function isFileLike(
+  dir: string,
+  entry: { name: string; isFile(): boolean; isSymbolicLink(): boolean },
+): boolean {
+  if (entry.isFile()) return true;
+  if (!entry.isSymbolicLink()) return false;
+  try {
+    return statSync(join(dir, entry.name)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isDirectoryLike(
+  dir: string,
+  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean },
+): boolean {
+  if (entry.isDirectory()) return true;
+  if (!entry.isSymbolicLink()) return false;
+  try {
+    return statSync(join(dir, entry.name)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Format skills for a system prompt using the Agent Skills XML block.
+ * Skills with `disableModelInvocation` are excluded.
+ */
+export function formatSkillsForPrompt(skills: MikanSkill[]): string {
+  const visible = skills.filter((skill) => !skill.disableModelInvocation);
+  if (visible.length === 0) return "";
+
+  const lines = [
+    "\n\nThe following skills provide specialized instructions for specific tasks.",
+    "Use the read tool to load a skill's file when the task matches its description.",
+    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+    "",
+    "<available_skills>",
+  ];
+  for (const skill of visible) {
+    lines.push("  <skill>");
+    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    lines.push(`    <description>${escapeXml(skill.description)}</description>`);
+    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}

--- a/src/harness/skills.ts
+++ b/src/harness/skills.ts
@@ -25,6 +25,12 @@ export interface MikanSkill {
   source: string;
   /** Exclude from model-visible skill lists. */
   disableModelInvocation?: boolean;
+  /**
+   * Embed the skill body in the prompt instead of referencing its file path.
+   * Used for skills whose files the agent cannot read at runtime (e.g.
+   * extension skills under the host-only state dir in sandbox modes).
+   */
+  inline?: boolean;
 }
 
 export interface SkillDiagnostic {
@@ -240,7 +246,12 @@ export function formatSkillsForPrompt(skills: MikanSkill[]): string {
     lines.push("  <skill>");
     lines.push(`    <name>${escapeXml(skill.name)}</name>`);
     lines.push(`    <description>${escapeXml(skill.description)}</description>`);
-    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    if (skill.inline) {
+      // Inline skills carry their body: the agent cannot read their file.
+      lines.push(`    <instructions>${escapeXml(skill.content)}</instructions>`);
+    } else {
+      lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    }
     lines.push("  </skill>");
   }
   lines.push("</available_skills>");

--- a/src/harness/types.ts
+++ b/src/harness/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Core types for the mikan agent harness.
+ *
+ * The harness is built directly on pi-agent-core and pi-ai. Session entries
+ * are structurally identical to pi-agent-core's `SessionTreeEntry`, and the
+ * on-disk JSONL format stays compatible with the v3 session files mikan has
+ * always written, so existing conversation history keeps working unchanged.
+ */
+import type {
+  BranchSummaryEntry,
+  CompactionEntry,
+  CustomEntry,
+  CustomMessageEntry,
+  MessageEntry,
+  SessionContext,
+  SessionInfoEntry,
+  SessionTreeEntry,
+} from "@earendil-works/pi-agent-core";
+
+export type {
+  BranchSummaryEntry,
+  CompactionEntry,
+  CustomEntry,
+  CustomMessageEntry,
+  SessionContext,
+  SessionInfoEntry,
+};
+
+/** Message entry as stored in mikan session files. */
+export type SessionMessageEntry = MessageEntry;
+
+/** Union of entry types mikan reads and writes. Alias of pi-agent-core's tree entry. */
+export type SessionEntry = SessionTreeEntry;
+
+export const CURRENT_SESSION_VERSION = 3;
+
+/**
+ * First line of every session file. `cwd` records where the session was
+ * started; extra fields (for example mikan's `source` marker) are preserved
+ * verbatim on read and rewrite.
+ */
+export interface SessionHeader {
+  type: "session";
+  version?: number;
+  id: string;
+  timestamp: string;
+  cwd: string;
+  parentSession?: string;
+  [extra: string]: unknown;
+}
+
+/** Raw file line: the header or one session entry. */
+export type SessionFileEntry = SessionHeader | SessionEntry;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { defaultCommandHandlers, dispatchCommand } from "./commands/registry.js";
+export * from "./harness/index.js";
 export type { CommandContext, CommandHandler, CommandServices } from "./commands/types.js";
 export * from "./sessions/agent-memory-file-manager.js";
 export * from "./sessions/metadata.js";

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { mkdirSync, statSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
 import { dirname, join as pathJoin } from "path";
-import type { MessagingBot } from "./adapter.js";
+import type { MessagingBot, PlatformNotifier } from "./adapter.js";
 import { DiscordMessagingBot } from "./adapters/discord/bot.js";
 import { TelegramMessagingBot } from "./adapters/telegram/bot.js";
 import { SlackMessagingBot as SlackMessagingBotClass } from "./adapters/slack/bot.js";
@@ -324,6 +324,30 @@ if (provisioner) {
   await provisioner.stopIdle(IMAGE_IDLE_TIMEOUT_MS);
   setInterval(() => provisioner.stopIdle(IMAGE_IDLE_TIMEOUT_MS), IMAGE_IDLE_TIMEOUT_MS).unref();
 }
+// Declared before the runtime so the notifier closure can capture them;
+// bots register below once their platforms initialize.
+const bots: MessagingBot[] = [];
+const botsByPlatform: Record<string, MessagingBot> = {};
+
+/**
+ * Extension `api.notify` backend: post into a conversation without an agent
+ * run. Platform resolution mirrors event files — explicit platform, or the
+ * sole running platform.
+ */
+const platformNotifier: PlatformNotifier = async (conversationId, text, platform) => {
+  const available = Object.keys(botsByPlatform);
+  const key = platform?.trim().toLowerCase() || (available.length === 1 ? available[0] : undefined);
+  const bot = key ? botsByPlatform[key] : undefined;
+  if (!bot) {
+    throw new Error(
+      platform
+        ? `notify: unknown platform '${platform}' (available: ${available.join(", ") || "none"})`
+        : `notify: multiple platforms active (${available.join(", ")}); specify platform`,
+    );
+  }
+  await bot.postMessage(conversationId, text);
+};
+
 const handler = createConversationRuntime({
   workingDir,
   sandbox,
@@ -333,6 +357,7 @@ const handler = createConversationRuntime({
   sessionViewTokenStore,
   adminTokenStore,
   portalBaseUrl: portalBaseUrl(),
+  platformNotifier,
 });
 
 const sandboxDesc =
@@ -346,9 +371,6 @@ const sandboxDesc =
           ? `firecracker:${sandbox.vmId}`
           : `cloudflare:${sandbox.sandboxId}`;
 log.logStartup(workingDir, sandboxDesc);
-
-const bots: MessagingBot[] = [];
-const botsByPlatform: Record<string, MessagingBot> = {};
 
 if (hasSlack) {
   const slackMessagingBotToken = SLACK_BOT_TOKEN;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { InMemoryLinkTokenStore } from "./web/login/store.js";
 import { InMemorySessionViewTokenStore } from "./web/session-view/store.js";
 import { DockerContainerManager } from "./provisioner.js";
 import {
+  assertStateDirOutsideWorkspace,
   createGlobalSettingsFile,
   loadGlobalSettings,
   MissingGlobalSettingsError,
@@ -237,6 +238,11 @@ const { workingDir, sandbox } = { workingDir: parsedArgs.workingDir, sandbox: pa
 const stateDir = parsedArgs.stateDir ?? join(homedir(), ".mikan");
 setEnvAliases("STATE_DIR", stateDir);
 ensureSecureStateDir(stateDir);
+try {
+  assertStateDirOutsideWorkspace(stateDir, workingDir, sandbox.type);
+} catch (error) {
+  handleStartupError(error);
+}
 
 // Validate platform tokens
 const hasSlack = !!(SLACK_APP_TOKEN && SLACK_BOT_TOKEN);

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,13 @@ import {
   loadGlobalSettings,
   MissingGlobalSettingsError,
 } from "./config.js";
-import { configureHttpDispatcher, parseHttpIdleTimeoutMs } from "./harness/index.js";
+import {
+  configureHttpDispatcher,
+  defaultAuthPath,
+  defaultModelsJsonPath,
+  parseHttpIdleTimeoutMs,
+} from "./harness/index.js";
+import { existsSync, readFileSync } from "fs";
 import { readEnv, setEnvAliases } from "./utils/env.js";
 import { ensureDirExists, isRecord, readJsonFileIfExists } from "./utils/file-guards.js";
 import {
@@ -190,7 +196,8 @@ try {
 
 // Global fetch: proxy support (HTTP_PROXY/HTTPS_PROXY/NO_PROXY) and idle
 // timeouts so a stalled LLM stream errors out instead of hanging a session.
-configureHttpDispatcher(parseHttpIdleTimeoutMs(readEnv("HTTP_IDLE_TIMEOUT")));
+const httpIdleTimeoutMs = parseHttpIdleTimeoutMs(readEnv("HTTP_IDLE_TIMEOUT"));
+configureHttpDispatcher(httpIdleTimeoutMs);
 
 // Handle --version
 if (parsedArgs.showVersion) {
@@ -352,6 +359,7 @@ const platformNotifier: PlatformNotifier = async (conversationId, text, platform
     );
   }
   await bot.postMessage(conversationId, text);
+  log.logInfo(`[notify] posted to ${key}/${conversationId} (${text.length} chars)`);
 };
 
 const handler = createConversationRuntime({
@@ -377,6 +385,42 @@ const sandboxDesc =
           ? `firecracker:${sandbox.vmId}`
           : `cloudflare:${sandbox.sandboxId}`;
 log.logStartup(workingDir, sandboxDesc);
+logHarnessStartupSummary();
+
+/**
+ * One-look confirmation of the harness runtime surface, aimed at upgrade
+ * verification: config moved from ~/.pi to ~/.mikan with no fallback, so a
+ * missing auth.json here is the first thing to check when runs fail.
+ */
+function logHarnessStartupSummary(): void {
+  const proxy =
+    process.env.HTTPS_PROXY ??
+    process.env.https_proxy ??
+    process.env.HTTP_PROXY ??
+    process.env.http_proxy;
+  log.logInfo(
+    `HTTP dispatcher: idle timeout ${httpIdleTimeoutMs}ms${proxy ? `, proxy ${proxy}` : ", no proxy"}`,
+  );
+
+  const authPath = defaultAuthPath();
+  if (existsSync(authPath)) {
+    try {
+      const providers = Object.keys(JSON.parse(readFileSync(authPath, "utf-8")) as object);
+      log.logInfo(`Harness auth: ${authPath} (providers: ${providers.join(", ") || "none"})`);
+    } catch {
+      log.logWarning(`Harness auth: ${authPath} exists but is not valid JSON`);
+    }
+  } else {
+    log.logInfo(`Harness auth: ${authPath} missing — provider keys come from env vars only`);
+  }
+
+  const modelsPath = defaultModelsJsonPath();
+  log.logInfo(
+    existsSync(modelsPath)
+      ? `Harness models.json: ${modelsPath}`
+      : `Harness models.json: none (${modelsPath}) — built-in providers only`,
+  );
+}
 
 if (hasSlack) {
   const slackMessagingBotToken = SLACK_BOT_TOKEN;

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import {
   loadGlobalSettings,
   MissingGlobalSettingsError,
 } from "./config.js";
+import { configureHttpDispatcher, parseHttpIdleTimeoutMs } from "./harness/index.js";
 import { readEnv, setEnvAliases } from "./utils/env.js";
 import { ensureDirExists, isRecord, readJsonFileIfExists } from "./utils/file-guards.js";
 import {
@@ -185,6 +186,10 @@ try {
 } catch (error) {
   handleStartupError(error);
 }
+
+// Global fetch: proxy support (HTTP_PROXY/HTTPS_PROXY/NO_PROXY) and idle
+// timeouts so a stalled LLM stream errors out instead of hanging a session.
+configureHttpDispatcher(parseHttpIdleTimeoutMs(readEnv("HTTP_IDLE_TIMEOUT")));
 
 // Handle --version
 if (parsedArgs.showVersion) {

--- a/src/model-registry.ts
+++ b/src/model-registry.ts
@@ -1,12 +1,12 @@
 import { type Api, type Model } from "@earendil-works/pi-ai";
-import { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { MikanModels } from "./harness/index.js";
 
 export function resolveConfiguredModel(
-  modelRegistry: ModelRegistry,
+  modelRegistry: MikanModels,
   provider: string,
   modelId: string,
 ): Model<Api> {
-  const model = modelRegistry.find(provider, modelId) as Model<Api> | undefined;
+  const model = modelRegistry.find(provider, modelId);
   if (model) return model;
 
   throw new Error(

--- a/src/runtime/conversation-runtime.ts
+++ b/src/runtime/conversation-runtime.ts
@@ -259,6 +259,7 @@ class ConversationRuntimeImpl implements ConversationRuntime {
           tokenStore: this.options.sessionViewTokenStore,
           portalBaseUrl: this.options.portalBaseUrl,
         },
+        this.options.platformNotifier,
       ),
       stopRequested: false,
       lastAccessedAt: Date.now(),

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -5,6 +5,7 @@ import type {
   ConversationEvent,
   MessagingEventHandler,
   ConversationKind,
+  PlatformNotifier,
 } from "../adapter.js";
 import type { CommandHandler, CommandServices } from "../commands/types.js";
 
@@ -35,6 +36,8 @@ export interface CreateSessionSandboxOptions {
 export interface ConversationRuntimeOptions extends Omit<CommandServices, "runtime"> {
   /** Override the default command handlers (e.g., to add /help, /status). */
   commandHandlers?: readonly CommandHandler[];
+  /** Proactive platform messaging for extensions (`api.notify`). */
+  platformNotifier?: PlatformNotifier;
 }
 
 export interface ConversationRuntime extends MessagingEventHandler {

--- a/src/sandbox/README.md
+++ b/src/sandbox/README.md
@@ -68,10 +68,13 @@ Consequences to keep in mind:
 - **Extension schedules are agent-visible and agent-tamperable**: they are
   event files in the shared events dir. Ownership prefixes are cooperative,
   not a security boundary — never put secrets in schedule text.
-- **Known gap:** the events dir is global and agent-writable, so a container
-  can write an event targeting _another_ conversation (cross-conversation
-  instruction injection). Fix under consideration: per-conversation events
-  subdirectories with provenance-based trust.
+- **The events dir is a workspace-level scheduling bus — by design.** It is
+  global and agent-writable, so any conversation's agent (or extension, or
+  admin) can schedule runs in _any_ conversation. This is deliberate: one
+  mikan workspace is one trust domain for scheduling, and cross-conversation
+  events are exactly how PM-style workflows post reminders into other
+  channels (e.g. agent-pm). Do not "fix" this by scoping events per
+  conversation.
 - Auto-reply config files live in the conversation dir and are therefore
   agent-toggleable (feature is deprecated).
 

--- a/src/sandbox/README.md
+++ b/src/sandbox/README.md
@@ -14,3 +14,71 @@ This directory defines sandbox abstractions, concrete sandbox executors, and sha
 - `path-context.ts`: Builds mounted runtime path contexts and translates runtime paths back to host paths.
 - `types.ts`: Defines all sandbox configs, executors, exec results, runtime path contexts, and adapter types.
 - `utils.ts`: Provides simple child-process execution, process-tree killing, and shell escaping.
+
+## Host / sandbox path boundary (image mode)
+
+mikan's primary deployment is `image:*`: the mikan process (LLM calls, session
+persistence, extensions, platform bots) runs on the **host**, while agent tool
+commands execute inside a per-conversation **container**. Everything on disk
+belongs to exactly one of three trust classes:
+
+### Host-only — under the state dir (`~/.mikan`), never mounted
+
+| Path                               | Contents                                                        |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `settings.json`                    | global settings                                                 |
+| `conversations/<id>/settings.json` | conversation settings (model, mount mode, …)                    |
+| `auth.json`, `models.json`         | provider credentials and model catalog                          |
+| `extensions/…`                     | extension **code** (runs in the host process)                   |
+| `extension-data/<slug>/`           | per-extension data dirs                                         |
+| `vaults/…`                         | credentials; `vaults/extensions/<slug>/env` = extension secrets |
+
+Rules enforced in code:
+
+- Extension code loads only from the state dir (`defaultExtensionDirs`);
+  loading from a mounted path would let sandboxed code run on the host.
+- Conversation settings are read from the state dir only. They historically
+  lived at `<conversationDir>/settings.json` — which is bind-mounted rw — so
+  a sandboxed agent could flip its own `sandbox.image.workspaceMount` to
+  "full" and remount the whole workspace. `conversationSettingsPath()`
+  migrates legacy files once and never reads the mounted location again.
+- Startup refuses (fatal under sandboxed modes) a `--state-dir` located
+  inside the working directory (`assertStateDirOutsideWorkspace`).
+- Multi-instance hosts should give each instance its own `--state-dir`;
+  conversation settings, auth, and vaults are keyed per state dir.
+
+### Mounted read-write into the container — agent-writable by design
+
+| Mount (private mode)                                | Purpose                                    |
+| --------------------------------------------------- | ------------------------------------------ |
+| `MEMORY.md` → `/workspace/MEMORY.md`                | agent-maintained global memory             |
+| `skills/` → `/workspace/skills`                     | agent-creatable skills                     |
+| `events/` → `/workspace/events`                     | event files (agent self-scheduling)        |
+| `<conversationId>/` → `/workspace/<conversationId>` | sessions, scratch, per-conversation skills |
+| vault mounts                                        | per-user credential injection              |
+
+Full mode (per-conversation, admin/`/sandbox full`) mounts the entire working
+directory at `/workspace` instead.
+
+Consequences to keep in mind:
+
+- **Session files are agent-writable.** A corrupted session header makes
+  `SessionStore.open` throw instead of silently starting a fresh session
+  (which would erase history on the next append); `/new` recovers.
+- **Extension schedules are agent-visible and agent-tamperable**: they are
+  event files in the shared events dir. Ownership prefixes are cooperative,
+  not a security boundary — never put secrets in schedule text.
+- **Known gap:** the events dir is global and agent-writable, so a container
+  can write an event targeting _another_ conversation (cross-conversation
+  instruction injection). Fix under consideration: per-conversation events
+  subdirectories with provenance-based trust.
+- Auto-reply config files live in the conversation dir and are therefore
+  agent-toggleable (feature is deprecated).
+
+### Paths in prompts and tool output
+
+The model only ever sees **runtime** paths (`/workspace/…`); the host only
+ever touches **host** paths. `path-context.ts` translates between them
+(skill locations, upload paths). Extension-shipped skills are the exception:
+their files live under the host-only state dir, so their bodies are inlined
+into the system prompt instead of referenced by path.

--- a/src/sessions/agent-memory-file-manager.ts
+++ b/src/sessions/agent-memory-file-manager.ts
@@ -1,4 +1,4 @@
-import { SessionManager, type SessionEntry } from "@earendil-works/pi-coding-agent";
+import type { SessionEntry, SessionStore } from "../harness/index.js";
 import { join } from "path";
 import type { ConversationLogMessage } from "../types.js";
 import { isRecord, parseJsonValue, readTextFileIfExists } from "../utils/file-guards.js";
@@ -26,7 +26,7 @@ const CHAT_SYNC_CUSTOM_TYPE = "mikan.chat_sync";
 const BIWEEKLY_ROTATION_ANCHOR = new Date(2026, 0, 4); // Sunday
 const BIWEEKLY_MS = 14 * 24 * 60 * 60 * 1000;
 
-type SessionAppendMessage = Parameters<SessionManager["appendMessage"]>[0];
+type SessionAppendMessage = Parameters<SessionStore["appendMessage"]>[0];
 
 interface LogRecord {
   message: ConversationLogMessage;
@@ -171,7 +171,6 @@ export class AgentMemoryFileManager {
       if (!options.rotateTopLevelSession || !shouldRotateTopLevelSession(existing, this.now())) {
         syncSessionFromLog(
           existing,
-          options.sessionDir,
           options.cwd,
           selectExistingSessionSyncMessages(records, {
             sessionKey: null,
@@ -192,7 +191,6 @@ export class AgentMemoryFileManager {
     });
     bootstrapSessionFromLog(
       sessionFile,
-      options.sessionDir,
       options.cwd,
       bootstrapRecords,
       latestSyncMessageId(records, {
@@ -222,7 +220,6 @@ export class AgentMemoryFileManager {
     if (existing) {
       syncSessionFromLog(
         existing,
-        options.sessionDir,
         options.cwd,
         selectExistingSessionSyncMessages(records, {
           sessionKey: options.sessionKey,
@@ -242,7 +239,6 @@ export class AgentMemoryFileManager {
     });
     bootstrapSessionFromLog(
       threadFile,
-      options.sessionDir,
       options.cwd,
       bootstrapRecords,
       latestSyncMessageId(records, {
@@ -483,14 +479,13 @@ function sortTime(record: LogRecord): number {
 
 function bootstrapSessionFromLog(
   sessionFile: string,
-  sessionDir: string,
   cwd: string,
   records: LogRecord[],
   lastMessageId = records.at(-1)?.message.ts,
 ): void {
   if (records.length === 0 && !lastMessageId) return;
 
-  const sessionManager = openManagedSession(sessionFile, sessionDir, cwd);
+  const sessionManager = openManagedSession(sessionFile, cwd);
   appendLogRecordsToSession(sessionManager, records);
   sessionManager.appendCustomEntry(CHAT_SYNC_CUSTOM_TYPE, {
     source: "log.jsonl",
@@ -508,21 +503,16 @@ interface HistoryWindow {
 
 function syncSessionFromLog(
   sessionFile: string,
-  sessionDir: string,
   cwd: string,
   records: LogRecord[],
   historyWindow: HistoryWindow,
 ): void {
   if (records.length === 0) return;
-  syncSessionManagerFromLog(
-    openManagedSession(sessionFile, sessionDir, cwd),
-    records,
-    historyWindow,
-  );
+  syncSessionManagerFromLog(openManagedSession(sessionFile, cwd), records, historyWindow);
 }
 
 function syncSessionManagerFromLog(
-  sessionManager: SessionManager,
+  sessionManager: SessionStore,
   records: LogRecord[],
   historyWindow: HistoryWindow,
 ): void {
@@ -552,14 +542,14 @@ function syncSessionManagerFromLog(
   });
 }
 
-function appendLogRecordsToSession(sessionManager: SessionManager, records: LogRecord[]): void {
+function appendLogRecordsToSession(sessionManager: SessionStore, records: LogRecord[]): void {
   for (const record of records) {
     const message = buildHistorySessionMessage(record.message);
     if (message) sessionManager.appendMessage(message);
   }
 }
 
-function forceRewriteSession(sessionManager: SessionManager, sessionFile: string): void {
+function forceRewriteSession(sessionManager: SessionStore, sessionFile: string): void {
   const header = sessionManager.getHeader();
   if (!header) return;
 

--- a/src/sessions/metadata.ts
+++ b/src/sessions/metadata.ts
@@ -1,10 +1,10 @@
-import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { SessionStore } from "../harness/index.js";
 export type { MikanSessionHeader } from "./types.js";
 import type { MikanSessionHeader } from "./types.js";
 
 export function isPlatformHistorySession(sessionFile: string): boolean {
   try {
-    const header = SessionManager.open(sessionFile).getHeader() as MikanSessionHeader | null;
+    const header = SessionStore.open(sessionFile).getHeader() as MikanSessionHeader | null;
     return header?.source?.kind === "platform-history";
   } catch {
     return false;

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { basename, dirname, join } from "path";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { SessionStore } from "../harness/index.js";
 import { isRecord, parseJsonValue, readTextFileIfExists } from "../utils/file-guards.js";
 import { atomicWritePrivateFile } from "../utils/fs-atomic.js";
 import { isPlatformHistorySession } from "./metadata.js";
@@ -86,18 +86,14 @@ export function createManagedSessionFile(sessionDir: string, cwd: string): strin
 
 /**
  * Open a session file with an explicit cwd, even if the file does not exist yet.
- * This avoids SessionManager.open() falling back to process.cwd() for fresh sessions.
+ * This avoids SessionStore.open() falling back to process.cwd() for fresh sessions.
  */
-export function openManagedSession(
-  sessionFile: string,
-  sessionDir: string,
-  cwd: string,
-): SessionManager {
+export function openManagedSession(sessionFile: string, cwd: string): SessionStore {
   if (shouldRecreatePreinitializedSession(sessionFile)) {
     rmSync(sessionFile, { force: true });
   }
 
-  return SessionManager.open(sessionFile, sessionDir, cwd);
+  return SessionStore.open(sessionFile, cwd);
 }
 
 function createSessionFilename(sessionId = randomUUID()): string {

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -64,7 +64,7 @@ export interface ResolveChatSessionScopeOptions {
 export interface SyncAgentMemoryFileManagerOptions {
   conversationDir: string;
   sessionKey: string;
-  sessionManager: import("@earendil-works/pi-coding-agent").SessionManager;
+  sessionManager: import("../harness/index.js").SessionStore;
   /** The triggering platform message ID. Excluded from sync to avoid duplicate user turns. */
   currentMessageId?: string;
 }

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -1,10 +1,8 @@
-import { completeSimple } from "@earendil-works/pi-ai/compat";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { join } from "path";
+import { MikanModels } from "./harness/index.js";
 import type { ConversationEvent } from "./adapter.js";
 import { loadAutoReplyJudgeModel, loadConversationAutoReplyConfig } from "./config.js";
 import * as log from "./log.js";
-import { homedir } from "os";
-import { join } from "path";
 import { resolveConfiguredModel } from "./model-registry.js";
 
 const JUDGE_TIMEOUT_MS = 10_000;
@@ -93,16 +91,10 @@ async function judgeAutoReplyWithLlm(input: {
   conversationDir: string;
 }): Promise<boolean> {
   const judgeConfig = loadAutoReplyJudgeModel(input.conversationDir);
-  const modelRegistry = ModelRegistry.create(
-    AuthStorage.create(join(homedir(), ".pi", "mikan", "auth.json")),
-  );
-  const model = resolveConfiguredModel(modelRegistry, judgeConfig.provider, judgeConfig.model);
-  const auth = await modelRegistry.getApiKeyAndHeaders(model);
-  if (!auth.ok) {
-    throw new Error(auth.error);
-  }
+  const models = MikanModels.create();
+  const model = resolveConfiguredModel(models, judgeConfig.provider, judgeConfig.model);
 
-  const answer = await completeSimple(
+  const answer = await models.models.completeSimple(
     model,
     {
       systemPrompt:
@@ -128,8 +120,6 @@ async function judgeAutoReplyWithLlm(input: {
       temperature: 0,
       maxTokens: 4,
       reasoning: "minimal",
-      apiKey: auth.apiKey,
-      headers: auth.headers,
     },
   );
   const text = answer.content

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,17 @@ export interface MessagingBot {
   ): Promise<void>;
 }
 
+/**
+ * Post a plain message to a conversation without triggering an agent run.
+ * Backs extension `api.notify`; implemented in main.ts over the platform bots.
+ * `platform` is required only when more than one platform is running.
+ */
+export type PlatformNotifier = (
+  conversationId: string,
+  text: string,
+  platform?: string,
+) => Promise<void>;
+
 /** Normalized platform data and reply hook for one event. */
 export interface ConversationContext {
   message: ConversationMessage;

--- a/src/vault/index.ts
+++ b/src/vault/index.ts
@@ -7,6 +7,12 @@ import { reportUserFacingError } from "../observability/sentry.js";
 
 const PRIVATE_DIR_MODE = 0o700;
 const SHARED_VAULT_DIR = "shared";
+/**
+ * Top-level vault namespaces that are not user vaults: `shared/<name>` holds
+ * shared login profiles, `extensions/<slug>` holds extension secrets (read
+ * host-side via the harness `api.secrets`, never mounted into sandboxes).
+ */
+const RESERVED_VAULT_DIRS = new Set([SHARED_VAULT_DIR, "extensions"]);
 
 export function normalizeSharedVaultName(name: string): string | undefined {
   const trimmed = name.trim();
@@ -140,7 +146,7 @@ export class FileVaultManager implements VaultManager {
     if (!existsSync(this.vaultsDir)) return [];
     const keys = new Set<string>();
     for (const entry of readdirSync(this.vaultsDir, { withFileTypes: true })) {
-      if (entry.isDirectory()) keys.add(entry.name);
+      if (entry.isDirectory() && !RESERVED_VAULT_DIRS.has(entry.name)) keys.add(entry.name);
     }
     return Array.from(keys, (key) => this.buildResolved(key));
   }

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -1,8 +1,7 @@
 import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "fs";
 import type { IncomingMessage, ServerResponse } from "http";
-import { homedir } from "os";
 import { basename, join, resolve as pathResolve, sep as pathSep } from "path";
-import { AuthStorage, ModelRegistry, SessionManager } from "@earendil-works/pi-coding-agent";
+import { MikanModels, SessionStore } from "../../harness/index.js";
 
 import {
   loadConversationAutoReplyConfig,
@@ -370,7 +369,7 @@ function readSessionUsage(
   label: string,
 ): SessionUsageRow[] {
   try {
-    const manager = SessionManager.open(sessionFile);
+    const manager = SessionStore.open(sessionFile);
     const header = manager.getHeader();
     if (!header) return [];
 
@@ -488,8 +487,7 @@ function serveGlobalSettings(res: ServerResponse): void {
 
 async function serveModelsList(res: ServerResponse): Promise<void> {
   try {
-    const authStorage = AuthStorage.create(join(homedir(), ".pi", "mikan", "auth.json"));
-    const registry = ModelRegistry.create(authStorage);
+    const registry = MikanModels.create();
     const availableModels = await registry.getAvailable();
     const statuses = await resolveAdminModelAccessStatuses(registry, availableModels);
     const models = availableModels.map((model) => ({

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -248,7 +248,11 @@ function listConversationDirs(workingDir: string): string[] {
       const dir = join(workingDir, name);
       try {
         const items = readdirSync(dir);
-        return items.some((item) => SETTINGS_FILES.has(item) || item.endsWith(".jsonl"));
+        // Conversation settings migrated to the state dir, so a sessions/
+        // subdir is the primary marker for existing conversation dirs.
+        return items.some(
+          (item) => item === "sessions" || SETTINGS_FILES.has(item) || item.endsWith(".jsonl"),
+        );
       } catch {
         return false;
       }

--- a/src/web/admin/provider-models.ts
+++ b/src/web/admin/provider-models.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { MikanModels } from "../../harness/index.js";
 
 type AdminModelStatus = "available" | "unverified";
 
@@ -19,7 +19,7 @@ interface ProviderModelsCacheEntry {
 const providerModelsCache = new Map<string, ProviderModelsCacheEntry>();
 
 export async function resolveAdminModelAccessStatuses(
-  registry: ModelRegistry,
+  registry: MikanModels,
   models: Model<Api>[],
 ): Promise<Map<string, AdminModelAccessStatus>> {
   const result = new Map<string, AdminModelAccessStatus>();
@@ -54,7 +54,7 @@ function groupModelsByProvider(models: Model<Api>[]): Map<string, Model<Api>[]> 
 }
 
 async function fetchProviderModelIds(
-  registry: ModelRegistry,
+  registry: MikanModels,
   provider: string,
 ): Promise<Set<string> | undefined> {
   if (provider !== "openai" && provider !== "anthropic") return new Set<string>();

--- a/src/web/session-view/service.ts
+++ b/src/web/session-view/service.ts
@@ -1,12 +1,12 @@
 import { basename, dirname, join, resolve } from "path";
 import { existsSync, readdirSync } from "fs";
 import {
-  SessionManager,
+  SessionStore,
   type BranchSummaryEntry as SessionBranchSummaryEntry,
   type CompactionEntry,
   type SessionEntry,
   type SessionMessageEntry,
-} from "@earendil-works/pi-coding-agent";
+} from "../../harness/index.js";
 import {
   getThreadSessionFile,
   resolveChannelSessionFile,
@@ -32,7 +32,7 @@ export function resolveExistingSessionFile(
 
 export function loadSessionViewModel(sessionFile: string): SessionViewModel {
   const resolvedFile = resolve(sessionFile);
-  const sm = SessionManager.open(resolvedFile);
+  const sm = SessionStore.open(resolvedFile);
   const header = sm.getHeader();
   if (!header) throw new Error(`No valid session found: ${sessionFile}`);
 
@@ -98,9 +98,9 @@ export function resolveRequestedSessionFile(
   const candidate = join(dirname(resolvedBase), fileName);
   if (!existsSync(candidate)) return null;
 
-  let sm: SessionManager;
+  let sm: SessionStore;
   try {
-    sm = SessionManager.open(candidate);
+    sm = SessionStore.open(candidate);
   } catch (err) {
     throw new Error(
       `Session file is corrupted: ${candidate}: ${
@@ -129,9 +129,9 @@ function buildSessionRelation(
   kind: "parent" | "thread",
   expectedParent?: string,
 ): SessionViewRelation | null {
-  let sm: SessionManager;
+  let sm: SessionStore;
   try {
-    sm = SessionManager.open(sessionFile);
+    sm = SessionStore.open(sessionFile);
   } catch (err) {
     log.logWarning(
       `Skipping corrupted session file while building ${kind} relation: ${sessionFile}`,
@@ -158,7 +158,7 @@ function buildSessionRelation(
   const threadId = kind === "thread" ? getFixedThreadSessionId(sessionFile) : null;
   const anchorEntryId =
     kind === "thread" && expectedParent
-      ? findThreadAnchorEntryId(SessionManager.open(expectedParent).getEntries(), entries, threadId)
+      ? findThreadAnchorEntryId(SessionStore.open(expectedParent).getEntries(), entries, threadId)
       : undefined;
   return {
     kind,

--- a/test/agent-prompt.test.ts
+++ b/test/agent-prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   appendTriggerAttribution,
+  buildTurnInstructions,
   getUnresolvedSandboxPathContext,
   resolveTriggerAttribution,
   translateAttachPathToHost,
@@ -71,6 +72,27 @@ describe("append trigger attribution", () => {
         "https://mikan/session?t=1",
       ),
     ).toBe("Done.\n\n_Triggered by [event: daily] · session: https://mikan/session?t=1_");
+  });
+});
+
+describe("turn instructions", () => {
+  test("empty for a plain interactive turn", () => {
+    expect(buildTurnInstructions(false, undefined, "slack")).toBe("");
+  });
+
+  test("includes attribution with the platform name and trigger", () => {
+    const result = buildTurnInstructions(false, "@david", "slack");
+    expect(result).toContain("## Attribution");
+    expect(result).toContain("final slack response");
+    expect(result).toContain("_Triggered by @david_");
+    expect(result).not.toContain("## Event Trigger Mode");
+  });
+
+  test("includes event-trigger mode for event runs", () => {
+    const result = buildTurnInstructions(true, "[event: daily]", "telegram");
+    expect(result).toContain("## Event Trigger Mode");
+    expect(result).toContain("## Attribution");
+    expect(result).toContain("_Triggered by [event: daily]_");
   });
 });
 

--- a/test/chat-session-manager.test.ts
+++ b/test/chat-session-manager.test.ts
@@ -1,17 +1,13 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { SessionStore } from "../src/harness/index.js";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   AgentMemoryFileManager,
   registerThreadSession,
 } from "../src/sessions/agent-memory-file-manager.js";
-import {
-  getChannelSessionDir,
-  getThreadSessionFile,
-  openManagedSession,
-} from "../src/sessions/store.js";
+import { getThreadSessionFile, openManagedSession } from "../src/sessions/store.js";
 
 let conversationDir: string;
 
@@ -36,11 +32,7 @@ function writeLog(entries: object[]): void {
 }
 
 function readContextText(sessionFile: string): string {
-  const session = SessionManager.open(
-    sessionFile,
-    getChannelSessionDir(conversationDir),
-    conversationDir,
-  );
+  const session = SessionStore.open(sessionFile, conversationDir);
   return session
     .buildSessionContext()
     .messages.map((message) =>

--- a/test/chat-session-manager.test.ts
+++ b/test/chat-session-manager.test.ts
@@ -381,11 +381,7 @@ describe("AgentMemoryFileManager", () => {
       cwd: conversationDir,
       currentMessageId: "1000.0003",
     });
-    const session = openManagedSession(
-      firstScope.contextFile,
-      firstScope.sessionDir,
-      conversationDir,
-    );
+    const session = openManagedSession(firstScope.contextFile, conversationDir);
     session.appendMessage({
       role: "user",
       content: [{ type: "text", text: "[2026-05-01 00:00:02+00:00] [alice]: next one is?" }],
@@ -587,7 +583,7 @@ describe("AgentMemoryFileManager", () => {
       currentMessageId: "1000.0003",
     });
 
-    const session = openManagedSession(scope.contextFile, scope.sessionDir, conversationDir);
+    const session = openManagedSession(scope.contextFile, conversationDir);
     session.appendMessage({
       role: "user",
       content: [{ type: "text", text: "[alice]: current message" }],
@@ -661,7 +657,7 @@ describe("AgentMemoryFileManager", () => {
       cwd: conversationDir,
       currentMessageId: "2000.0002",
     });
-    const session = openManagedSession(scope.contextFile, scope.sessionDir, conversationDir);
+    const session = openManagedSession(scope.contextFile, conversationDir);
 
     manager.syncSessionManager({
       conversationDir,

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { MessagingBot, ConversationResponder } from "../src/adapter.js";
 import { AdminCommandHandler } from "../src/commands/admin.js";
 import { AutoReplyCommandHandler } from "../src/commands/auto-reply.js";
+import { conversationSettingsPath } from "../src/config.js";
 import { dispatchCommand } from "../src/commands/registry.js";
 import { LoginCommandHandler } from "../src/commands/login.js";
 import { NewCommandHandler } from "../src/commands/new.js";
@@ -519,6 +520,7 @@ describe("LoginCommandHandler", () => {
 describe("SandboxCommandHandler", () => {
   const handler = new SandboxCommandHandler();
   let workingDir: string;
+  let sandboxStateDir: string;
 
   beforeEach(() => {
     workingDir = join(
@@ -526,9 +528,14 @@ describe("SandboxCommandHandler", () => {
       `cmd-sandbox-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
     );
     mkdirSync(workingDir, { recursive: true });
+    // Conversation settings are host-authoritative under the state dir.
+    sandboxStateDir = join(workingDir, "state");
+    mkdirSync(sandboxStateDir, { recursive: true });
+    process.env.MIKAN_STATE_DIR = sandboxStateDir;
   });
 
   afterEach(() => {
+    delete process.env.MIKAN_STATE_DIR;
     rmSync(workingDir, { recursive: true, force: true });
   });
 
@@ -568,9 +575,11 @@ describe("SandboxCommandHandler", () => {
 
     expect(await handler.tryHandle(ctx)).toBe(true);
     const sandboxConfig = JSON.parse(
-      readFileSync(join(workingDir, "C123", "settings.json"), "utf-8"),
+      readFileSync(conversationSettingsPath(join(workingDir, "C123")), "utf-8"),
     ) as { sandbox: { image: { workspaceMount: string } } };
     expect(sandboxConfig.sandbox.image.workspaceMount).toBe("full");
+    // Never written into the (sandbox-mounted) conversation dir.
+    expect(existsSync(join(workingDir, "C123", "settings.json"))).toBe(false);
     expect(ctx.responder.responses[0]).toContain("Workspace mount: full");
   });
 
@@ -592,7 +601,7 @@ describe("SandboxCommandHandler", () => {
 
     expect(await handler.tryHandle(ctx)).toBe(true);
     const sandboxConfig = JSON.parse(
-      readFileSync(join(workingDir, "C123", "settings.json"), "utf-8"),
+      readFileSync(conversationSettingsPath(join(workingDir, "C123")), "utf-8"),
     ) as { sandbox: { image: { workspaceMount: string } } };
     expect(sandboxConfig.sandbox.image.workspaceMount).toBe("private");
     expect(ctx.responder.responses[0]).toContain("Workspace mount: private");

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
+  assertStateDirOutsideWorkspace,
+  conversationSettingsPath,
   createGlobalSettingsFile,
+  isPathInside,
   loadGlobalSettings,
   resolveConversationSettings,
   resolveSentryDsn,
@@ -186,7 +189,10 @@ describe("loadGlobalSettings", () => {
     expect(config.provider).toBe("openai");
     expect(config.model).toBe("gpt-4o");
     expect(config.thinkingLevel).toBe("low");
-    expect(JSON.parse(readFileSync(join(conversationDir, "settings.json"), "utf-8"))).toEqual({
+    // Settings are host-authoritative: stored under the state dir, never in
+    // the (sandbox-mounted) conversation dir.
+    expect(existsSync(join(conversationDir, "settings.json"))).toBe(false);
+    expect(JSON.parse(readFileSync(conversationSettingsPath(conversationDir), "utf-8"))).toEqual({
       llm: { provider: "openai", model: "gpt-4o", thinkingLevel: "low" },
     });
   });
@@ -198,7 +204,7 @@ describe("loadGlobalSettings", () => {
 
     const config = resolveConversationSettings(conversationDir);
     expect(config.sandboxImageWorkspaceMount).toBe("full");
-    expect(JSON.parse(readFileSync(join(conversationDir, "settings.json"), "utf-8"))).toEqual({
+    expect(JSON.parse(readFileSync(conversationSettingsPath(conversationDir), "utf-8"))).toEqual({
       sandbox: { image: { workspaceMount: "full" } },
     });
   });
@@ -210,9 +216,64 @@ describe("loadGlobalSettings", () => {
 
     const config = resolveConversationSettings(conversationDir);
     expect(config.slack?.replyMode).toBe("thread");
-    expect(JSON.parse(readFileSync(join(conversationDir, "settings.json"), "utf-8"))).toEqual({
+    expect(JSON.parse(readFileSync(conversationSettingsPath(conversationDir), "utf-8"))).toEqual({
       slack: { replyMode: "thread" },
     });
+  });
+
+  test("migrates a legacy conversation settings.json into the state dir once", () => {
+    createGlobalSettingsFile(stateDir);
+    const conversationDir = join(stateDir, "workspace", "C123");
+    mkdirSync(conversationDir, { recursive: true });
+    const legacyPath = join(conversationDir, "settings.json");
+    writeFileSync(legacyPath, JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }));
+
+    const config = resolveConversationSettings(conversationDir);
+    expect(config.sandboxImageWorkspaceMount).toBe("full");
+    // Legacy file was moved out of the (sandbox-mounted) conversation dir.
+    expect(existsSync(legacyPath)).toBe(false);
+    expect(existsSync(conversationSettingsPath(conversationDir))).toBe(true);
+  });
+
+  test("a legacy settings.json appearing after migration is never read (sandbox plant)", () => {
+    createGlobalSettingsFile(stateDir);
+    const conversationDir = join(stateDir, "workspace", "C123");
+    mkdirSync(conversationDir, { recursive: true });
+
+    // First access with no legacy file writes the migration marker.
+    // (Global onboard settings default the mount mode to "private".)
+    expect(resolveConversationSettings(conversationDir).sandboxImageWorkspaceMount).toBe("private");
+
+    // An agent inside the sandbox plants a legacy settings.json afterwards,
+    // trying to flip its own mount mode to full. It must stay ignored.
+    writeFileSync(
+      join(conversationDir, "settings.json"),
+      JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }),
+    );
+    expect(resolveConversationSettings(conversationDir).sandboxImageWorkspaceMount).toBe("private");
+    // And it is not deleted either: only pre-migration files are moved.
+    expect(existsSync(join(conversationDir, "settings.json"))).toBe(true);
+  });
+});
+
+describe("state dir placement guard", () => {
+  test("isPathInside is lexical and slash-aware", () => {
+    expect(isPathInside("/work/state", "/work")).toBe(true);
+    expect(isPathInside("/work", "/work")).toBe(true);
+    expect(isPathInside("/work-state", "/work")).toBe(false);
+    expect(isPathInside("/elsewhere", "/work")).toBe(false);
+  });
+
+  test("throws under sandboxed modes when state dir is inside the working dir", () => {
+    expect(() => assertStateDirOutsideWorkspace("/work/.mikan", "/work", "image")).toThrow(
+      /must not be inside the working directory/,
+    );
+    expect(() => assertStateDirOutsideWorkspace("/work/.mikan", "/work", "container")).toThrow();
+  });
+
+  test("host mode only warns; disjoint paths always pass", () => {
+    expect(() => assertStateDirOutsideWorkspace("/work/.mikan", "/work", "host")).not.toThrow();
+    expect(() => assertStateDirOutsideWorkspace("/home/u/.mikan", "/work", "image")).not.toThrow();
   });
 });
 

--- a/test/harness-auth.test.ts
+++ b/test/harness-auth.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { FileCredentialStore } from "../src/harness/index.js";
+
+let dir: string;
+let authPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mikan-harness-auth-"));
+  authPath = join(dir, "auth.json");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("FileCredentialStore", () => {
+  test("reads credentials from an existing auth.json", async () => {
+    writeFileSync(authPath, JSON.stringify({ anthropic: { type: "api_key", key: "sk-test" } }));
+    const store = new FileCredentialStore(authPath);
+    expect(await store.read("anthropic")).toEqual({ type: "api_key", key: "sk-test" });
+    expect(await store.read("missing")).toBeUndefined();
+  });
+
+  test("modify persists atomically with private permissions", async () => {
+    const store = new FileCredentialStore(authPath);
+    await store.modify("openai", async () => ({ type: "api_key", key: "sk-new" }));
+
+    const written = JSON.parse(readFileSync(authPath, "utf-8")) as Record<string, unknown>;
+    expect(written.openai).toEqual({ type: "api_key", key: "sk-new" });
+    expect(statSync(authPath).mode & 0o777).toBe(0o600);
+  });
+
+  test("modify returning undefined leaves the entry unchanged", async () => {
+    writeFileSync(authPath, JSON.stringify({ openai: { type: "api_key", key: "keep" } }));
+    const store = new FileCredentialStore(authPath);
+    const result = await store.modify("openai", async () => undefined);
+    expect(result).toEqual({ type: "api_key", key: "keep" });
+  });
+
+  test("delete removes a provider entry", async () => {
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        a: { type: "api_key", key: "1" },
+        b: { type: "api_key", key: "2" },
+      }),
+    );
+    const store = new FileCredentialStore(authPath);
+    await store.delete("a");
+    const written = JSON.parse(readFileSync(authPath, "utf-8")) as Record<string, unknown>;
+    expect(Object.keys(written)).toEqual(["b"]);
+  });
+
+  test("malformed auth.json reads as empty instead of throwing", async () => {
+    writeFileSync(authPath, "not json");
+    const store = new FileCredentialStore(authPath);
+    expect(await store.read("anything")).toBeUndefined();
+  });
+});

--- a/test/harness-extensions.test.ts
+++ b/test/harness-extensions.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { ExtensionRegistry, loadExtensions } from "../src/harness/index.js";
+import { defaultExtensionDirs, ExtensionRegistry, loadExtensions } from "../src/harness/index.js";
 import type { Api, Model } from "@earendil-works/pi-ai";
 
 let dir: string;
@@ -33,6 +33,20 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
+});
+
+describe("defaultExtensionDirs", () => {
+  test("returns host-only global and per-conversation dirs under the state dir", () => {
+    expect(defaultExtensionDirs("C123", "/state")).toEqual([
+      join("/state", "extensions", "global"),
+      join("/state", "extensions", "C123"),
+    ]);
+  });
+
+  test("defaults the state dir to ~/.mikan", () => {
+    const [globalDir] = defaultExtensionDirs("C123");
+    expect(globalDir.endsWith(join(".mikan", "extensions", "global"))).toBe(true);
+  });
 });
 
 describe("loadExtensions", () => {

--- a/test/harness-extensions.test.ts
+++ b/test/harness-extensions.test.ts
@@ -1,0 +1,125 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { ExtensionRegistry, loadExtensions } from "../src/harness/index.js";
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+let dir: string;
+
+const testModel = {
+  id: "test-model",
+  name: "Test",
+  api: "openai-completions",
+  provider: "test",
+  baseUrl: "",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1000,
+  maxTokens: 100,
+} as Model<Api>;
+
+const context = {
+  conversationId: "C123",
+  workspaceDir: "/work",
+  model: testModel,
+  thinkingLevel: "off" as const,
+};
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mikan-harness-ext-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("loadExtensions", () => {
+  test("activates default-export extensions and dispatches hooks", async () => {
+    writeFileSync(
+      join(dir, "blocker.mjs"),
+      `export default function activate(api) {
+        api.on("tool_call", ({ toolName }) => {
+          if (toolName === "bash") return { block: true, reason: "no shell" };
+        });
+      }
+      `,
+    );
+
+    const { registry, extensions, errors } = await loadExtensions({ dirs: [dir], context });
+    expect(errors).toHaveLength(0);
+    expect(extensions).toHaveLength(1);
+
+    const blocked = await registry.emit("tool_call", {
+      toolCallId: "t1",
+      toolName: "bash",
+      args: {},
+    });
+    expect(blocked).toEqual({ block: true, reason: "no shell" });
+
+    const allowed = await registry.emit("tool_call", {
+      toolCallId: "t2",
+      toolName: "read",
+      args: {},
+    });
+    expect(allowed).toBeUndefined();
+  });
+
+  test("supports named activate exports in index.js directories", async () => {
+    const extDir = join(dir, "named");
+    mkdirSync(extDir, { recursive: true });
+    writeFileSync(
+      join(extDir, "index.mjs"),
+      `export const name = "named-extension";
+      export function activate(api) {
+        api.registerTool({ name: "custom_tool", description: "d", parameters: { type: "object", properties: {} }, execute: async () => ({ content: [] }) });
+      }
+      `,
+    );
+
+    const { registry, extensions } = await loadExtensions({ dirs: [dir], context });
+    expect(extensions[0]?.name).toBe("named-extension");
+    expect(registry.getContributedTools().map((tool) => tool.name)).toEqual(["custom_tool"]);
+  });
+
+  test("collects module errors without failing the load", async () => {
+    writeFileSync(join(dir, "broken.mjs"), "throw new Error('boom');\n");
+    writeFileSync(join(dir, "no-activate.mjs"), "export const nothing = 1;\n");
+
+    const { extensions, errors } = await loadExtensions({ dirs: [dir], context });
+    expect(extensions).toHaveLength(0);
+    expect(errors).toHaveLength(2);
+  });
+
+  test("missing directories are skipped", async () => {
+    const { extensions, errors } = await loadExtensions({
+      dirs: [join(dir, "missing")],
+      context,
+    });
+    expect(extensions).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe("ExtensionRegistry", () => {
+  test("handler errors are isolated and later handlers still run", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("bad", "tool_call", () => {
+      throw new Error("broken handler");
+    });
+    registry.register("good", "tool_call", () => ({ block: true }));
+
+    const result = await registry.emit("tool_call", { toolCallId: "t", toolName: "x", args: {} });
+    expect(result).toEqual({ block: true });
+  });
+
+  test("first non-undefined result wins", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("first", "tool_call", () => ({ block: false }));
+    registry.register("second", "tool_call", () => ({ block: true }));
+
+    const result = await registry.emit("tool_call", { toolCallId: "t", toolName: "x", args: {} });
+    expect(result).toEqual({ block: false });
+  });
+});

--- a/test/harness-extensions.test.ts
+++ b/test/harness-extensions.test.ts
@@ -1,8 +1,15 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { defaultExtensionDirs, ExtensionRegistry, loadExtensions } from "../src/harness/index.js";
+import {
+  defaultExtensionDirs,
+  extensionSlug,
+  ExtensionRegistry,
+  loadExtensions,
+  type ExtensionSchedulePayload,
+  type ExtensionScheduleStore,
+} from "../src/harness/index.js";
 import type { Api, Model } from "@earendil-works/pi-ai";
 
 let dir: string;
@@ -113,6 +120,216 @@ describe("loadExtensions", () => {
     });
     expect(extensions).toHaveLength(0);
     expect(errors).toHaveLength(0);
+  });
+});
+
+describe("extensionSlug", () => {
+  test("directory-form extensions slug from the directory name", () => {
+    expect(extensionSlug("/x/extensions/global/Agent PM/index.mjs")).toBe("agent-pm");
+    expect(extensionSlug("/x/extensions/global/agent-pm/index.js")).toBe("agent-pm");
+  });
+
+  test("file-form extensions slug from the file basename", () => {
+    expect(extensionSlug("/x/extensions/global/Audit Log.mjs")).toBe("audit-log");
+  });
+});
+
+function createFakeScheduleStore() {
+  const files = new Map<string, ExtensionSchedulePayload>();
+  const store: ExtensionScheduleStore = {
+    write: async (filename, payload) => {
+      files.set(filename, payload);
+    },
+    delete: async (filename) => files.delete(filename),
+    list: async () => [...files.entries()].map(([filename, payload]) => ({ filename, payload })),
+  };
+  return { files, store };
+}
+
+describe("loadExtensions v2 api", () => {
+  /**
+   * Write a directory-form probe extension whose activate body can report
+   * results by writing JSON to the `out` path (lint-safe, no globals).
+   */
+  function writeProbeExtension(body: string): { extDir: string; out: string; read: () => any } {
+    const extDir = join(dir, "probe");
+    const out = join(dir, "probe-out.json");
+    mkdirSync(extDir, { recursive: true });
+    writeFileSync(
+      join(extDir, "index.mjs"),
+      `import { writeFileSync } from "node:fs";
+      const report = (data) => writeFileSync(${JSON.stringify(out)}, JSON.stringify(data));
+      ${body}
+      `,
+    );
+    return { extDir, out, read: () => JSON.parse(readFileSync(out, "utf-8")) };
+  }
+
+  test("manifest.json provides name, version, and description", async () => {
+    const { extDir } = writeProbeExtension("export default function activate() {}");
+    writeFileSync(
+      join(extDir, "manifest.json"),
+      JSON.stringify({ name: "Probe 探針", version: "1.2.3", description: "a probe" }),
+    );
+
+    const { extensions, errors } = await loadExtensions({ dirs: [dir], context });
+    expect(errors).toHaveLength(0);
+    expect(extensions[0]).toMatchObject({
+      name: "Probe 探針",
+      slug: "probe",
+      version: "1.2.3",
+      description: "a probe",
+    });
+  });
+
+  test("malformed manifest.json is ignored and the extension still loads", async () => {
+    const { extDir } = writeProbeExtension("export default function activate() {}");
+    writeFileSync(join(extDir, "manifest.json"), "{not json");
+
+    const { extensions, errors } = await loadExtensions({ dirs: [dir], context });
+    expect(errors).toHaveLength(0);
+    expect(extensions[0]?.name).toBe("probe");
+  });
+
+  test("api.paths.dataDir creates a per-slug dir under the state dir", async () => {
+    const probe = writeProbeExtension(
+      "export default function activate(api) { report({ dataDir: api.paths.dataDir }); }",
+    );
+
+    const { errors } = await loadExtensions({
+      dirs: [dir],
+      context,
+      services: { stateDir: join(dir, "state") },
+    });
+    expect(errors).toHaveLength(0);
+    const { dataDir } = probe.read() as { dataDir: string };
+    expect(dataDir).toBe(join(dir, "state", "extension-data", "probe"));
+    expect(existsSync(dataDir)).toBe(true);
+  });
+
+  test("api.secrets reads from the injected resolver, keyed by slug", async () => {
+    const probe = writeProbeExtension(
+      `export default function activate(api) {
+        report({ token: api.secrets.get("TOKEN"), keys: api.secrets.list() });
+      }`,
+    );
+
+    const { errors } = await loadExtensions({
+      dirs: [dir],
+      context,
+      services: {
+        resolveSecrets: (slug) => (slug === "probe" ? { TOKEN: "s3cret", OTHER: "x" } : {}),
+      },
+    });
+    expect(errors).toHaveLength(0);
+    expect(probe.read()).toEqual({ token: "s3cret", keys: ["TOKEN", "OTHER"] });
+  });
+
+  test("api.schedules scopes files by slug + conversation and round-trips specs", async () => {
+    const { files, store } = createFakeScheduleStore();
+    // A schedule from another extension/conversation must not leak into list().
+    files.set("ext.other.c123.job.json", {
+      type: "periodic",
+      conversationId: "C123",
+      text: "other",
+      schedule: "0 9 * * *",
+      timezone: "UTC",
+    });
+
+    const probe = writeProbeExtension(
+      `export default async function activate(api) {
+        await api.schedules.upsert("Daily Sweep", {
+          type: "periodic",
+          schedule: "0 9 * * *",
+          timezone: "Asia/Taipei",
+          text: "review overdue follow-ups",
+        });
+        await api.schedules.upsert("kickoff", {
+          type: "one-shot",
+          at: "2026-08-01T09:00:00+08:00",
+          text: "kick off",
+        });
+        const listed = await api.schedules.list();
+        const deleted = await api.schedules.delete("kickoff");
+        report({ names: listed.map((info) => info.name).toSorted(), deleted });
+      }`,
+    );
+
+    const { errors } = await loadExtensions({
+      dirs: [dir],
+      context,
+      services: { scheduleStore: store },
+    });
+    expect(errors).toHaveLength(0);
+
+    expect(files.get("ext.probe.c123.daily-sweep.json")).toEqual({
+      type: "periodic",
+      conversationId: "C123",
+      text: "review overdue follow-ups",
+      schedule: "0 9 * * *",
+      timezone: "Asia/Taipei",
+    });
+    expect(probe.read()).toEqual({ names: ["daily-sweep", "kickoff"], deleted: true });
+    expect(files.has("ext.probe.c123.kickoff.json")).toBe(false);
+  });
+
+  test("api.notify posts to the extension's conversation", async () => {
+    const posts: Array<{ conversationId: string; text: string }> = [];
+    writeProbeExtension(
+      'export default async function activate(api) { await api.notify("hello there"); }',
+    );
+
+    const { errors } = await loadExtensions({
+      dirs: [dir],
+      context,
+      services: {
+        postMessage: async (conversationId, text) => {
+          posts.push({ conversationId, text });
+        },
+      },
+    });
+    expect(errors).toHaveLength(0);
+    expect(posts).toEqual([{ conversationId: "C123", text: "hello there" }]);
+  });
+
+  test("service-less contexts surface informative errors for schedules and notify", async () => {
+    const probe = writeProbeExtension(
+      `export default async function activate(api) {
+        const caught = [];
+        try { await api.schedules.upsert("x", { type: "one-shot", at: "2026-01-01T00:00:00Z", text: "t" }); }
+        catch (err) { caught.push(String(err)); }
+        try { await api.notify("x"); }
+        catch (err) { caught.push(String(err)); }
+        report({ caught });
+      }`,
+    );
+
+    const { errors } = await loadExtensions({ dirs: [dir], context });
+    expect(errors).toHaveLength(0);
+    const { caught } = probe.read() as { caught: string[] };
+    expect(caught[0]).toMatch(/schedule store/);
+    expect(caught[1]).toMatch(/platform messaging/);
+  });
+
+  test("skills/ directory contributes inline skills", async () => {
+    const { extDir } = writeProbeExtension("export default function activate() {}");
+    const skillDir = join(extDir, "skills", "triage");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: triage\ndescription: triage follow-ups\n---\nAlways triage before answering.\n",
+    );
+
+    const { skills, extensions, errors } = await loadExtensions({ dirs: [dir], context });
+    expect(errors).toHaveLength(0);
+    expect(skills).toHaveLength(1);
+    expect(skills[0]).toMatchObject({
+      name: "triage",
+      source: "extension:probe",
+      inline: true,
+    });
+    expect(skills[0].content).toContain("Always triage");
+    expect(extensions[0]?.skills).toHaveLength(1);
   });
 });
 

--- a/test/harness-http.test.ts
+++ b/test/harness-http.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import { getGlobalDispatcher, EnvHttpProxyAgent } from "undici";
+import {
+  DEFAULT_HTTP_IDLE_TIMEOUT_MS,
+  configureHttpDispatcher,
+  parseHttpIdleTimeoutMs,
+} from "../src/harness/index.js";
+
+describe("parseHttpIdleTimeoutMs", () => {
+  test("accepts non-negative numbers, flooring fractions", () => {
+    expect(parseHttpIdleTimeoutMs(0)).toBe(0);
+    expect(parseHttpIdleTimeoutMs(30_000)).toBe(30_000);
+    expect(parseHttpIdleTimeoutMs(1500.9)).toBe(1500);
+  });
+
+  test("accepts numeric strings and the disabled keyword", () => {
+    expect(parseHttpIdleTimeoutMs("60000")).toBe(60_000);
+    expect(parseHttpIdleTimeoutMs(" disabled ")).toBe(0);
+    expect(parseHttpIdleTimeoutMs("Disabled")).toBe(0);
+  });
+
+  test("rejects invalid values", () => {
+    expect(parseHttpIdleTimeoutMs("")).toBeUndefined();
+    expect(parseHttpIdleTimeoutMs("soon")).toBeUndefined();
+    expect(parseHttpIdleTimeoutMs(-1)).toBeUndefined();
+    expect(parseHttpIdleTimeoutMs(Number.NaN)).toBeUndefined();
+    expect(parseHttpIdleTimeoutMs(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(parseHttpIdleTimeoutMs(null)).toBeUndefined();
+    expect(parseHttpIdleTimeoutMs(undefined)).toBeUndefined();
+  });
+});
+
+const fetchOverride: typeof globalThis.fetch = () => Promise.reject(new Error("stub"));
+
+describe("configureHttpDispatcher", () => {
+  test("installs an EnvHttpProxyAgent as the global dispatcher", () => {
+    configureHttpDispatcher(DEFAULT_HTTP_IDLE_TIMEOUT_MS);
+    expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  test("swaps global fetch to undici's and keeps it on reconfigure", () => {
+    configureHttpDispatcher();
+    const installedFetch = globalThis.fetch;
+    configureHttpDispatcher(60_000);
+    expect(globalThis.fetch).toBe(installedFetch);
+  });
+
+  test("preserves a deliberate fetch override", () => {
+    configureHttpDispatcher();
+    const installedFetch = globalThis.fetch;
+    globalThis.fetch = fetchOverride;
+    try {
+      configureHttpDispatcher();
+      expect(globalThis.fetch).toBe(fetchOverride);
+    } finally {
+      globalThis.fetch = installedFetch;
+    }
+  });
+
+  test("throws on an unparseable timeout", () => {
+    expect(() => configureHttpDispatcher(-5)).toThrow(/Invalid HTTP idle timeout/);
+  });
+});

--- a/test/harness-runner.test.ts
+++ b/test/harness-runner.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { fauxAssistantMessage, fauxProvider, fauxToolCall } from "@earendil-works/pi-ai";
+import type { Api, Model, MutableModels } from "@earendil-works/pi-ai";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import {
+  ExtensionRegistry,
+  MikanAgentSession,
+  MikanModels,
+  SessionStore,
+  type HarnessEvent,
+} from "../src/harness/index.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mikan-harness-runner-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function createFauxSetup(): {
+  models: MikanModels;
+  faux: ReturnType<typeof fauxProvider>;
+  model: Model<Api>;
+} {
+  // Auth path with a stored key so preflight auth checks pass for the faux provider.
+  const authPath = join(dir, "auth.json");
+  writeFileSync(authPath, JSON.stringify({ faux: { type: "api_key", key: "test-key" } }));
+  const models = MikanModels.create({
+    authPath,
+    modelsJsonPath: join(dir, "models.json"),
+  });
+  const faux = fauxProvider();
+  (models.models as MutableModels).setProvider(faux.provider);
+  return { models, faux, model: faux.getModel() as Model<Api> };
+}
+
+const echoTool: AgentTool = {
+  name: "echo",
+  description: "Echo the input",
+  parameters: { type: "object", properties: { text: { type: "string" } } },
+  execute: async (_toolCallId, args) => ({
+    content: [{ type: "text", text: `echo: ${(args as { text?: string }).text ?? ""}` }],
+  }),
+} as unknown as AgentTool;
+
+describe("MikanAgentSession", () => {
+  test("runs a prompt, persists messages, and reports the final text", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([fauxAssistantMessage("hello from faux")]);
+
+    const sessionFile = join(dir, "session.jsonl");
+    const sessionStore = SessionStore.create(sessionFile, dir);
+    const session = new MikanAgentSession({
+      systemPrompt: "You are a test bot.",
+      model,
+      thinkingLevel: "off",
+      tools: [],
+      models,
+      sessionStore,
+    });
+
+    const events: string[] = [];
+    session.subscribe((event: HarnessEvent) => {
+      events.push(event.type);
+    });
+
+    await session.prompt("hi");
+
+    const lastAssistant = session.messages.findLast((message) => message.role === "assistant");
+    expect(lastAssistant).toBeDefined();
+    expect(JSON.stringify(lastAssistant)).toContain("hello from faux");
+
+    // User + assistant messages are persisted to the session file.
+    const persisted = readFileSync(sessionFile, "utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { type?: string; message?: { role?: string } });
+    const roles = persisted
+      .filter((entry) => entry.type === "message")
+      .map((entry) => entry.message?.role);
+    expect(roles).toEqual(["user", "assistant"]);
+
+    expect(events).toContain("message_start");
+    expect(events).toContain("message_end");
+    expect(events).toContain("agent_end");
+  });
+
+  test("executes tool calls and persists tool results", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([
+      fauxAssistantMessage(fauxToolCall("echo", { text: "ping" })),
+      fauxAssistantMessage("done"),
+    ]);
+
+    const sessionStore = SessionStore.create(join(dir, "session.jsonl"), dir);
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [echoTool],
+      models,
+      sessionStore,
+    });
+
+    await session.prompt("run the tool");
+
+    const roles = sessionStore
+      .getEntries()
+      .filter((entry) => entry.type === "message")
+      .map((entry) => (entry as { message: { role: string } }).message.role);
+    expect(roles).toEqual(["user", "assistant", "toolResult", "assistant"]);
+  });
+
+  test("extension tool_call hooks can block tools", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([
+      fauxAssistantMessage(fauxToolCall("echo", { text: "ping" })),
+      fauxAssistantMessage("acknowledged"),
+    ]);
+
+    const extensions = new ExtensionRegistry();
+    extensions.register("test", "tool_call", ({ toolName }) =>
+      toolName === "echo" ? { block: true, reason: "blocked by test" } : undefined,
+    );
+
+    const sessionStore = SessionStore.create(join(dir, "session.jsonl"), dir);
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [echoTool],
+      models,
+      sessionStore,
+    });
+    // Reuse the runner with hooks by constructing with extensions.
+    const hooked = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [echoTool],
+      models,
+      sessionStore: SessionStore.create(join(dir, "hooked.jsonl"), dir),
+      extensions,
+    });
+    void session;
+
+    await hooked.prompt("run the tool");
+
+    const toolResults = hooked.sessionStore
+      .getEntries()
+      .filter(
+        (entry) =>
+          entry.type === "message" &&
+          (entry as { message: { role: string } }).message.role === "toolResult",
+      );
+    expect(JSON.stringify(toolResults)).toContain("blocked by test");
+  });
+
+  test("throws a clear error when provider auth is missing", async () => {
+    // Custom provider with no key configured anywhere: auth resolution fails.
+    const modelsJsonPath = join(dir, "models.json");
+    writeFileSync(
+      modelsJsonPath,
+      JSON.stringify({
+        providers: {
+          "keyless-provider": {
+            api: "openai-completions",
+            baseUrl: "http://localhost:1/v1",
+            models: [{ id: "m1", name: "M1", input: ["text"], reasoning: false }],
+          },
+        },
+      }),
+    );
+    const models = MikanModels.create({ authPath: join(dir, "auth.json"), modelsJsonPath });
+    const model = models.find("keyless-provider", "m1");
+    expect(model).toBeDefined();
+
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model: model!,
+      thinkingLevel: "off",
+      tools: [],
+      models,
+      sessionStore: SessionStore.create(join(dir, "session.jsonl"), dir),
+    });
+
+    await expect(session.prompt("hi")).rejects.toThrow(/No credentials for provider/);
+  });
+});

--- a/test/harness-runner.test.ts
+++ b/test/harness-runner.test.ts
@@ -162,6 +162,43 @@ describe("MikanAgentSession", () => {
     expect(JSON.stringify(toolResults)).toContain("blocked by test");
   });
 
+  test("budget circuit breaker aborts a run that exceeds the LLM-call cap", async () => {
+    const { models, faux, model } = createFauxSetup();
+    // Would take two LLM calls (tool call, then final); the cap stops it at one.
+    faux.setResponses([
+      fauxAssistantMessage(fauxToolCall("echo", { text: "ping" })),
+      fauxAssistantMessage("done"),
+    ]);
+
+    const sessionStore = SessionStore.create(join(dir, "session.jsonl"), dir);
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [echoTool],
+      models,
+      sessionStore,
+    });
+
+    const events: HarnessEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.prompt("run the tool", { budget: { maxLlmCalls: 1 } });
+
+    const budgetEvent = events.find((event) => event.type === "budget_exceeded");
+    expect(budgetEvent).toBeDefined();
+    if (budgetEvent?.type === "budget_exceeded") {
+      expect(budgetEvent.llmCalls).toBe(1);
+      expect(budgetEvent.reason).toContain("LLM calls");
+    }
+
+    // The cap trips after the first LLM call and aborts the run, so the second
+    // turn produces no output — the "done" response never materializes.
+    expect(JSON.stringify(sessionStore.getEntries())).not.toContain("done");
+  });
+
   test("throws a clear error when provider auth is missing", async () => {
     // Custom provider with no key configured anywhere: auth resolution fails.
     const modelsJsonPath = join(dir, "models.json");

--- a/test/harness-session-store.test.ts
+++ b/test/harness-session-store.test.ts
@@ -1,0 +1,136 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { SessionStore } from "../src/harness/index.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mikan-harness-session-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function readLines(file: string): Array<Record<string, unknown>> {
+  return readFileSync(file, "utf-8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("SessionStore", () => {
+  test("create writes a v3 header and appends persist as JSONL lines", () => {
+    const file = join(dir, "session.jsonl");
+    const store = SessionStore.create(file, "/work");
+    store.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 1 });
+
+    const lines = readLines(file);
+    expect(lines[0]).toMatchObject({ type: "session", version: 3, cwd: "/work" });
+    expect(lines[1]).toMatchObject({ type: "message", parentId: null });
+    expect(typeof lines[1].id).toBe("string");
+    expect((lines[1].id as string).length).toBe(8);
+  });
+
+  test("entries form a parent chain and getBranch returns root-first order", () => {
+    const file = join(dir, "session.jsonl");
+    const store = SessionStore.create(file, "/work");
+    const first = store.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "one" }],
+      timestamp: 1,
+    });
+    const second = store.appendCustomEntry("mikan.test", { n: 2 });
+
+    const branch = store.getBranch();
+    expect(branch.map((entry) => entry.id)).toEqual([first, second]);
+    expect(branch[1].parentId).toBe(first);
+    expect(store.getLeafId()).toBe(second);
+  });
+
+  test("reopens files written by earlier mikan versions (v3 format)", () => {
+    const file = join(dir, "session.jsonl");
+    const header = {
+      type: "session",
+      version: 3,
+      id: "abc-123",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      cwd: "/legacy",
+      source: { kind: "platform-history" },
+    };
+    const entry = {
+      type: "message",
+      id: "aaaa1111",
+      parentId: null,
+      timestamp: "2026-01-01T00:00:01.000Z",
+      message: { role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 },
+    };
+    writeFileSync(file, `${JSON.stringify(header)}\n${JSON.stringify(entry)}\n`);
+
+    const store = SessionStore.open(file);
+    expect(store.getSessionId()).toBe("abc-123");
+    expect(store.getHeader()?.source).toEqual({ kind: "platform-history" });
+    expect(store.getEntries()).toHaveLength(1);
+    expect(store.getLeafId()).toBe("aaaa1111");
+    expect(store.getCwd()).toBe("/legacy");
+  });
+
+  test("buildSessionContext resolves compaction summaries", () => {
+    const file = join(dir, "session.jsonl");
+    const store = SessionStore.create(file, "/work");
+    store.appendMessage({ role: "user", content: [{ type: "text", text: "old" }], timestamp: 1 });
+    const kept = store.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "recent" }],
+      timestamp: 2,
+    });
+    store.appendCompaction("summary of old", kept, 1000);
+
+    const context = store.buildSessionContext();
+    const rendered = context.messages
+      .map((message) => {
+        if ("summary" in message && typeof message.summary === "string") return message.summary;
+        if ("content" in message && Array.isArray(message.content)) {
+          return message.content.map((part) => ("text" in part ? part.text : "")).join("");
+        }
+        return "";
+      })
+      .join("|");
+    expect(rendered).toContain("summary of old");
+    expect(rendered).toContain("recent");
+    expect(rendered).not.toMatch(/(^|\|)old($|\|)/);
+  });
+
+  test("malformed lines are skipped and headerless files read as empty", () => {
+    const file = join(dir, "session.jsonl");
+    writeFileSync(file, 'not json\n{"type":"message"}\n');
+    const store = SessionStore.open(file, "/work");
+    expect(store.getHeader()).toBeNull();
+    expect(store.getEntries()).toHaveLength(0);
+  });
+
+  test("appending to a headerless file materializes the header", () => {
+    const file = join(dir, "fresh.jsonl");
+    const store = SessionStore.open(file, "/work");
+    const sessionId = store.getSessionId();
+    store.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 1 });
+
+    const lines = readLines(file);
+    expect(lines[0]).toMatchObject({ type: "session", version: 3, id: sessionId, cwd: "/work" });
+    expect(lines).toHaveLength(2);
+  });
+
+  test("session name comes from the latest session_info entry", () => {
+    const file = join(dir, "session.jsonl");
+    const store = SessionStore.create(file, "/work");
+    expect(store.getSessionName()).toBeUndefined();
+    store.appendSessionInfo("first name");
+    store.appendSessionInfo("second name");
+    expect(store.getSessionName()).toBe("second name");
+
+    const reopened = SessionStore.open(file);
+    expect(reopened.getSessionName()).toBe("second name");
+  });
+});

--- a/test/harness-session-store.test.ts
+++ b/test/harness-session-store.test.ts
@@ -103,15 +103,27 @@ describe("SessionStore", () => {
     expect(rendered).not.toMatch(/(^|\|)old($|\|)/);
   });
 
-  test("malformed lines are skipped and headerless files read as empty", () => {
+  test("open throws on a file with content but no valid header, instead of silently overwriting", () => {
+    // A file whose header line is corrupted but whose message lines survive
+    // must not be opened as a fresh session: the first append would rewrite
+    // the file and erase the existing history. Surface the corruption instead.
     const file = join(dir, "session.jsonl");
-    writeFileSync(file, 'not json\n{"type":"message"}\n');
-    const store = SessionStore.open(file, "/work");
-    expect(store.getHeader()).toBeNull();
-    expect(store.getEntries()).toHaveLength(0);
+    writeFileSync(file, 'not json\n{"type":"message","content":"kept"}\n');
+    expect(() => SessionStore.open(file, "/work")).toThrow(/corrupted/i);
+    // The original content is left untouched on disk.
+    expect(readFileSync(file, "utf-8")).toContain("kept");
   });
 
-  test("appending to a headerless file materializes the header", () => {
+  test("open treats a whitespace-only file as empty and materializes on append", () => {
+    const file = join(dir, "blank.jsonl");
+    writeFileSync(file, "\n  \n");
+    const store = SessionStore.open(file, "/work");
+    expect(store.getHeader()).toBeNull();
+    store.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 1 });
+    expect(readLines(file)[0]).toMatchObject({ type: "session", version: 3 });
+  });
+
+  test("appending to a missing (headerless) file materializes the header", () => {
     const file = join(dir, "fresh.jsonl");
     const store = SessionStore.open(file, "/work");
     const sessionId = store.getSessionId();

--- a/test/harness-skills.test.ts
+++ b/test/harness-skills.test.ts
@@ -103,6 +103,22 @@ describe("formatSkillsForPrompt", () => {
     expect(prompt).not.toContain("hidden");
   });
 
+  test("inline skills embed instructions instead of a file location", () => {
+    const prompt = formatSkillsForPrompt([
+      {
+        name: "triage",
+        description: "Triage follow-ups",
+        content: "Always triage <first>.",
+        filePath: "/state/extensions/global/agent-pm/skills/triage/SKILL.md",
+        baseDir: "/state/extensions/global/agent-pm/skills/triage",
+        source: "extension:agent-pm",
+        inline: true,
+      },
+    ]);
+    expect(prompt).toContain("<instructions>Always triage &lt;first&gt;.</instructions>");
+    expect(prompt).not.toContain("<location>");
+  });
+
   test("returns empty string when no skills are visible", () => {
     expect(formatSkillsForPrompt([])).toBe("");
   });

--- a/test/harness-skills.test.ts
+++ b/test/harness-skills.test.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  formatSkillsForPrompt,
+  loadSkillsFromDir,
+  parseFrontmatter,
+} from "../src/harness/index.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mikan-harness-skills-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("parseFrontmatter", () => {
+  test("parses key/value pairs and strips quotes", () => {
+    const { values, body } = parseFrontmatter(
+      '---\nname: my-skill\ndescription: "Does things"\n---\n# Body\n',
+    );
+    expect(values).toEqual({ name: "my-skill", description: "Does things" });
+    expect(body).toBe("# Body\n");
+  });
+
+  test("returns full content as body without frontmatter", () => {
+    const { values, body } = parseFrontmatter("# Just markdown\n");
+    expect(values).toEqual({});
+    expect(body).toBe("# Just markdown\n");
+  });
+});
+
+describe("loadSkillsFromDir", () => {
+  test("loads SKILL.md directories and falls back to directory names", () => {
+    const skillDir = join(dir, "email");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\ndescription: Send emails\n---\nUse the script in {baseDir}.\n",
+    );
+
+    const { skills, diagnostics } = loadSkillsFromDir({ dir, source: "workspace" });
+    expect(diagnostics).toHaveLength(0);
+    expect(skills).toHaveLength(1);
+    expect(skills[0]).toMatchObject({
+      name: "email",
+      description: "Send emails",
+      baseDir: skillDir,
+      source: "workspace",
+    });
+  });
+
+  test("skips skills without a description and reports a diagnostic", () => {
+    const skillDir = join(dir, "broken");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "---\nname: broken\n---\nNo description.\n");
+
+    const { skills, diagnostics } = loadSkillsFromDir({ dir, source: "workspace" });
+    expect(skills).toHaveLength(0);
+    expect(diagnostics[0].message).toContain("description is required");
+  });
+
+  test("loads root-level markdown files as skills", () => {
+    writeFileSync(join(dir, "notes.md"), "---\nname: notes\ndescription: Take notes\n---\nBody\n");
+    const { skills } = loadSkillsFromDir({ dir, source: "channel" });
+    expect(skills.map((skill) => skill.name)).toEqual(["notes"]);
+  });
+
+  test("missing directory yields no skills", () => {
+    const { skills } = loadSkillsFromDir({ dir: join(dir, "nope"), source: "workspace" });
+    expect(skills).toHaveLength(0);
+  });
+});
+
+describe("formatSkillsForPrompt", () => {
+  test("renders the available_skills XML block and hides disabled skills", () => {
+    const prompt = formatSkillsForPrompt([
+      {
+        name: "visible",
+        description: "A & B",
+        content: "",
+        filePath: "/skills/visible/SKILL.md",
+        baseDir: "/skills/visible",
+        source: "workspace",
+      },
+      {
+        name: "hidden",
+        description: "Hidden",
+        content: "",
+        filePath: "/skills/hidden/SKILL.md",
+        baseDir: "/skills/hidden",
+        source: "workspace",
+        disableModelInvocation: true,
+      },
+    ]);
+    expect(prompt).toContain("<available_skills>");
+    expect(prompt).toContain("<name>visible</name>");
+    expect(prompt).toContain("A &amp; B");
+    expect(prompt).not.toContain("hidden");
+  });
+
+  test("returns empty string when no skills are visible", () => {
+    expect(formatSkillsForPrompt([])).toBe("");
+  });
+});

--- a/test/model-registry.test.ts
+++ b/test/model-registry.test.ts
@@ -1,15 +1,17 @@
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { MikanModels } from "../src/harness/index.js";
 import { describe, expect, test } from "vitest";
 import { resolveConfiguredModel } from "../src/model-registry.js";
 
-function withTempRegistry(config: unknown): ModelRegistry {
+function withTempRegistry(config: unknown): MikanModels {
   const dir = mkdtempSync(join(tmpdir(), "mikan-model-registry-"));
   writeFileSync(join(dir, "models.json"), JSON.stringify(config));
-  const authStorage = AuthStorage.create(join(dir, "auth.json"));
-  return ModelRegistry.create(authStorage, join(dir, "models.json"));
+  return MikanModels.create({
+    authPath: join(dir, "auth.json"),
+    modelsJsonPath: join(dir, "models.json"),
+  });
 }
 
 describe("resolveConfiguredModel", () => {
@@ -48,10 +50,10 @@ describe("resolveConfiguredModel", () => {
   test("throws a clear error for unknown models", () => {
     const dir = mkdtempSync(join(tmpdir(), "mikan-empty-model-registry-"));
     try {
-      const registry = ModelRegistry.create(
-        AuthStorage.create(join(dir, "auth.json")),
-        join(dir, "models.json"),
-      );
+      const registry = MikanModels.create({
+        authPath: join(dir, "auth.json"),
+        modelsJsonPath: join(dir, "models.json"),
+      });
 
       expect(() => resolveConfiguredModel(registry, "missing", "model")).toThrow(
         'Unknown model "missing/model"',

--- a/test/session-runtime.test.ts
+++ b/test/session-runtime.test.ts
@@ -64,7 +64,7 @@ describe("ConversationRuntime chat session scope", () => {
   test("uses a pre-registered empty thread session for Slack event anchors", async () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const channelFile = createManagedSessionFile(sessionDir, conversationDir);
-    const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
+    const channelSession = openManagedSession(channelFile, conversationDir);
     channelSession.appendMessage(makeUserMessage("channel history should not leak"));
 
     const runtime = makeRuntime();

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -77,7 +77,7 @@ function seedManagedSession(
   text: string,
 ): string {
   createManagedSessionFileAtPath(sessionFile, cwd);
-  const sessionManager = openManagedSession(sessionFile, sessionDir, cwd);
+  const sessionManager = openManagedSession(sessionFile, cwd);
   sessionManager.appendMessage(makeUserMessage(text));
   sessionManager.appendMessage(makeAssistantMessage(`${text} reply`));
   return sessionFile;
@@ -203,7 +203,7 @@ describe("managed session initialization", () => {
   test("creates a channel session with the provided cwd", () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const sessionFile = resolveManagedSessionFile(sessionDir, channelDir);
-    const sessionManager = openManagedSession(sessionFile, sessionDir, channelDir);
+    const sessionManager = openManagedSession(sessionFile, channelDir);
 
     sessionManager.appendMessage(makeUserMessage("hello"));
     sessionManager.appendMessage(makeAssistantMessage("hi"));
@@ -221,7 +221,7 @@ describe("managed session initialization", () => {
   test("opens a missing managed session file with the provided cwd", () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const sessionFile = join(sessionDir, "missing.jsonl");
-    const sessionManager = openManagedSession(sessionFile, sessionDir, channelDir);
+    const sessionManager = openManagedSession(sessionFile, channelDir);
 
     sessionManager.appendMessage(makeUserMessage("hello"));
     sessionManager.appendMessage(makeAssistantMessage("hi"));
@@ -262,10 +262,9 @@ describe("managed session initialization", () => {
   });
 
   test("creates a fixed-path thread session with the provided cwd", () => {
-    const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
-    const sessionManager = openManagedSession(threadFile, sessionDir, channelDir);
+    const sessionManager = openManagedSession(threadFile, channelDir);
 
     sessionManager.appendMessage(makeUserMessage("hello thread"));
     sessionManager.appendMessage(makeAssistantMessage("thread reply"));
@@ -285,14 +284,14 @@ describe("fixed thread sessions", () => {
   test("thread session has a different session ID than channel session", () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
-    const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
+    const channelSM = openManagedSession(channelFile, channelDir);
     channelSM.appendMessage(makeUserMessage("hello channel"));
     channelSM.appendMessage(makeAssistantMessage("hi there"));
     const channelSessionId = channelSM.getSessionId();
 
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
-    const threadSM = openManagedSession(threadFile, sessionDir, channelDir);
+    const threadSM = openManagedSession(threadFile, channelDir);
     threadSM.appendMessage(makeUserMessage("hello thread"));
     threadSM.appendMessage(makeAssistantMessage("thread reply"));
 
@@ -301,10 +300,9 @@ describe("fixed thread sessions", () => {
   });
 
   test("second thread access reuses the same fixed thread file", () => {
-    const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
-    const threadSM = openManagedSession(threadFile, sessionDir, channelDir);
+    const threadSM = openManagedSession(threadFile, channelDir);
     const threadSessionId = threadSM.getSessionId();
 
     threadSM.appendMessage(makeUserMessage("thread msg"));
@@ -313,7 +311,7 @@ describe("fixed thread sessions", () => {
     const existing = tryResolveThreadSession(threadFile);
     expect(existing).toBe(threadFile);
 
-    const reopened = openManagedSession(existing!, sessionDir, channelDir);
+    const reopened = openManagedSession(existing!, channelDir);
     expect(reopened.getSessionId()).toBe(threadSessionId);
     expect(readFileSync(existing!, "utf-8")).toContain("thread msg");
   });
@@ -321,15 +319,15 @@ describe("fixed thread sessions", () => {
   test("different threads get independent session IDs", () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = resolveManagedSessionFile(sessionDir, channelDir);
-    const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
+    const channelSM = openManagedSession(channelFile, channelDir);
 
     const thread1File = getThreadSessionFile(channelDir, "C123:1000.0001");
     const thread2File = getThreadSessionFile(channelDir, "C123:1000.0002");
     createManagedSessionFileAtPath(thread1File, channelDir);
     createManagedSessionFileAtPath(thread2File, channelDir);
 
-    const thread1SM = openManagedSession(thread1File, sessionDir, channelDir);
-    const thread2SM = openManagedSession(thread2File, sessionDir, channelDir);
+    const thread1SM = openManagedSession(thread1File, channelDir);
+    const thread2SM = openManagedSession(thread2File, channelDir);
 
     const ids = new Set([
       channelSM.getSessionId(),
@@ -340,10 +338,9 @@ describe("fixed thread sessions", () => {
   });
 
   test("fresh thread file can be created without a channel source", () => {
-    const sessionDir = getChannelSessionDir(channelDir);
     const threadFile = getThreadSessionFile(channelDir, "C123:1000.0001");
     createManagedSessionFileAtPath(threadFile, channelDir);
-    const threadSM = openManagedSession(threadFile, sessionDir, channelDir);
+    const threadSM = openManagedSession(threadFile, channelDir);
     const entries = threadSM.getEntries().filter((e: { type: string }) => e.type === "message");
     expect(entries.length).toBe(0);
   });
@@ -354,7 +351,7 @@ describe("top-level session rotation", () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const oldFile = createManagedSessionFile(sessionDir, channelDir);
     rewriteSessionTimestamp(oldFile, "2026-01-05T12:00:00.000Z");
-    const oldSession = openManagedSession(oldFile, sessionDir, channelDir);
+    const oldSession = openManagedSession(oldFile, channelDir);
     oldSession.appendMessage(makeUserMessage("stale active context"));
 
     appendLogMessage({
@@ -512,7 +509,7 @@ describe("session-scoped /new reset", () => {
   test("channel /new rotates channel current pointer and keeps thread session intact", () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = createManagedSessionFile(sessionDir, channelDir);
-    const originalChannel = openManagedSession(channelFile, sessionDir, channelDir);
+    const originalChannel = openManagedSession(channelFile, channelDir);
     originalChannel.appendMessage(makeUserMessage("channel"));
     originalChannel.appendMessage(makeAssistantMessage("channel reply"));
 
@@ -530,7 +527,7 @@ describe("session-scoped /new reset", () => {
   test("thread /new resets the same fixed file and keeps channel plus sibling thread intact", () => {
     const sessionDir = getChannelSessionDir(channelDir);
     const channelFile = createManagedSessionFile(sessionDir, channelDir);
-    const channelSM = openManagedSession(channelFile, sessionDir, channelDir);
+    const channelSM = openManagedSession(channelFile, channelDir);
     channelSM.appendMessage(makeUserMessage("channel"));
     channelSM.appendMessage(makeAssistantMessage("channel reply"));
 

--- a/test/session-view.test.ts
+++ b/test/session-view.test.ts
@@ -97,7 +97,7 @@ describe("loadSessionViewModel", () => {
   test("maps session entries into a readable timeline", () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const sessionFile = createManagedSessionFile(sessionDir, conversationDir);
-    const sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
+    const sessionManager = openManagedSession(sessionFile, conversationDir);
 
     sessionManager.appendMessage(makeUserMessage("請幫我看一下測試結果"));
     sessionManager.appendMessage(makeAssistantMessage("好的，我正在查看。"));
@@ -125,7 +125,7 @@ describe("loadSessionViewModel", () => {
   test("preserves assistant content block order and bash execution status details", () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const sessionFile = createManagedSessionFile(sessionDir, conversationDir);
-    const sessionManager = openManagedSession(sessionFile, sessionDir, conversationDir);
+    const sessionManager = openManagedSession(sessionFile, conversationDir);
 
     sessionManager.appendMessage({
       role: "assistant",
@@ -169,7 +169,7 @@ describe("loadSessionViewModel", () => {
   test("keeps channel and thread sessions on separate pages while linking them", () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const channelFile = createManagedSessionFile(sessionDir, conversationDir);
-    const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
+    const channelSession = openManagedSession(channelFile, conversationDir);
     channelSession.appendMessage({
       ...makeUserMessage("channel root"),
       timestamp: Number("1000.0001") * 1000,
@@ -178,7 +178,7 @@ describe("loadSessionViewModel", () => {
 
     const threadFile = getThreadSessionFile(conversationDir, "D123:1000.0001");
     createManagedSessionFileAtPath(threadFile, conversationDir);
-    const threadSession = openManagedSession(threadFile, sessionDir, conversationDir);
+    const threadSession = openManagedSession(threadFile, conversationDir);
     threadSession.appendMessage({
       ...makeUserMessage("channel root"),
       timestamp: Number("1000.0001") * 1000,
@@ -201,7 +201,7 @@ describe("loadSessionViewModel", () => {
   test("anchors fixed thread links to the root instead of earlier bootstrap context", () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const channelFile = createManagedSessionFile(sessionDir, conversationDir);
-    const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
+    const channelSession = openManagedSession(channelFile, conversationDir);
     channelSession.appendMessage({ ...makeUserMessage("prior context"), timestamp: 1 });
     channelSession.appendMessage(makeAssistantMessage("prior reply"));
     channelSession.appendMessage({ ...makeUserMessage("thread root"), timestamp: 2 });
@@ -209,7 +209,7 @@ describe("loadSessionViewModel", () => {
 
     const threadFile = getThreadSessionFile(conversationDir, "D123:1000.0001");
     createManagedSessionFileAtPath(threadFile, conversationDir);
-    const threadSession = openManagedSession(threadFile, sessionDir, conversationDir);
+    const threadSession = openManagedSession(threadFile, conversationDir);
     threadSession.appendMessage({ ...makeUserMessage("prior context"), timestamp: 1 });
     threadSession.appendMessage(makeAssistantMessage("prior reply"));
     threadSession.appendMessage({ ...makeUserMessage("thread root"), timestamp: 2 });
@@ -226,7 +226,7 @@ describe("loadSessionViewModel", () => {
   test("anchors non-timestamp thread files by matching the root message", () => {
     const sessionDir = getChannelSessionDir(conversationDir);
     const channelFile = createManagedSessionFile(sessionDir, conversationDir);
-    const channelSession = openManagedSession(channelFile, sessionDir, conversationDir);
+    const channelSession = openManagedSession(channelFile, conversationDir);
     channelSession.appendMessage(
       makeUserMessage(
         "[2026-04-28 18:18:59+08:00] [alice]: first\n\n<slack_attachments>\n/tmp/a.txt\n</slack_attachments>",
@@ -236,7 +236,7 @@ describe("loadSessionViewModel", () => {
 
     const threadFile = getThreadSessionFile(conversationDir, "D123:M1");
     createManagedSessionFileAtPath(threadFile, conversationDir);
-    const threadSession = openManagedSession(threadFile, sessionDir, conversationDir);
+    const threadSession = openManagedSession(threadFile, conversationDir);
     threadSession.appendMessage(makeUserMessage("[alice]: first"));
     threadSession.appendMessage(makeAssistantMessage("thread reply"));
 

--- a/test/vault.test.ts
+++ b/test/vault.test.ts
@@ -57,6 +57,17 @@ describe("FileVaultManager", () => {
     expect(new FileVaultManager(tmpDir).isEnabled()).toBe(false);
   });
 
+  test("list() skips reserved namespaces (shared profiles, extension secrets)", () => {
+    mkdirSync(join(vaultsDir, "U123"), { recursive: true });
+    writeFileSync(join(vaultsDir, "U123", "env"), "TOKEN=x\n");
+    mkdirSync(join(vaultsDir, "shared", "team-login"), { recursive: true });
+    mkdirSync(join(vaultsDir, "extensions", "agent-pm"), { recursive: true });
+    writeFileSync(join(vaultsDir, "extensions", "agent-pm", "env"), "LINEAR_TOKEN=y\n");
+
+    const keys = new FileVaultManager(tmpDir).list().map((vault) => vault.userId);
+    expect(keys).toEqual(["U123"]);
+  });
+
   test("resolves a vault from directory contents", () => {
     const userDir = join(vaultsDir, "U123");
     mkdirSync(join(userDir, ".ssh"), { recursive: true });


### PR DESCRIPTION
mikan now owns its agent harness engineering layer (`src/harness/`), built
directly on pi-agent-core (agent loop, compaction, context building) and
pi-ai (providers, models, auth, streaming). The pi-coding-agent dependency
is removed — it is a full single-user TUI product of which mikan used only
a small slice, and its assumptions increasingly diverged from mikan's
headless multi-conversation chat-bot needs. On top of the swap, this PR
ships mikan's own extension system (v1 + v2) and closes the host/sandbox
path-boundary holes the audit surfaced.

## 1. Harness (`src/harness/`)

- **SessionStore** — synchronous v3 JSONL session-tree store, file-format
  compatible with all existing mikan session files (replaces `SessionManager`).
  Now refuses to open a file that has content but no valid header instead of
  silently overwriting it on the next append (prevented a permanent
  history-wipe on corrupted files).
- **MikanAgentSession** — run loop with message persistence, auto-compaction
  (threshold + overflow recovery), auto-retry with exponential backoff,
  **budget circuit breakers** (token / cost USD / wall-clock / LLM-call caps;
  autonomous event runs get a default stop-loss, interactive turns are
  uncapped), and extension hook dispatch (replaces `AgentSession`).
- **MikanModels + FileCredentialStore** — model catalog and auth over pi-ai's
  Models collection, same auth.json shape and models.json custom-provider
  subset (replaces `ModelRegistry`/`AuthStorage`).
- **skills** — SKILL.md discovery and prompt formatting, with inline-skill
  support (bodies embedded when the agent cannot read the file at runtime).
- **http** — global fetch via undici EnvHttpProxyAgent: HTTP(S)_PROXY support
  and an idle timeout so a stalled LLM stream errors instead of hanging.
- **Cache-stable system prompt** — per-turn content (event-trigger mode,
  attribution) moved out of the system prompt into turn instructions so the
  provider prompt cache stays warm. Verified live on official Anthropic
  (cache hits confirmed); a per-run `System prompt: N chars, sha XXXX` log
  makes prompt-bit instability vs provider-side misses trivially
  distinguishable.

Compatibility preserved: session JSONL format, auth.json shape, models.json
custom providers, and the event surface consumed by platform adapters
(`budget_exceeded` is additive). Architecture notes in `src/harness/README.md`.

## 2. Extension system (v1 + v2)

ES-module extensions under host-only state-dir paths
(`~/.mikan/extensions/global`, `~/.mikan/extensions/<conversationId>`),
activated per conversation. Extension code runs in the mikan host process;
installing one is an admin action.

- **v1**: hooks (`before_agent_start`, `tool_call` blocking, `tool_result`,
  `message_end`, `turn_end`, `session_compact`) + `registerTool`.
- **v2**: `api.schedules` (named cron/one-shot schedules → event files picked
  up live by EventsWatcher, firing autonomous agent runs), `api.notify`
  (post to the conversation without an agent run, via a PlatformNotifier
  over the platform bots), `api.paths.dataDir`
  (`<stateDir>/extension-data/<slug>`), `api.secrets`
  (`vaults/extensions/<slug>/env`, read-only), `manifest.json`
  (display name/version; slug always derives from the install path), and
  `skills/` auto-discovery (inlined into the prompt; local skills win).
  The harness defines the service interfaces (`ExtensionHostServices`) and
  mikan injects the implementations — other embedders can bring their own.

Reference extension: `examples/extensions/agent-pm/` — a sqlite-backed
follow-up tracker (~200 lines, zero npm deps) with a daily overdue-sweep
schedule, proactive reminders, and a bundled skill; the shape agent-pm-style
integrations are meant to take.

## 3. Host/sandbox path boundary (security)

Audit of `image:*` mode (mikan's primary deployment), map documented in
`src/sandbox/README.md`:

- **Fixed a sandbox self-escalation**: conversation settings lived at
  `<conversationDir>/settings.json`, which is bind-mounted read-write into
  that conversation's container — a sandboxed agent could flip its own
  `sandbox.image.workspaceMount` to `full` and get the entire workspace
  (other conversations' sessions, including other users' DMs) remounted into
  its container. Settings are now host-authoritative at
  `<stateDir>/conversations/<id>/settings.json` with a one-time migration;
  a legacy file (re)appearing later is never read.
- Startup rejects a `--state-dir` inside the working directory under
  sandboxed modes (full-mode mounts would expose extension code, vaults,
  and auth.json to the sandbox).
- Extension code/data/secrets are host-only; extension-shipped skills are
  inlined because sandboxes cannot read the state dir.
- The events dir remains a **workspace-level scheduling bus by design**:
  any conversation's agent can schedule runs in any conversation (this is
  how PM-style workflows post reminders across channels).

## 4. Observability

Startup summary (auth.json/models.json locations + providers found, HTTP
dispatcher timeout/proxy) aimed at upgrade verification; `[notify]` logging;
per-run system-prompt hash; budget-breaker and compaction/retry events were
already logged.

## BREAKING

Config moves from `~/.pi` to `~/.mikan` with **no fallback**: auth.json and
models.json default to `~/.mikan/auth.json` / `~/.mikan/models.json`; the old
`~/.pi/mikan` and `~/.pi/agent` paths are no longer read (file formats are
unchanged — move the files). Conversation settings auto-migrate from
`<conversationDir>/settings.json` to `<stateDir>/conversations/<id>/settings.json`
on first access. pi extensions (`.pi/extensions`) are no longer loaded.

## Verification

- 688 unit tests (59 files), CI green on Node 22.19 / 24 + Cloudflare Pages
- Live Slack deployment: conversations, upgrade path, and prompt caching
  (official Anthropic) verified
- agent-pm example exercised end-to-end through the real loader
  (tool CRUD, schedule file emission, notify, skill inlining,
  per-conversation isolation)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VHumtPaAawmACd6niXLDqP
