### PR TITLE
feat(extensions): extension API expansion — origin, blocking, rewriting, commands, lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ any release.
 
 ### Added
 
+- Add extension chat commands via `api.registerCommand`: deterministic `/name` dispatch with no model call; built-ins and first registrations win.
+- Add an extension disposal lifecycle (`api.onDispose` or an `activate` return value), run when a harness instance is discarded (`/pi-new`, idle eviction, session rotation).
+- Add `api.triggerRun(text)` to fire an immediate autonomous agent run, `api.uploadFile(path, title)` for proactive file uploads, and an explicit `conversationId` option on `api.notify` for cross-conversation posting.
+- Add `agent_error` and `budget_exceeded` extension hooks so monitoring extensions see failed turns and tripped run budgets.
 - Pass a `RunOrigin` (platform, triggering message id, user identity, attachments) to extension hook events, making `api.react` and per-user extension policy usable.
 - Let `before_agent_start` extensions rewrite the user prompt or block the turn before the model runs; blocked turns leave no trace in the transcript or session store.
 - Let `tool_result` extensions rewrite tool output (content and error flag) before the model and the session store see it, enabling secret redaction and output truncation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ any release.
 
 ## [Unreleased]
 
+### Added
+
+- Pass a `RunOrigin` (platform, triggering message id, user identity, attachments) to extension hook events, making `api.react` and per-user extension policy usable.
+- Let `before_agent_start` extensions rewrite the user prompt or block the turn before the model runs; blocked turns leave no trace in the transcript or session store.
+- Let `tool_result` extensions rewrite tool output (content and error flag) before the model and the session store see it, enabling secret redaction and output truncation.
+
+### Changed
+
+- Dispatch `before_agent_start` and `tool_result` hooks with chaining semantics (each handler sees earlier handlers' rewrites; any `block` wins) instead of first-result-wins.
+
 ## [1.0.0-beta.14]
 
 ### Added

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -12,5 +12,6 @@ export type {
   PlatformName,
   PlatformNotifier,
   PlatformReactor,
+  PlatformUploader,
   RunningSession,
 } from "./types.js";

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,6 +19,7 @@ import {
   MikanAgentSession,
   MikanModels,
   type MikanSkill,
+  type RunOrigin,
   type SessionStore,
 } from "./harness/index.js";
 import { createHash } from "crypto";
@@ -1779,10 +1780,40 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
       // Autonomous (event/trigger) runs get an explicit resource ceiling since
       // no human is watching the loop; interactive turns stay human-gated.
       const isEventRun = message.id.startsWith("event:");
-      await session.prompt(prepared.userMessage, {
+      // Event runs have no triggering platform message, so identity fields
+      // stay unset and extensions must null-check them.
+      const origin: RunOrigin = isEventRun
+        ? { kind: "event", platform: platform.name }
+        : {
+            kind: "interactive",
+            platform: platform.name,
+            messageTs: message.id,
+            userId: message.userId,
+            userName: message.userName,
+            threadTs: message.threadTs,
+            attachments: message.attachments,
+          };
+      const outcome = await session.prompt(prepared.userMessage, {
+        origin,
         ...(prepared.imageAttachments.length > 0 ? { images: prepared.imageAttachments } : {}),
         ...(isEventRun ? { budget: DEFAULT_EVENT_BUDGET } : {}),
       });
+
+      if (outcome?.blocked) {
+        const text = outcome.reason
+          ? `_Turn blocked by an extension: ${outcome.reason}_`
+          : "_Turn blocked by an extension._";
+        sendAgentEvent({
+          sessionId: sessionUuid,
+          actorName: formatAgentActorName(message.userName, prepared.sessionConversation),
+          event: { kind: "diagnostic", text },
+        });
+        await responder.respondDiagnostic(text, { style: "muted" });
+        runState.responder = null;
+        runState.logCtx = null;
+        runState.queue = null;
+        return { stopReason: "blocked" };
+      }
 
       // Wait for queued messages
       await prepared.runQueue.wait();

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_EVENT_BUDGET,
   defaultExtensionDirs,
   type ExtensionHostServices,
+  type ExtensionRegistry,
   type ExtensionSchedulePayload,
   formatSkillsForPrompt,
   loadExtensions,
@@ -39,6 +40,7 @@ import type {
   PlatformNotifier,
   PlatformReactor,
   PlatformTrustModel,
+  PlatformUploader,
 } from "./types.js";
 import type { SessionViewTokenStoreLike } from "./commands/types.js";
 import { resolveConversationSettings } from "./config.js";
@@ -949,6 +951,10 @@ interface ConfiguredAgentSession {
   session: MikanAgentSession;
   /** Skills contributed by extensions, merged into each run's system prompt. */
   extensionSkills: MikanSkill[];
+  /** Registry backing extension command dispatch for this harness instance. */
+  extensionRegistry: ExtensionRegistry;
+  /** Runs extension disposers; call once when the runner is discarded. */
+  disposeExtensions: () => Promise<void>;
 }
 
 function createRunnerExecutionContext(
@@ -1012,8 +1018,10 @@ function buildExtensionHostServices(params: {
   vaultManager?: VaultManager;
   platformNotifier?: PlatformNotifier;
   platformReactor?: PlatformReactor;
+  platformUploader?: PlatformUploader;
 }): ExtensionHostServices {
-  const { workspaceDir, vaultManager, platformNotifier, platformReactor } = params;
+  const { workspaceDir, vaultManager, platformNotifier, platformReactor, platformUploader } =
+    params;
   const eventStore = HostEventStore.fromWorkspaceDir(workspaceDir);
   return {
     stateDir: readEnv("STATE_DIR"),
@@ -1034,6 +1042,7 @@ function buildExtensionHostServices(params: {
     },
     ...(platformNotifier ? { postMessage: platformNotifier } : {}),
     ...(platformReactor ? { addReaction: platformReactor } : {}),
+    ...(platformUploader ? { uploadFile: platformUploader } : {}),
     ...(vaultManager
       ? {
           resolveSecrets: (slug: string) => vaultManager.resolve(`extensions/${slug}`)?.env ?? {},
@@ -1054,6 +1063,7 @@ async function createConfiguredAgentSession(params: {
   vaultManager?: VaultManager;
   platformNotifier?: PlatformNotifier;
   platformReactor?: PlatformReactor;
+  platformUploader?: PlatformUploader;
 }): Promise<ConfiguredAgentSession> {
   const {
     conversationId,
@@ -1067,6 +1077,7 @@ async function createConfiguredAgentSession(params: {
     vaultManager,
     platformNotifier,
     platformReactor,
+    platformUploader,
   } = params;
 
   // Host-only dirs under the state dir: extension code runs in the mikan
@@ -1080,6 +1091,7 @@ async function createConfiguredAgentSession(params: {
       vaultManager,
       platformNotifier,
       platformReactor,
+      platformUploader,
     }),
   });
   for (const err of extensionsResult.errors) {
@@ -1105,7 +1117,12 @@ async function createConfiguredAgentSession(params: {
   if (reloaded > 0) {
     log.logInfo(`[${conversationId}] Reloaded ${reloaded} messages from session context`);
   }
-  return { session, extensionSkills: extensionsResult.skills };
+  return {
+    session,
+    extensionSkills: extensionsResult.skills,
+    extensionRegistry: extensionsResult.registry,
+    disposeExtensions: extensionsResult.dispose,
+  };
 }
 
 function reloadSessionMessages(session: MikanAgentSession, conversationId: string): void {
@@ -1602,6 +1619,7 @@ export interface CreateRunnerOptions {
   };
   platformNotifier?: PlatformNotifier;
   platformReactor?: PlatformReactor;
+  platformUploader?: PlatformUploader;
   platformToolPackFactories?: readonly PlatformToolPackFactory[];
   /** Model registry override; defaults to the process-wide models.json load. */
   models?: MikanModels;
@@ -1627,6 +1645,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
     sessionView,
     platformNotifier,
     platformReactor,
+    platformUploader,
     platformToolPackFactories,
   } = options;
   const agentConfig = resolveConversationSettings(conversationDir);
@@ -1697,19 +1716,21 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
 
   const sessionUuid = extractSessionUuid(contextFile);
   const chatSessionManager = new AgentMemoryFileManager();
-  const { session, extensionSkills } = await createConfiguredAgentSession({
-    conversationId,
-    workspaceDir,
-    systemPrompt,
-    model,
-    thinkingLevel: agentConfig.thinkingLevel,
-    tools,
-    sessionStore: sessionManager,
-    models: modelRegistry,
-    vaultManager,
-    platformNotifier,
-    platformReactor,
-  });
+  const { session, extensionSkills, extensionRegistry, disposeExtensions } =
+    await createConfiguredAgentSession({
+      conversationId,
+      workspaceDir,
+      systemPrompt,
+      model,
+      thinkingLevel: agentConfig.thinkingLevel,
+      tools,
+      sessionStore: sessionManager,
+      models: modelRegistry,
+      vaultManager,
+      platformNotifier,
+      platformReactor,
+      platformUploader,
+    });
 
   // Mutable per-run state - event handler references this
   const runState = createRunState();
@@ -1873,6 +1894,25 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
 
     abort(): void {
       session.abort();
+    },
+
+    async tryExtensionCommand(
+      message: ConversationMessage,
+      responder: ConversationResponder,
+    ): Promise<boolean> {
+      const match = /^\/([a-z0-9_-]+)(?:\s+([\s\S]*))?$/i.exec(message.text.trim());
+      if (!match) return false;
+      return extensionRegistry.dispatchCommand(match[1], {
+        args: match[2]?.trim() ?? "",
+        conversationId,
+        userId: message.userId,
+        userName: message.userName,
+        respond: (text: string) => responder.respond(text),
+      });
+    },
+
+    async dispose(): Promise<void> {
+      await disposeExtensions();
     },
 
     getCurrentStep(): { toolName?: string; label?: string } | undefined {

--- a/src/content/docs/extension-development.mdx
+++ b/src/content/docs/extension-development.mdx
@@ -142,16 +142,47 @@ api.on("tool_call", ({ toolName, args }) => {
 });
 ```
 
-| Hook                 | Use                                           |
-| -------------------- | --------------------------------------------- |
-| `before_agent_start` | Replace or append to the turn's system prompt |
-| `tool_call`          | Observe or block a tool call before execution |
-| `tool_result`        | Observe tool output                           |
-| `message_end`        | Observe one completed agent message           |
-| `turn_end`           | Observe the completed turn                    |
-| `session_compact`    | Observe session compaction and its reason     |
+| Hook                 | Use                                                         |
+| -------------------- | ----------------------------------------------------------- |
+| `before_agent_start` | Rewrite the system prompt or user prompt, or block the turn |
+| `tool_call`          | Observe or block a tool call before execution               |
+| `tool_result`        | Observe or rewrite tool output (e.g. redaction, truncation) |
+| `message_end`        | Observe one completed agent message                         |
+| `turn_end`           | Observe the completed turn                                  |
+| `session_compact`    | Observe session compaction and its reason                   |
 
-Hooks run in registration order. For hooks that return a result, the first non-`undefined` result wins. Hook errors are logged and skipped rather than crashing the run.
+Hooks run in registration order. Result semantics are per hook: `tool_call` returns the first non-`undefined` result; `before_agent_start` and `tool_result` chain — each handler sees the event as rewritten by earlier handlers, and a `block` from any `before_agent_start` handler wins regardless of registration order. Hook errors are logged and skipped rather than crashing the run.
+
+#### Run origin
+
+Hook events carry an optional `origin` with the run's platform provenance: `kind` (`"interactive"` or `"event"`), `platform`, and — for interactive runs — `messageTs`, `userId`, `userName`, `threadTs`, and downloaded `attachments`. Use it for per-user policy, and pass `origin.messageTs` to `api.react` to react to the triggering message:
+
+```ts
+api.on("before_agent_start", async ({ origin }) => {
+  if (origin?.kind === "interactive" && origin.userId && !allowlist.has(origin.userId)) {
+    return { block: true, reason: "not authorized for this bot" };
+  }
+  if (origin?.messageTs) await api.react(origin.messageTs, "eyes");
+});
+```
+
+Autonomous runs fired by schedules have no triggering platform message, so identity fields are unset — always null-check them.
+
+#### Blocking a turn
+
+Returning `{ block: true, reason }` from `before_agent_start` stops the turn before the model is called. The user message never enters the transcript or the session store, and the platform shows `reason` as a diagnostic message.
+
+#### Rewriting tool results
+
+Return `{ content }` (and/or `{ isError }`) from `tool_result` to replace what the model — and the persisted session — sees. This is the mechanism for redacting secrets from tool output:
+
+```ts
+api.on("tool_result", ({ content }) => ({
+  content: content.map((part) =>
+    part.type === "text" ? { ...part, text: part.text.replaceAll(SECRET, "***") } : part,
+  ),
+}));
+```
 
 ### Custom tools
 

--- a/src/content/docs/extension-development.mdx
+++ b/src/content/docs/extension-development.mdx
@@ -150,6 +150,8 @@ api.on("tool_call", ({ toolName, args }) => {
 | `message_end`        | Observe one completed agent message                         |
 | `turn_end`           | Observe the completed turn                                  |
 | `session_compact`    | Observe session compaction and its reason                   |
+| `agent_error`        | Observe a turn that settled on an error                     |
+| `budget_exceeded`    | Observe the run budget circuit breaker tripping             |
 
 Hooks run in registration order. Result semantics are per hook: `tool_call` returns the first non-`undefined` result; `before_agent_start` and `tool_result` chain — each handler sees the event as rewritten by earlier handlers, and a `block` from any `before_agent_start` handler wins regardless of registration order. Hook errors are logged and skipped rather than crashing the run.
 
@@ -188,6 +190,35 @@ api.on("tool_result", ({ content }) => ({
 
 Register an `AgentTool` with `api.registerTool(tool)`. Use TypeBox-compatible parameter schemas and return standard text/image tool content. See the complete [`agent-pm` example](https://github.com/geminixiang/mikan/tree/main/examples/extensions/agent-pm) for a typed tool implementation.
 
+### Custom commands
+
+`api.registerCommand` contributes a chat command dispatched deterministically — no model call, no tokens, no session entry:
+
+```ts
+api.registerCommand({
+  name: "pm",
+  description: "Show the follow-up board",
+  handler: async ({ args, userId, respond }) => {
+    await respond(renderBoard(args));
+  },
+});
+```
+
+Users invoke it as `/pm list`. Matching is case-insensitive; built-in commands (`/pi-*`, `/login`, …) always win over extension commands, and the first registration of a name wins across extensions. Slash text that matches no command still goes to the agent as a normal prompt. A handler error is reported in the conversation and logged; it never crashes mikan.
+
+### Lifecycle and disposal
+
+A harness instance is discarded on `/pi-new`, idle eviction, and session rotation. Release resources (database handles, watchers) by returning a disposer from `activate` or registering one with `api.onDispose`:
+
+```ts
+export default function activate(api: MikanExtensionApi) {
+  const db = openDb(api.paths.dataDir);
+  api.onDispose(() => db.close());
+}
+```
+
+Disposers run in reverse registration order; errors are logged and never propagate.
+
 ### Context and storage
 
 | API                       | Meaning                                                                               |
@@ -216,7 +247,7 @@ const availableNames = api.secrets.list();
 
 Secrets are read-only through the extension API. Do not log them or place them in tool descriptions, prompts, schedule text, or returned content.
 
-### Schedules, notifications, and reactions
+### Schedules, runs, notifications, reactions, and uploads
 
 ```ts
 await api.schedules.upsert("daily-check", {
@@ -226,11 +257,14 @@ await api.schedules.upsert("daily-check", {
   text: "Check overdue work. Report only actionable items.",
 });
 
+await api.triggerRun("Check the failed deploy and summarize the cause.");
 await api.notify("The scheduled check is ready.");
+await api.notify("Cross-post", { conversationId: "C0OTHER" });
 await api.react(messageTs, "white_check_mark");
+await api.uploadFile("/path/on/host/report.pdf", "Weekly report");
 ```
 
-Schedules create mikan event files and trigger autonomous runs without inheriting conversation history, so `text` must be self-contained. Specify `platform` when more than one platform is running and inference is ambiguous. Do not put secrets in schedule text.
+Schedules create mikan event files and trigger autonomous runs without inheriting conversation history, so `text` must be self-contained; `api.triggerRun` fires such a run immediately (e.g. in response to an external event). Specify `platform` when more than one platform is running and inference is ambiguous. Do not put secrets in schedule text. `api.notify` defaults to the extension's conversation and accepts an explicit `conversationId` for cross-conversation applications; `api.uploadFile` sends a host-side file into the conversation on platforms with upload support.
 
 ### Bundled skills
 
@@ -250,7 +284,7 @@ Extension skills are discovered automatically and inlined into the system prompt
 ## 6. Lifecycle rules
 
 1. Make `activate` idempotent. `/pi-new` can activate the extension again; `schedules.upsert` is safe for this pattern.
-2. Do not create `setInterval`, servers, watchers, or other long-lived resources. There is currently no deactivate hook; use `api.schedules` for timers.
+2. Release long-lived resources (database handles, watchers) in a disposer (`api.onDispose` or the `activate` return value). Prefer `api.schedules` over `setInterval` for timers — schedules survive restarts, in-process timers do not.
 3. Default to `api.paths.dataDir`. Use `sharedDataDir` only for deliberate multi-conversation behavior.
 4. Keep top-level imports and initialization safe because validation imports the module.
 5. Treat extension output and tool parameters as trust boundaries; validate untrusted input.

--- a/src/content/docs/ja/extension-development.mdx
+++ b/src/content/docs/ja/extension-development.mdx
@@ -148,6 +148,8 @@ api.on("tool_call", ({ toolName, args }) => {
 | `message_end`        | 完了した一つのエージェントメッセージを監視する                   |
 | `turn_end`           | 完了したターンを監視する                                         |
 | `session_compact`    | セッションのコンパクションとその理由を監視する                   |
+| `agent_error`        | エラーで終わったターンを監視する                                 |
+| `budget_exceeded`    | 実行バジェットのサーキットブレーカー発動を監視する               |
 
 フックは登録順に実行されます。結果のマージ方法はフックごとに異なります。`tool_call` は最初の `undefined` でない結果が採用されます。`before_agent_start` と `tool_result` はチェーンされ、各ハンドラーは前のハンドラーによる書き換え後のイベントを受け取ります。また、いずれかの `before_agent_start` ハンドラーが返した `block` は登録順に関係なく有効です。フックのエラーはログに記録され、実行をクラッシュさせることなくスキップされます。
 
@@ -186,6 +188,35 @@ api.on("tool_result", ({ content }) => ({
 
 `api.registerTool(tool)` で `AgentTool` を登録します。TypeBox 互換のパラメータスキーマを使用し、標準のテキスト／画像ツールコンテンツを返してください。型付けされたツール実装については、完全な [`agent-pm` の例](https://github.com/geminixiang/mikan/tree/main/examples/extensions/agent-pm)を参照してください。
 
+### カスタムコマンド
+
+`api.registerCommand` は決定的にディスパッチされるチャットコマンドを提供します——モデル呼び出しなし、トークン消費なし、セッション書き込みなし:
+
+```ts
+api.registerCommand({
+  name: "pm",
+  description: "Show the follow-up board",
+  handler: async ({ args, userId, respond }) => {
+    await respond(renderBoard(args));
+  },
+});
+```
+
+ユーザーは `/pm list` として呼び出します。名前の照合は大文字小文字を区別しません。組み込みコマンド（`/pi-*`、`/login` など）は常に拡張機能コマンドより優先され、同名コマンドは先に登録されたものが有効です。どのコマンドにも一致しないスラッシュ付きテキストは、通常のプロンプトとしてエージェントに渡されます。ハンドラーのエラーは会話に報告されログに記録され、mikan をクラッシュさせることはありません。
+
+### ライフサイクルと破棄
+
+ハーネスインスタンスは `/pi-new`、アイドル回収、セッションローテーションで破棄されます。リソース（データベースハンドル、ウォッチャー）は `activate` からディスポーザーを返すか、`api.onDispose` で登録して解放してください:
+
+```ts
+export default function activate(api: MikanExtensionApi) {
+  const db = openDb(api.paths.dataDir);
+  api.onDispose(() => db.close());
+}
+```
+
+ディスポーザーは登録の逆順に実行されます。エラーはログに記録され、外へは伝播しません。
+
 ### コンテキストとストレージ
 
 | API                       | 意味                                                           |
@@ -214,7 +245,7 @@ const availableNames = api.secrets.list();
 
 拡張機能 API を通じてシークレットにアクセスできるのは読み取り専用です。シークレットをログに記録したり、ツールの説明、プロンプト、スケジュールテキスト、返却コンテンツに含めたりしないでください。
 
-### スケジュール、通知、リアクション
+### スケジュール、実行トリガー、通知、リアクション、ファイルアップロード
 
 ```ts
 await api.schedules.upsert("daily-check", {
@@ -224,11 +255,14 @@ await api.schedules.upsert("daily-check", {
   text: "Check overdue work. Report only actionable items.",
 });
 
+await api.triggerRun("Check the failed deploy and summarize the cause.");
 await api.notify("The scheduled check is ready.");
+await api.notify("Cross-post", { conversationId: "C0OTHER" });
 await api.react(messageTs, "white_check_mark");
+await api.uploadFile("/path/on/host/report.pdf", "Weekly report");
 ```
 
-スケジュールは mikan のイベントファイルを作成し、会話履歴を引き継がずに自律実行を開始するため、`text` は自己完結していなければなりません。複数のプラットフォームが実行中で推論が曖昧な場合は、`platform` を指定してください。スケジュールテキストにシークレットを含めないでください。
+スケジュールは mikan のイベントファイルを作成し、会話履歴を引き継がずに自律実行を開始するため、`text` は自己完結していなければなりません。`api.triggerRun` はそのような実行を即座に発火します（外部イベントへの応答など）。複数のプラットフォームが実行中で推論が曖昧な場合は、`platform` を指定してください。スケジュールテキストにシークレットを含めないでください。`api.notify` はデフォルトで拡張機能自身の会話に投稿し、会話をまたぐアプリケーション向けに明示的な `conversationId` を受け取ります。`api.uploadFile` はアップロード対応プラットフォームでホスト側のファイルを会話に送信します。
 
 ### 同梱スキル
 
@@ -248,7 +282,7 @@ hello-mikan/
 ## 6. ライフサイクルのルール
 
 1. `activate` を冪等にしてください。`/pi-new` によって拡張機能が再度有効化される場合があります。このパターンでは `schedules.upsert` を安全に使用できます。
-2. `setInterval`、サーバー、ウォッチャー、その他の長時間存続するリソースを作成しないでください。現在は無効化フックがないため、タイマーには `api.schedules` を使用してください。
+2. 長時間存続するリソース（データベースハンドル、ウォッチャー）はディスポーザー（`api.onDispose` または `activate` の戻り値）で解放してください。タイマーには `setInterval` ではなく `api.schedules` を優先してください——スケジュールは再起動をまたいで存続しますが、プロセス内タイマーは存続しません。
 3. デフォルトでは `api.paths.dataDir` を使用してください。意図的に複数の会話にまたがる動作をさせる場合にのみ `sharedDataDir` を使用してください。
 4. 検証時にモジュールがインポートされるため、トップレベルのインポートと初期化を安全に保ってください。
 5. 拡張機能の出力とツールパラメータを信頼境界として扱い、信頼できない入力を検証してください。

--- a/src/content/docs/ja/extension-development.mdx
+++ b/src/content/docs/ja/extension-development.mdx
@@ -140,16 +140,47 @@ api.on("tool_call", ({ toolName, args }) => {
 });
 ```
 
-| フック               | 用途                                             |
-| -------------------- | ------------------------------------------------ |
-| `before_agent_start` | ターンのシステムプロンプトを置換、または追記する |
-| `tool_call`          | 実行前にツール呼び出しを監視、またはブロックする |
-| `tool_result`        | ツールの出力を監視する                           |
-| `message_end`        | 完了した一つのエージェントメッセージを監視する   |
-| `turn_end`           | 完了したターンを監視する                         |
-| `session_compact`    | セッションのコンパクションとその理由を監視する   |
+| フック               | 用途                                                             |
+| -------------------- | ---------------------------------------------------------------- |
+| `before_agent_start` | システム／ユーザープロンプトの書き換え、またはターンのブロック   |
+| `tool_call`          | 実行前にツール呼び出しを監視、またはブロックする                 |
+| `tool_result`        | ツール出力の監視または書き換え（機密のマスキング、切り詰めなど） |
+| `message_end`        | 完了した一つのエージェントメッセージを監視する                   |
+| `turn_end`           | 完了したターンを監視する                                         |
+| `session_compact`    | セッションのコンパクションとその理由を監視する                   |
 
-フックは登録順に実行されます。結果を返すフックでは、最初の `undefined` でない結果が採用されます。フックのエラーはログに記録され、実行をクラッシュさせることなくスキップされます。
+フックは登録順に実行されます。結果のマージ方法はフックごとに異なります。`tool_call` は最初の `undefined` でない結果が採用されます。`before_agent_start` と `tool_result` はチェーンされ、各ハンドラーは前のハンドラーによる書き換え後のイベントを受け取ります。また、いずれかの `before_agent_start` ハンドラーが返した `block` は登録順に関係なく有効です。フックのエラーはログに記録され、実行をクラッシュさせることなくスキップされます。
+
+#### 実行元（origin）
+
+フックイベントには、実行のプラットフォーム上の出所を表すオプションの `origin` が含まれます。`kind`（`"interactive"` または `"event"`）と `platform`、インタラクティブな実行ではさらに `messageTs`、`userId`、`userName`、`threadTs`、ダウンロード済みの `attachments` を持ちます。ユーザー単位のポリシーに利用でき、`origin.messageTs` を `api.react` に渡すとトリガーとなったメッセージにリアクションできます:
+
+```ts
+api.on("before_agent_start", async ({ origin }) => {
+  if (origin?.kind === "interactive" && origin.userId && !allowlist.has(origin.userId)) {
+    return { block: true, reason: "not authorized for this bot" };
+  }
+  if (origin?.messageTs) await api.react(origin.messageTs, "eyes");
+});
+```
+
+スケジュールから起動される自律実行にはトリガーメッセージがないため、ID 系のフィールドは未設定です。必ず null チェックしてください。
+
+#### ターンのブロック
+
+`before_agent_start` から `{ block: true, reason }` を返すと、モデルが呼び出される前にターンが終了します。ユーザーメッセージはトランスクリプトにもセッションストアにも残らず、プラットフォーム上には `reason` が診断メッセージとして表示されます。
+
+#### ツール結果の書き換え
+
+`tool_result` から `{ content }`（および/または `{ isError }`）を返すと、モデル—および永続化されるセッション—が受け取る内容を置き換えられます。ツール出力から機密をマスキングする仕組みです:
+
+```ts
+api.on("tool_result", ({ content }) => ({
+  content: content.map((part) =>
+    part.type === "text" ? { ...part, text: part.text.replaceAll(SECRET, "***") } : part,
+  ),
+}));
+```
 
 ### カスタムツール
 

--- a/src/content/docs/zh-cn/extension-development.mdx
+++ b/src/content/docs/zh-cn/extension-development.mdx
@@ -150,6 +150,8 @@ api.on("tool_call", ({ toolName, args }) => {
 | `message_end`        | 观察一条已完成的智能体消息             |
 | `turn_end`           | 观察已完成的轮次                       |
 | `session_compact`    | 观察会话压缩及其原因                   |
+| `agent_error`        | 观察以错误收场的轮次                   |
+| `budget_exceeded`    | 观察运行预算断路器触发                 |
 
 钩子按注册顺序运行。结果的合成语义因钩子而异：`tool_call` 以第一个非 `undefined` 的结果为准；`before_agent_start` 与 `tool_result` 采用链式（chaining）——每个处理器看到的是前面处理器改写后的事件，且任一 `before_agent_start` 处理器返回的 `block` 都会生效，与注册顺序无关。钩子错误会被记录并跳过，而不会导致运行崩溃。
 
@@ -188,6 +190,35 @@ api.on("tool_result", ({ content }) => ({
 
 使用 `api.registerTool(tool)` 注册 `AgentTool`。使用兼容 TypeBox 的参数模式，并返回标准的文本/图像工具内容。如需类型完备的工具实现，请参阅完整的 [`agent-pm` 示例](https://github.com/geminixiang/mikan/tree/main/examples/extensions/agent-pm)。
 
+### 自定义命令
+
+`api.registerCommand` 贡献一个确定性分发的聊天命令——不经过模型、不耗 token、不写入会话：
+
+```ts
+api.registerCommand({
+  name: "pm",
+  description: "Show the follow-up board",
+  handler: async ({ args, userId, respond }) => {
+    await respond(renderBoard(args));
+  },
+});
+```
+
+用户以 `/pm list` 调用。名称匹配不区分大小写；内置命令（`/pi-*`、`/login` 等）永远优先于扩展命令，同名命令以先注册者为准。没有匹配命令的斜杠文本仍会作为普通提示词交给智能体。处理器的错误会回报在对话中并记录日志，绝不会让 mikan 崩溃。
+
+### 生命周期与释放
+
+Harness 实例会在 `/pi-new`、闲置回收与会话轮换时被丢弃。请通过 `activate` 返回释放函数、或用 `api.onDispose` 注册，来释放资源（数据库连接、监视器）：
+
+```ts
+export default function activate(api: MikanExtensionApi) {
+  const db = openDb(api.paths.dataDir);
+  api.onDispose(() => db.close());
+}
+```
+
+释放函数按注册顺序反向执行；错误会记录日志且不会向外抛出。
+
 ### 上下文与存储
 
 | API                       | 含义                                       |
@@ -216,7 +247,7 @@ const availableNames = api.secrets.list();
 
 通过扩展 API 只能读取密钥。请勿记录密钥，也不要将其放入工具描述、提示词、定时任务文本或返回内容中。
 
-### 定时任务、通知和回应
+### 定时任务、触发运行、通知、回应与文件上传
 
 ```ts
 await api.schedules.upsert("daily-check", {
@@ -226,11 +257,14 @@ await api.schedules.upsert("daily-check", {
   text: "Check overdue work. Report only actionable items.",
 });
 
+await api.triggerRun("Check the failed deploy and summarize the cause.");
 await api.notify("The scheduled check is ready.");
+await api.notify("Cross-post", { conversationId: "C0OTHER" });
 await api.react(messageTs, "white_check_mark");
+await api.uploadFile("/path/on/host/report.pdf", "Weekly report");
 ```
 
-定时任务会创建 mikan 事件文件，并在不继承对话历史记录的情况下触发自主运行，因此 `text` 必须自成一体。如果同时运行多个平台且无法明确推断平台，请指定 `platform`。不要在定时任务文本中放入密钥。
+定时任务会创建 mikan 事件文件，并在不继承对话历史记录的情况下触发自主运行，因此 `text` 必须自成一体；`api.triggerRun` 会立即触发一次这样的运行（例如响应外部事件）。如果同时运行多个平台且无法明确推断平台，请指定 `platform`。不要在定时任务文本中放入密钥。`api.notify` 默认发到扩展自己的对话，可传入 `conversationId` 供跨对话应用使用；`api.uploadFile` 会在支持上传的平台上把宿主端文件发进对话。
 
 ### 捆绑技能
 
@@ -250,7 +284,7 @@ hello-mikan/
 ## 6. 生命周期规则
 
 1. 确保 `activate` 是幂等的。`/pi-new` 可能会再次激活扩展；`schedules.upsert` 可以安全地用于此模式。
-2. 不要创建 `setInterval`、服务器、监视器或其他长期存续的资源。目前没有停用钩子；请使用 `api.schedules` 实现定时器。
+2. 长期存续的资源（数据库连接、监视器）请在释放函数中释放（`api.onDispose` 或 `activate` 的返回值）。定时器优先使用 `api.schedules` 而非 `setInterval`——计划任务能跨重启存活，进程内定时器不能。
 3. 默认使用 `api.paths.dataDir`。仅在有意实现跨对话行为时使用 `sharedDataDir`。
 4. 确保顶层导入和初始化安全，因为验证过程会导入模块。
 5. 将扩展输出和工具参数视为信任边界；验证不受信任的输入。

--- a/src/content/docs/zh-cn/extension-development.mdx
+++ b/src/content/docs/zh-cn/extension-development.mdx
@@ -142,16 +142,47 @@ api.on("tool_call", ({ toolName, args }) => {
 });
 ```
 
-| 钩子                 | 用途                         |
-| -------------------- | ---------------------------- |
-| `before_agent_start` | 替换或追加本轮的系统提示词   |
-| `tool_call`          | 在工具调用执行前观察或阻止它 |
-| `tool_result`        | 观察工具输出                 |
-| `message_end`        | 观察一条已完成的智能体消息   |
-| `turn_end`           | 观察已完成的轮次             |
-| `session_compact`    | 观察会话压缩及其原因         |
+| 钩子                 | 用途                                   |
+| -------------------- | -------------------------------------- |
+| `before_agent_start` | 改写系统提示词或用户提示词，或拦截本轮 |
+| `tool_call`          | 在工具调用执行前观察或阻止它           |
+| `tool_result`        | 观察或改写工具输出（例如脱敏、截断）   |
+| `message_end`        | 观察一条已完成的智能体消息             |
+| `turn_end`           | 观察已完成的轮次                       |
+| `session_compact`    | 观察会话压缩及其原因                   |
 
-钩子按注册顺序运行。对于会返回结果的钩子，以第一个非 `undefined` 的结果为准。钩子错误会被记录并跳过，而不会导致运行崩溃。
+钩子按注册顺序运行。结果的合成语义因钩子而异：`tool_call` 以第一个非 `undefined` 的结果为准；`before_agent_start` 与 `tool_result` 采用链式（chaining）——每个处理器看到的是前面处理器改写后的事件，且任一 `before_agent_start` 处理器返回的 `block` 都会生效，与注册顺序无关。钩子错误会被记录并跳过，而不会导致运行崩溃。
+
+#### 运行来源（origin）
+
+钩子事件带有可选的 `origin`，描述本次运行的平台来源：`kind`（`"interactive"` 或 `"event"`）、`platform`，交互式运行还包含 `messageTs`、`userId`、`userName`、`threadTs` 与已下载的 `attachments`。可用于 per-user 策略，并把 `origin.messageTs` 传给 `api.react` 对触发消息添加表情回应：
+
+```ts
+api.on("before_agent_start", async ({ origin }) => {
+  if (origin?.kind === "interactive" && origin.userId && !allowlist.has(origin.userId)) {
+    return { block: true, reason: "not authorized for this bot" };
+  }
+  if (origin?.messageTs) await api.react(origin.messageTs, "eyes");
+});
+```
+
+由计划任务触发的自主运行没有触发消息，身份字段均未设置——请务必做 null 检查。
+
+#### 拦截本轮
+
+`before_agent_start` 返回 `{ block: true, reason }` 会在模型被调用前终止本轮。用户消息不会进入对话记录或会话存储，平台上会以诊断消息显示 `reason`。
+
+#### 改写工具结果
+
+`tool_result` 返回 `{ content }`（和/或 `{ isError }`）可替换模型——以及持久化会话——看到的内容。这是从工具输出中脱敏的机制：
+
+```ts
+api.on("tool_result", ({ content }) => ({
+  content: content.map((part) =>
+    part.type === "text" ? { ...part, text: part.text.replaceAll(SECRET, "***") } : part,
+  ),
+}));
+```
 
 ### 自定义工具
 

--- a/src/content/docs/zh-tw/extension-development.mdx
+++ b/src/content/docs/zh-tw/extension-development.mdx
@@ -150,6 +150,8 @@ api.on("tool_call", ({ toolName, args }) => {
 | `message_end`        | 觀察一則已完成的代理訊息                   |
 | `turn_end`           | 觀察已完成的回合                           |
 | `session_compact`    | 觀察工作階段壓縮及其原因                   |
+| `agent_error`        | 觀察以錯誤收場的回合                       |
+| `budget_exceeded`    | 觀察執行預算斷路器觸發                     |
 
 鉤子依註冊順序執行。結果的合成語意依鉤子而異：`tool_call` 以第一個非 `undefined` 的結果為準；`before_agent_start` 與 `tool_result` 採串接（chaining）——每個處理常式看到的是前面處理常式改寫後的事件，且任一 `before_agent_start` 處理常式回傳的 `block` 都會生效，與註冊順序無關。鉤子錯誤會被記錄並略過，而不會導致執行作業當機。
 
@@ -188,6 +190,35 @@ api.on("tool_result", ({ content }) => ({
 
 使用 `api.registerTool(tool)` 註冊 `AgentTool`。請使用與 TypeBox 相容的參數結構描述，並回傳標準的文字／影像工具內容。如需具備型別的工具實作，請參閱完整的 [`agent-pm` 範例](https://github.com/geminixiang/mikan/tree/main/examples/extensions/agent-pm)。
 
+### 自訂指令
+
+`api.registerCommand` 貢獻一個確定性分派的聊天指令——不經過模型、不耗 token、不寫入工作階段：
+
+```ts
+api.registerCommand({
+  name: "pm",
+  description: "Show the follow-up board",
+  handler: async ({ args, userId, respond }) => {
+    await respond(renderBoard(args));
+  },
+});
+```
+
+使用者以 `/pm list` 呼叫。名稱比對不分大小寫；內建指令（`/pi-*`、`/login` 等）永遠優先於擴充功能指令，同名指令以先註冊者為準。沒有對應指令的斜線文字仍會作為一般提示詞交給代理。處理常式的錯誤會回報在對話中並記錄至日誌，絕不會讓 mikan 當機。
+
+### 生命週期與釋放
+
+Harness 實例會在 `/pi-new`、閒置回收與工作階段輪替時被丟棄。請透過 `activate` 回傳釋放函式、或以 `api.onDispose` 註冊，來釋放資源（資料庫連線、監看器）：
+
+```ts
+export default function activate(api: MikanExtensionApi) {
+  const db = openDb(api.paths.dataDir);
+  api.onDispose(() => db.close());
+}
+```
+
+釋放函式依註冊順序反向執行；錯誤會記錄至日誌且不會向外拋出。
+
 ### 上下文與儲存空間
 
 | API                       | 意義                                           |
@@ -216,7 +247,7 @@ const availableNames = api.secrets.list();
 
 透過擴充功能 API 只能讀取祕密資訊。請勿將其記錄至日誌，或放入工具描述、提示詞、排程文字或回傳內容中。
 
-### 排程、通知與反應
+### 排程、觸發執行、通知、反應與檔案上傳
 
 ```ts
 await api.schedules.upsert("daily-check", {
@@ -226,11 +257,14 @@ await api.schedules.upsert("daily-check", {
   text: "Check overdue work. Report only actionable items.",
 });
 
+await api.triggerRun("Check the failed deploy and summarize the cause.");
 await api.notify("The scheduled check is ready.");
+await api.notify("Cross-post", { conversationId: "C0OTHER" });
 await api.react(messageTs, "white_check_mark");
+await api.uploadFile("/path/on/host/report.pdf", "Weekly report");
 ```
 
-排程會建立 mikan 事件檔案，並觸發不繼承對話歷史的自主執行，因此 `text` 必須內容完備。若執行多個平台且無法明確推斷，請指定 `platform`。請勿在排程文字中放入祕密資訊。
+排程會建立 mikan 事件檔案，並觸發不繼承對話歷史的自主執行，因此 `text` 必須內容完備；`api.triggerRun` 會立即觸發一次這樣的執行（例如回應外部事件）。若執行多個平台且無法明確推斷，請指定 `platform`。請勿在排程文字中放入祕密資訊。`api.notify` 預設發到擴充功能自己的對話，可傳入 `conversationId` 供跨對話應用使用；`api.uploadFile` 會在支援上傳的平台上把 host 端檔案送進對話。
 
 ### 隨附技能
 
@@ -250,7 +284,7 @@ hello-mikan/
 ## 生命週期規則
 
 1. 讓 `activate` 具備冪等性。`/pi-new` 可能再次啟用擴充功能；`schedules.upsert` 可安全用於此模式。
-2. 請勿建立 `setInterval`、伺服器、監看器或其他長期存續的資源。目前沒有停用鉤子；請使用 `api.schedules` 作為計時器。
+2. 長期存續的資源（資料庫連線、監看器）請在釋放函式中釋放（`api.onDispose` 或 `activate` 的回傳值）。計時器優先使用 `api.schedules` 而非 `setInterval`——排程能跨重啟存活，行程內計時器不能。
 3. 預設使用 `api.paths.dataDir`。只有在刻意實作多對話行為時才使用 `sharedDataDir`。
 4. 頂層匯入與初始化必須安全，因為驗證程序會匯入模組。
 5. 將擴充功能輸出與工具參數視為信任邊界；驗證不受信任的輸入。

--- a/src/content/docs/zh-tw/extension-development.mdx
+++ b/src/content/docs/zh-tw/extension-development.mdx
@@ -142,16 +142,47 @@ api.on("tool_call", ({ toolName, args }) => {
 });
 ```
 
-| 鉤子                 | 用途                         |
-| -------------------- | ---------------------------- |
-| `before_agent_start` | 取代或附加該回合的系統提示詞 |
-| `tool_call`          | 在執行前觀察或封鎖工具呼叫   |
-| `tool_result`        | 觀察工具輸出                 |
-| `message_end`        | 觀察一則已完成的代理訊息     |
-| `turn_end`           | 觀察已完成的回合             |
-| `session_compact`    | 觀察工作階段壓縮及其原因     |
+| 鉤子                 | 用途                                       |
+| -------------------- | ------------------------------------------ |
+| `before_agent_start` | 改寫系統提示詞或使用者提示詞，或擋下該回合 |
+| `tool_call`          | 在執行前觀察或封鎖工具呼叫                 |
+| `tool_result`        | 觀察或改寫工具輸出（例如遮蔽機密、截斷）   |
+| `message_end`        | 觀察一則已完成的代理訊息                   |
+| `turn_end`           | 觀察已完成的回合                           |
+| `session_compact`    | 觀察工作階段壓縮及其原因                   |
 
-鉤子依註冊順序執行。對於會回傳結果的鉤子，以第一個非 `undefined` 的結果為準。鉤子錯誤會被記錄並略過，而不會導致執行作業當機。
+鉤子依註冊順序執行。結果的合成語意依鉤子而異：`tool_call` 以第一個非 `undefined` 的結果為準；`before_agent_start` 與 `tool_result` 採串接（chaining）——每個處理常式看到的是前面處理常式改寫後的事件，且任一 `before_agent_start` 處理常式回傳的 `block` 都會生效，與註冊順序無關。鉤子錯誤會被記錄並略過，而不會導致執行作業當機。
+
+#### 執行來源（origin）
+
+鉤子事件帶有選用的 `origin`，描述這次執行的平台來源：`kind`（`"interactive"` 或 `"event"`）、`platform`，互動式執行還有 `messageTs`、`userId`、`userName`、`threadTs` 與已下載的 `attachments`。可用於 per-user 政策，並把 `origin.messageTs` 傳給 `api.react` 對觸發訊息加上表情反應：
+
+```ts
+api.on("before_agent_start", async ({ origin }) => {
+  if (origin?.kind === "interactive" && origin.userId && !allowlist.has(origin.userId)) {
+    return { block: true, reason: "not authorized for this bot" };
+  }
+  if (origin?.messageTs) await api.react(origin.messageTs, "eyes");
+});
+```
+
+排程觸發的自主執行沒有觸發訊息，身分欄位皆為未設定——請務必做 null 檢查。
+
+#### 擋下回合
+
+`before_agent_start` 回傳 `{ block: true, reason }` 會在模型被呼叫前終止該回合。使用者訊息不會進入逐字稿或工作階段儲存，平台上會以診斷訊息顯示 `reason`。
+
+#### 改寫工具結果
+
+`tool_result` 回傳 `{ content }`（及／或 `{ isError }`）可取代模型——以及持久化的工作階段——看到的內容。這是從工具輸出中遮蔽機密的機制：
+
+```ts
+api.on("tool_result", ({ content }) => ({
+  content: content.map((part) =>
+    part.type === "text" ? { ...part, text: part.text.replaceAll(SECRET, "***") } : part,
+  ),
+}));
+```
 
 ### 自訂工具
 

--- a/src/harness/extensions/loader.ts
+++ b/src/harness/extensions/loader.ts
@@ -32,6 +32,8 @@ import * as log from "../../log.js";
 import { loadSkillsFromDir, type MikanSkill } from "../skills.js";
 import { ExtensionRegistry } from "./registry.js";
 import type {
+  ExtensionCommand,
+  ExtensionDisposer,
   ExtensionHostServices,
   ExtensionLoadError,
   ExtensionManifest,
@@ -134,6 +136,12 @@ export interface LoadExtensionsResult {
   errors: ExtensionLoadError[];
   /** Skills contributed by extensions (inline: bodies ride in the prompt). */
   skills: MikanSkill[];
+  /**
+   * Run extension disposers (from `api.onDispose` and `activate` return
+   * values). Call when the harness instance owning these extensions is
+   * discarded. Idempotent; disposer errors are logged, never thrown.
+   */
+  dispose(): Promise<void>;
 }
 
 /**
@@ -417,6 +425,8 @@ function buildExtensionApi(params: {
   return {
     on: (hook, handler) => registry.register(name, hook, handler),
     registerTool: (tool: AgentTool) => registry.registerTool(tool),
+    registerCommand: (command: ExtensionCommand) => registry.registerCommand(name, command),
+    onDispose: (disposer: ExtensionDisposer) => registry.registerDisposer(name, disposer),
     log: (message: string) => log.logInfo(`[extension:${name}] ${message}`),
     context,
     paths: {
@@ -464,11 +474,11 @@ function buildExtensionApi(params: {
         return infos;
       },
     },
-    notify: async (text: string) => {
+    notify: async (text: string, options?: { conversationId?: string }) => {
       if (!services.postMessage) {
         throw new Error("api.notify is unavailable: this context provides no platform messaging");
       }
-      await services.postMessage(conversationId, text);
+      await services.postMessage(options?.conversationId ?? conversationId, text);
     },
     react: async (messageTs: string, emoji: string) => {
       if (!services.addReaction) {
@@ -476,8 +486,25 @@ function buildExtensionApi(params: {
       }
       await services.addReaction(conversationId, messageTs, emoji);
     },
+    uploadFile: async (filePath: string, title?: string) => {
+      if (!services.uploadFile) {
+        throw new Error("api.uploadFile is unavailable: this context provides no file uploads");
+      }
+      await services.uploadFile(conversationId, filePath, title);
+    },
+    triggerRun: async (text: string) => {
+      const store = requireScheduleStore();
+      // Distinct "extrun." namespace: run files must never surface in
+      // api.schedules.list(), whose ownership filter is the "ext." prefix.
+      // The embedder's watcher fires and deletes the file immediately.
+      const filename = `extrun.${slug}.${scheduleNameSegment(conversationId)}.${Date.now()}-${runCounter++}${SCHEDULE_FILE_SUFFIX}`;
+      await store.write(filename, { type: "immediate", conversationId, text });
+    },
   };
 }
+
+/** Monotonic suffix so rapid triggerRun calls in one process never collide. */
+let runCounter = 0;
 
 function resolveActivate(moduleExports: unknown): MikanExtensionModule | undefined {
   if (!moduleExports || typeof moduleExports !== "object") return undefined;
@@ -534,7 +561,8 @@ export async function loadExtensions(
           context: options.context,
           services,
         });
-        await extension.activate(api);
+        const disposer = await extension.activate(api);
+        if (typeof disposer === "function") registry.registerDisposer(name, disposer);
         const extensionSkills = loadExtensionSkills(rootDir, slug);
         skills.push(...extensionSkills);
         extensions.push({
@@ -554,7 +582,7 @@ export async function loadExtensions(
     }
   }
 
-  return { registry, extensions, errors, skills };
+  return { registry, extensions, errors, skills, dispose: () => registry.dispose() };
 }
 
 export interface ExtensionValidation {

--- a/src/harness/extensions/registry.ts
+++ b/src/harness/extensions/registry.ts
@@ -7,7 +7,14 @@
  */
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import * as log from "../../log.js";
-import type { MikanHookMap, MikanHookName } from "./types.js";
+import type {
+  BeforeAgentStartHookEvent,
+  BeforeAgentStartHookResult,
+  MikanHookMap,
+  MikanHookName,
+  ToolResultHookEvent,
+  ToolResultHookResult,
+} from "./types.js";
 
 type HookHandlers = {
   [T in MikanHookName]: Array<{ owner: string; handler: MikanHookMap[T] }>;
@@ -62,5 +69,77 @@ export class ExtensionRegistry {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Dispatch `before_agent_start` with merge semantics: `systemPrompt` and
+   * `prompt` rewrites chain (each handler sees the event as rewritten by
+   * earlier handlers), while `block` from ANY handler wins so a policy
+   * extension cannot be shadowed by registration order. The first block's
+   * reason is kept. Returns undefined when no handler changed anything.
+   */
+  async emitBeforeAgentStart(
+    event: BeforeAgentStartHookEvent,
+  ): Promise<BeforeAgentStartHookResult | undefined> {
+    const chained: BeforeAgentStartHookEvent = { ...event };
+    const merged: BeforeAgentStartHookResult = {};
+    for (const { owner, handler } of this.handlers.before_agent_start) {
+      try {
+        const result = await handler(chained);
+        if (!result) continue;
+        if (result.systemPrompt !== undefined) {
+          merged.systemPrompt = result.systemPrompt;
+          chained.systemPrompt = result.systemPrompt;
+        }
+        if (result.prompt !== undefined) {
+          merged.prompt = result.prompt;
+          chained.prompt = result.prompt;
+        }
+        if (result.block && !merged.block) {
+          merged.block = true;
+          merged.reason = result.reason;
+        }
+      } catch (err) {
+        log.logWarning(
+          `Extension hook "before_agent_start" failed (${owner})`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+    return merged.systemPrompt !== undefined || merged.prompt !== undefined || merged.block
+      ? merged
+      : undefined;
+  }
+
+  /**
+   * Dispatch `tool_result` with chaining semantics: each handler sees the
+   * content/isError as rewritten by earlier handlers, so e.g. a redaction
+   * extension processes the output of upstream rewriters instead of the
+   * original. Returns the accumulated override, or undefined when no handler
+   * changed anything.
+   */
+  async emitToolResult(event: ToolResultHookEvent): Promise<ToolResultHookResult | undefined> {
+    const chained: ToolResultHookEvent = { ...event };
+    const merged: ToolResultHookResult = {};
+    for (const { owner, handler } of this.handlers.tool_result) {
+      try {
+        const result = await handler(chained);
+        if (!result) continue;
+        if (result.content !== undefined) {
+          merged.content = result.content;
+          chained.content = result.content;
+        }
+        if (result.isError !== undefined) {
+          merged.isError = result.isError;
+          chained.isError = result.isError;
+        }
+      } catch (err) {
+        log.logWarning(
+          `Extension hook "tool_result" failed (${owner})`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+    return merged.content !== undefined || merged.isError !== undefined ? merged : undefined;
   }
 }

--- a/src/harness/extensions/registry.ts
+++ b/src/harness/extensions/registry.ts
@@ -10,11 +10,16 @@ import * as log from "../../log.js";
 import type {
   BeforeAgentStartHookEvent,
   BeforeAgentStartHookResult,
+  ExtensionCommand,
+  ExtensionCommandContext,
+  ExtensionDisposer,
   MikanHookMap,
   MikanHookName,
   ToolResultHookEvent,
   ToolResultHookResult,
 } from "./types.js";
+
+const COMMAND_NAME_PATTERN = /^[a-z0-9_-]+$/i;
 
 type HookHandlers = {
   [T in MikanHookName]: Array<{ owner: string; handler: MikanHookMap[T] }>;
@@ -28,8 +33,12 @@ export class ExtensionRegistry {
     message_end: [],
     turn_end: [],
     session_compact: [],
+    agent_error: [],
+    budget_exceeded: [],
   };
   private tools: AgentTool[] = [];
+  private commands = new Map<string, { owner: string; command: ExtensionCommand }>();
+  private disposers: Array<{ owner: string; disposer: ExtensionDisposer }> = [];
 
   register<T extends MikanHookName>(owner: string, hook: T, handler: MikanHookMap[T]): void {
     this.handlers[hook].push({ owner, handler });
@@ -39,8 +48,80 @@ export class ExtensionRegistry {
     this.tools.push(tool);
   }
 
+  /**
+   * Register an extension command. Invalid names throw (surfaces as an
+   * activation error for that extension); a duplicate name is logged and
+   * ignored so the first registration wins, mirroring hook isolation.
+   */
+  registerCommand(owner: string, command: ExtensionCommand): void {
+    if (!COMMAND_NAME_PATTERN.test(command.name)) {
+      throw new Error(`Invalid extension command name: ${JSON.stringify(command.name)}`);
+    }
+    const key = command.name.toLowerCase();
+    const existing = this.commands.get(key);
+    if (existing) {
+      log.logWarning(
+        `Extension command "/${command.name}" already registered by ${existing.owner}`,
+        `ignoring registration from ${owner}`,
+      );
+      return;
+    }
+    this.commands.set(key, { owner, command });
+  }
+
+  registerDisposer(owner: string, disposer: ExtensionDisposer): void {
+    this.disposers.push({ owner, disposer });
+  }
+
   getContributedTools(): AgentTool[] {
     return [...this.tools];
+  }
+
+  /** Registered commands, for inventory surfaces. */
+  getCommands(): ExtensionCommand[] {
+    return [...this.commands.values()].map((entry) => entry.command);
+  }
+
+  /**
+   * Run the handler for `/name`, if an extension registered it. Returns true
+   * when a matching command exists — including when its handler threw (the
+   * command was consumed; the error is logged and reported to the user).
+   */
+  async dispatchCommand(name: string, context: ExtensionCommandContext): Promise<boolean> {
+    const entry = this.commands.get(name.toLowerCase());
+    if (!entry) return false;
+    try {
+      await entry.command.handler(context);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.logWarning(`Extension command "/${entry.command.name}" failed (${entry.owner})`, message);
+      try {
+        await context.respond(`Command /${entry.command.name} failed: ${message}`);
+      } catch {
+        // The reply channel itself failed; the log line above is the record.
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Run all registered disposers in reverse registration order (LIFO).
+   * Disposer errors are logged and never propagate. Idempotent: disposers
+   * run once and the list is cleared.
+   */
+  async dispose(): Promise<void> {
+    const disposers = this.disposers;
+    this.disposers = [];
+    for (const { owner, disposer } of disposers.toReversed()) {
+      try {
+        await disposer();
+      } catch (err) {
+        log.logWarning(
+          `Extension disposer failed (${owner})`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
   }
 
   hasHandlers(hook: MikanHookName): boolean {

--- a/src/harness/extensions/types.ts
+++ b/src/harness/extensions/types.ts
@@ -109,6 +109,23 @@ export interface SessionCompactHookEvent {
   reason: "threshold" | "overflow" | "manual";
 }
 
+/** A turn settled with an error after retries were exhausted (or none applied). */
+export interface AgentErrorHookEvent {
+  errorMessage: string;
+  origin?: RunOrigin;
+}
+
+/** The run budget circuit breaker tripped and the run was aborted. */
+export interface BudgetExceededHookEvent {
+  /** Which cap was hit, e.g. "cost 2.01 USD >= 2 USD limit". */
+  reason: string;
+  tokens: number;
+  costUsd: number;
+  llmCalls: number;
+  durationMs: number;
+  origin?: RunOrigin;
+}
+
 /** Map of hook names to handler signatures. */
 export interface MikanHookMap {
   before_agent_start: (
@@ -127,6 +144,8 @@ export interface MikanHookMap {
   message_end: (event: MessageEndHookEvent) => void | Promise<void>;
   turn_end: (event: TurnEndHookEvent) => void | Promise<void>;
   session_compact: (event: SessionCompactHookEvent) => void | Promise<void>;
+  agent_error: (event: AgentErrorHookEvent) => void | Promise<void>;
+  budget_exceeded: (event: BudgetExceededHookEvent) => void | Promise<void>;
 }
 
 export type MikanHookName = keyof MikanHookMap;
@@ -166,16 +185,46 @@ export interface ExtensionScheduleInfo {
 /**
  * Event-file payload the harness hands to the embedder's schedule store.
  * Mirrors mikan's event-file shape; `platform` may be omitted when the
- * embedder runs a single platform.
+ * embedder runs a single platform. `immediate` backs `api.triggerRun` —
+ * the event fires as soon as the embedder's watcher picks it up.
  */
 export interface ExtensionSchedulePayload {
-  type: "one-shot" | "periodic";
+  type: "one-shot" | "periodic" | "immediate";
   conversationId: string;
   text: string;
   platform?: string;
   at?: string;
   schedule?: string;
   timezone?: string;
+}
+
+// ── v3: commands and lifecycle ───────────────────────────────────────────────
+
+/** Cleanup callback run when the harness instance owning the extension is discarded. */
+export type ExtensionDisposer = () => void | Promise<void>;
+
+/** Context handed to an extension command handler for one invocation. */
+export interface ExtensionCommandContext {
+  /** Text after the command name, trimmed ("" when none). */
+  args: string;
+  conversationId: string;
+  userId?: string;
+  userName?: string;
+  /** Reply in the conversation the command was sent from. */
+  respond(text: string): Promise<void>;
+}
+
+/**
+ * A chat command contributed by an extension (`/name args…`). Dispatched
+ * deterministically by the embedder — no model call, no session entry.
+ * Built-in commands always win over extension commands of the same name.
+ */
+export interface ExtensionCommand {
+  /** Command name without the leading slash; `[a-z0-9_-]+`, case-insensitive match. */
+  name: string;
+  /** One-line description for inventory surfaces. */
+  description?: string;
+  handler: (context: ExtensionCommandContext) => void | Promise<void>;
 }
 
 // ── v2: embedder-injected services ───────────────────────────────────────────
@@ -211,6 +260,13 @@ export interface ExtensionHostServices {
     emoji: string,
     platform?: string,
   ) => Promise<void>;
+  /** Upload a host file into a conversation; enables `api.uploadFile`. */
+  uploadFile?: (
+    conversationId: string,
+    filePath: string,
+    title?: string,
+    platform?: string,
+  ) => Promise<void>;
   /** Resolve read-only secrets for an extension slug; enables `api.secrets`. */
   resolveSecrets?: (slug: string) => Record<string, string>;
 }
@@ -235,6 +291,17 @@ export interface MikanExtensionApi {
   on<T extends MikanHookName>(hook: T, handler: MikanHookMap[T]): void;
   /** Contribute an additional agent tool. */
   registerTool(tool: AgentTool): void;
+  /**
+   * Contribute a chat command (`/name`). Dispatched without a model call;
+   * built-in commands and earlier registrations of the same name win.
+   */
+  registerCommand(command: ExtensionCommand): void;
+  /**
+   * Register cleanup to run when this harness instance is discarded
+   * (`/pi-new`, session eviction, shutdown). Alternative to returning a
+   * disposer from `activate`. Disposers run in reverse registration order.
+   */
+  onDispose(disposer: ExtensionDisposer): void;
   /** Extension-scoped logging that lands in mikan's structured log. */
   log(message: string): void;
   /** Context about the conversation this harness instance serves. */
@@ -290,20 +357,35 @@ export interface MikanExtensionApi {
     list(): Promise<ExtensionScheduleInfo[]>;
   };
   /**
-   * Post text into this conversation without triggering an agent run.
-   * Available when the embedder provides platform messaging.
+   * Post text into a conversation without triggering an agent run. Defaults
+   * to this conversation; pass `conversationId` to post elsewhere (pairs
+   * with `sharedDataDir` for cross-conversation applications). Available
+   * when the embedder provides platform messaging.
    */
-  notify(text: string): Promise<void>;
+  notify(text: string, options?: { conversationId?: string }): Promise<void>;
   /**
    * Add an emoji reaction to a message in this conversation. `messageTs` is
-   * the platform message id the extension read from an event; `emoji` is a
-   * short name without colons. Available when the embedder provides reaction
-   * support.
+   * the platform message id the extension read from an event (see
+   * `RunOrigin.messageTs`); `emoji` is a short name without colons.
+   * Available when the embedder provides reaction support.
    */
   react(messageTs: string, emoji: string): Promise<void>;
+  /**
+   * Upload a host-side file into this conversation without an agent run.
+   * Available when the embedder provides file uploads for the platform.
+   */
+  uploadFile(filePath: string, title?: string): Promise<void>;
+  /**
+   * Fire an autonomous agent run in this conversation as soon as possible.
+   * Like a schedule, the run does not inherit conversation history — write
+   * `text` self-contained. Backed by the embedder's schedule store.
+   */
+  triggerRun(text: string): Promise<void>;
 }
 
-export type MikanExtensionActivate = (api: MikanExtensionApi) => void | Promise<void>;
+export type MikanExtensionActivate = (
+  api: MikanExtensionApi,
+) => void | ExtensionDisposer | Promise<void | ExtensionDisposer>;
 
 export interface MikanExtensionModule {
   name?: string;

--- a/src/harness/extensions/types.ts
+++ b/src/harness/extensions/types.ts
@@ -17,8 +17,10 @@
  * }
  * ```
  *
- * Hooks run in registration order. For hooks with results, the first
- * non-undefined result wins (v1 semantics; later versions may merge).
+ * Hooks run in registration order. Result semantics are per hook:
+ * `tool_call` keeps v1's first-non-undefined-wins; `before_agent_start` and
+ * `tool_result` chain — each handler sees the event as rewritten by earlier
+ * handlers, and for `before_agent_start` a `block` from any handler wins.
  * Hook errors are logged and never crash a run.
  */
 import type { AgentMessage, AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
@@ -26,21 +28,48 @@ import type { Api, ImageContent, Model, TextContent } from "@earendil-works/pi-a
 import type { MikanSkill } from "../skills.js";
 import type { CompactionEntry } from "../types.js";
 
+/**
+ * Platform provenance of the run a hook event belongs to. Interactive runs
+ * carry the triggering message's identity (usable with `api.react` and for
+ * per-user policy); autonomous runs (schedules/events) have no triggering
+ * platform message, so only `kind` and `platform` are set.
+ */
+export interface RunOrigin {
+  kind: "interactive" | "event";
+  /** Platform adapter name serving this run (e.g. "slack"). */
+  platform?: string;
+  /** Platform message id of the triggering message; pass to `api.react`. */
+  messageTs?: string;
+  userId?: string;
+  userName?: string;
+  threadTs?: string;
+  /** Attachments already downloaded to host paths (extensions run on host). */
+  attachments?: { name: string; localPath: string }[];
+}
+
 export interface BeforeAgentStartHookEvent {
   prompt: string;
   images?: ImageContent[];
   systemPrompt: string;
+  origin?: RunOrigin;
 }
 
 export interface BeforeAgentStartHookResult {
   /** Replace the system prompt for this turn. */
   systemPrompt?: string;
+  /** Rewrite the user prompt for this turn. */
+  prompt?: string;
+  /** Block the turn entirely; the model is never called and nothing persists. */
+  block?: boolean;
+  /** Shown to the user when the turn is blocked. */
+  reason?: string;
 }
 
 export interface ToolCallHookEvent {
   toolCallId: string;
   toolName: string;
   args: unknown;
+  origin?: RunOrigin;
 }
 
 export interface ToolCallHookResult {
@@ -55,14 +84,24 @@ export interface ToolResultHookEvent {
   args: unknown;
   content: (TextContent | ImageContent)[];
   isError: boolean;
+  origin?: RunOrigin;
+}
+
+export interface ToolResultHookResult {
+  /** Replace the tool result content sent back to the model (e.g. redaction). */
+  content?: (TextContent | ImageContent)[];
+  /** Override the tool result error flag. */
+  isError?: boolean;
 }
 
 export interface MessageEndHookEvent {
   message: AgentMessage;
+  origin?: RunOrigin;
 }
 
 export interface TurnEndHookEvent {
   messages: AgentMessage[];
+  origin?: RunOrigin;
 }
 
 export interface SessionCompactHookEvent {
@@ -82,7 +121,9 @@ export interface MikanHookMap {
   tool_call: (
     event: ToolCallHookEvent,
   ) => ToolCallHookResult | undefined | void | Promise<ToolCallHookResult | undefined | void>;
-  tool_result: (event: ToolResultHookEvent) => void | Promise<void>;
+  tool_result: (
+    event: ToolResultHookEvent,
+  ) => ToolResultHookResult | undefined | void | Promise<ToolResultHookResult | undefined | void>;
   message_end: (event: MessageEndHookEvent) => void | Promise<void>;
   turn_end: (event: TurnEndHookEvent) => void | Promise<void>;
   session_compact: (event: SessionCompactHookEvent) => void | Promise<void>;

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -19,6 +19,7 @@ export {
   type HarnessEvent,
   type HarnessEventListener,
   type MikanAgentSessionOptions,
+  type PromptBlockedOutcome,
 } from "./runner.js";
 export {
   formatSkillsForPrompt,
@@ -67,10 +68,12 @@ export type {
   MikanExtensionModule,
   MikanHookMap,
   MikanHookName,
+  RunOrigin,
   SessionCompactHookEvent,
   ToolCallHookEvent,
   ToolCallHookResult,
   ToolResultHookEvent,
+  ToolResultHookResult,
   TurnEndHookEvent,
 } from "./extensions/types.js";
 export {

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -52,8 +52,13 @@ export {
   type LoadExtensionsResult,
 } from "./extensions/loader.js";
 export type {
+  AgentErrorHookEvent,
   BeforeAgentStartHookEvent,
   BeforeAgentStartHookResult,
+  BudgetExceededHookEvent,
+  ExtensionCommand,
+  ExtensionCommandContext,
+  ExtensionDisposer,
   ExtensionHostServices,
   ExtensionLoadError,
   ExtensionManifest,

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -38,6 +38,7 @@ import {
 } from "@earendil-works/pi-ai";
 import * as log from "../log.js";
 import type { ExtensionRegistry } from "./extensions/registry.js";
+import type { RunOrigin } from "./extensions/types.js";
 import type { MikanModels } from "./models.js";
 import { resolveHarnessSettings, type BudgetSettings, type HarnessSettings } from "./settings.js";
 import type { SessionStore } from "./session-store.js";
@@ -89,6 +90,12 @@ export type HarnessEvent =
 
 export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
 
+/** Outcome of a `prompt()` call that an extension blocked before the model ran. */
+export interface PromptBlockedOutcome {
+  blocked: true;
+  reason?: string;
+}
+
 // Transient provider failures worth retrying: overload/rate-limit responses,
 // 5xx statuses, and network/stream interruptions.
 const RETRYABLE_ERROR_PATTERN =
@@ -137,6 +144,7 @@ export class MikanAgentSession {
   private tally: RunTally = { tokens: 0, costUsd: 0, llmCalls: 0, startedAt: 0 };
   private runBudget: BudgetSettings = {};
   private budgetExceededReason: string | undefined;
+  private runOrigin: RunOrigin | undefined;
 
   constructor(options: MikanAgentSessionOptions) {
     this.models = options.models;
@@ -161,20 +169,23 @@ export class MikanAgentSession {
           toolCallId: toolCall.id,
           toolName: toolCall.name,
           args,
+          origin: this.runOrigin,
         });
         return result ?? undefined;
       },
       afterToolCall: async ({ toolCall, args, result, isError }) => {
-        if (this.extensions?.hasHandlers("tool_result")) {
-          await this.extensions.emit("tool_result", {
-            toolCallId: toolCall.id,
-            toolName: toolCall.name,
-            args,
-            content: result.content,
-            isError,
-          });
-        }
-        return undefined;
+        if (!this.extensions?.hasHandlers("tool_result")) return undefined;
+        // Chained extension rewrites (redaction, truncation) become a
+        // pi-agent-core AfterToolCallResult override; undefined keeps the
+        // executed result untouched.
+        return this.extensions.emitToolResult({
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          args,
+          content: result.content,
+          isError,
+          origin: this.runOrigin,
+        });
       },
     });
 
@@ -209,16 +220,19 @@ export class MikanAgentSession {
   /**
    * Send a user prompt and run the agent loop to completion, including
    * automatic retries and compaction. Resolves when the turn (and any
-   * recovery continuations) settles.
+   * recovery continuations) settles. Returns a blocked outcome when a
+   * `before_agent_start` extension blocked the turn — the model was never
+   * called and nothing was persisted.
    *
    * @param options.budget Per-run resource ceilings that override the session
    *   defaults. Autonomous (event / trigger) runs should pass a budget so a
    *   runaway loop is stopped even with no human watching.
+   * @param options.origin Platform provenance forwarded to extension hooks.
    */
   async prompt(
     text: string,
-    options?: { images?: ImageContent[]; budget?: BudgetSettings },
-  ): Promise<void> {
+    options?: { images?: ImageContent[]; budget?: BudgetSettings; origin?: RunOrigin },
+  ): Promise<PromptBlockedOutcome | undefined> {
     if (this.agent.state.isStreaming) {
       throw new Error("Agent is already processing a prompt");
     }
@@ -231,6 +245,7 @@ export class MikanAgentSession {
     this.runBudget = { ...this.settings.budget, ...options?.budget };
     this.budgetExceededReason = undefined;
     this.tally = { tokens: 0, costUsd: 0, llmCalls: 0, startedAt: Date.now() };
+    this.runOrigin = options?.origin;
 
     // A previous turn may have ended over the threshold (for example after an
     // abort); compact before adding new context on top.
@@ -239,13 +254,27 @@ export class MikanAgentSession {
       await this.checkThresholdCompaction(lastAssistant);
     }
 
+    let promptText = text;
     let systemPrompt = this.agent.state.systemPrompt;
     if (this.extensions?.hasHandlers("before_agent_start")) {
-      const result = await this.extensions.emit("before_agent_start", {
-        prompt: text,
+      const result = await this.extensions.emitBeforeAgentStart({
+        prompt: promptText,
         images: options?.images,
         systemPrompt,
+        origin: this.runOrigin,
       });
+      if (result?.block) {
+        // Blocked before agent.prompt(): the user message never enters the
+        // transcript or session store, so the blocked turn leaves no trace.
+        log.logInfo(`Extension blocked turn${result.reason ? `: ${result.reason}` : ""}`);
+        return { blocked: true, reason: result.reason };
+      }
+      if (result?.prompt !== undefined && result.prompt !== promptText) {
+        log.logInfo(
+          `Extension rewrote user prompt: ${promptText.length} → ${result.prompt.length} chars`,
+        );
+        promptText = result.prompt;
+      }
       if (result?.systemPrompt && result.systemPrompt !== systemPrompt) {
         // An extension rewrote the system prompt for this turn. Log the new
         // size so the diagnostic in agent.ts (which logs the pre-hook prompt)
@@ -260,7 +289,7 @@ export class MikanAgentSession {
 
     const userMessage: AgentMessage = {
       role: "user",
-      content: [{ type: "text", text }, ...(options?.images ?? [])],
+      content: [{ type: "text", text: promptText }, ...(options?.images ?? [])],
       timestamp: Date.now(),
     };
 
@@ -270,8 +299,12 @@ export class MikanAgentSession {
     }
 
     if (this.extensions?.hasHandlers("turn_end")) {
-      await this.extensions.emit("turn_end", { messages: this.agent.state.messages });
+      await this.extensions.emit("turn_end", {
+        messages: this.agent.state.messages,
+        origin: this.runOrigin,
+      });
     }
+    return undefined;
   }
 
   /** Abort the active run, pending retry backoff, and in-flight compaction. */
@@ -322,7 +355,7 @@ export class MikanAgentSession {
     }
 
     if (this.extensions?.hasHandlers("message_end")) {
-      await this.extensions.emit("message_end", { message });
+      await this.extensions.emit("message_end", { message, origin: this.runOrigin });
     }
 
     if (message.role === "assistant") {

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -298,6 +298,16 @@ export class MikanAgentSession {
       await this.agent.continue();
     }
 
+    // The turn settled on an error (retries exhausted or not retryable):
+    // give monitoring extensions the final failure, once per turn.
+    const settled = this.findLastAssistantMessage();
+    if (settled?.stopReason === "error" && this.extensions?.hasHandlers("agent_error")) {
+      await this.extensions.emit("agent_error", {
+        errorMessage: settled.errorMessage || "Unknown error",
+        origin: this.runOrigin,
+      });
+    }
+
     if (this.extensions?.hasHandlers("turn_end")) {
       await this.extensions.emit("turn_end", {
         messages: this.agent.state.messages,
@@ -395,6 +405,16 @@ export class MikanAgentSession {
       llmCalls: this.tally.llmCalls,
       durationMs: Date.now() - this.tally.startedAt,
     });
+    if (this.extensions?.hasHandlers("budget_exceeded")) {
+      await this.extensions.emit("budget_exceeded", {
+        reason,
+        tokens: this.tally.tokens,
+        costUsd: this.tally.costUsd,
+        llmCalls: this.tally.llmCalls,
+        durationMs: Date.now() - this.tally.startedAt,
+        origin: this.runOrigin,
+      });
+    }
     log.logWarning("Run budget exceeded — aborting", reason);
     this.agent.abort();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,12 @@ import { mkdirSync, statSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
 import { dirname, join as pathJoin } from "path";
-import type { MessagingBot, PlatformNotifier, PlatformReactor } from "./adapter.js";
+import type {
+  MessagingBot,
+  PlatformNotifier,
+  PlatformReactor,
+  PlatformUploader,
+} from "./adapter.js";
 import { DiscordMessagingBot } from "./adapters/discord/bot.js";
 import { GithubMessagingBot } from "./adapters/github/bot.js";
 import { createGithubToolPack } from "./adapters/github/tool-pack.js";
@@ -405,6 +410,16 @@ const platformReactor: PlatformReactor = async (conversationId, messageTs, emoji
   log.logInfo(`[react] :${emoji}: on ${key}/${conversationId}`);
 };
 
+/** Extension `api.uploadFile` backend: send a host file into a conversation. */
+const platformUploader: PlatformUploader = async (conversationId, filePath, title, platform) => {
+  const [key, bot] = resolvePlatformBot("upload", platform);
+  if (!bot.uploadFile) {
+    throw new Error(`upload: platform '${key}' does not support file uploads`);
+  }
+  await bot.uploadFile(conversationId, filePath, title);
+  log.logInfo(`[upload] ${filePath} to ${key}/${conversationId}`);
+};
+
 /** github_* tool backends: PR push/create and CI checks, host-side. */
 function requireGithubBot(op: string): GithubMessagingBot {
   const bot = botsByPlatform.github as GithubMessagingBot | undefined;
@@ -453,6 +468,7 @@ const handler = createConversationRuntime({
   portalBaseUrl: portalBaseUrl(),
   platformNotifier,
   platformReactor,
+  platformUploader,
   platformToolPackFactories: buildPlatformToolPackFactories(),
 });
 

--- a/src/runtime/conversation-runtime.ts
+++ b/src/runtime/conversation-runtime.ts
@@ -162,7 +162,7 @@ class ConversationRuntimeImpl implements ConversationRuntime {
     );
     this.chatSessionManager.resetSession({ conversationDir, sessionKey, cwd: runtimeCwd });
 
-    this.conversationStates.delete(sessionKey);
+    this.discardState(sessionKey);
 
     log.logInfo(`[${conversationId}] Session reset: ${sessionKey}`);
     await bot.postMessage(conversationId, "Conversation reset. Send a new message to start fresh.");
@@ -233,6 +233,17 @@ class ConversationRuntimeImpl implements ConversationRuntime {
         conversationKind: event.conversationKind,
       });
       state.runner.syncChatHistory(event.ts);
+
+      // Extension-contributed commands: deterministic dispatch, no agent run.
+      // Built-in commands already had their chance above, so extensions can
+      // never shadow them; unmatched slash text falls through to the agent.
+      if (event.text.trim().startsWith("/")) {
+        const handled = await state.runner.tryExtensionCommand(context.message, context.responder);
+        if (handled) {
+          state.lastAccessedAt = Date.now();
+          return;
+        }
+      }
     } catch (err) {
       reportUserFacingError(err, {
         domain: "mikan",
@@ -459,6 +470,10 @@ class ConversationRuntimeImpl implements ConversationRuntime {
       return existing;
     }
 
+    // A stale state (rotated session file) is being replaced: release the old
+    // runner's extension resources before the new one takes the slot.
+    if (existing) this.discardState(sessionKey);
+
     const state: ConversationState = {
       running: false,
       runner: await createRunner({
@@ -478,6 +493,7 @@ class ConversationRuntimeImpl implements ConversationRuntime {
           : undefined,
         platformNotifier: this.options.platformNotifier,
         platformReactor: this.options.platformReactor,
+        platformUploader: this.options.platformUploader,
         platformToolPackFactories: this.options.platformToolPackFactories,
         models: this.options.models,
       }),
@@ -512,12 +528,28 @@ class ConversationRuntimeImpl implements ConversationRuntime {
     }
   }
 
+  /**
+   * Remove a session state and release its resources: fire-and-forget the
+   * runner's extension disposers so a slow disposer never stalls the caller.
+   */
+  private discardState(sessionKey: string): void {
+    const state = this.conversationStates.get(sessionKey);
+    if (!state) return;
+    this.conversationStates.delete(sessionKey);
+    state.runner.dispose().catch((err: unknown) => {
+      log.logWarning(
+        `Runner dispose failed: ${sessionKey}`,
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+  }
+
   private evictIdleSessions(): void {
     const now = Date.now();
 
     for (const [key, state] of this.conversationStates) {
       if (!state.running && now - state.lastAccessedAt > IDLE_TIMEOUT_MS) {
-        this.conversationStates.delete(key);
+        this.discardState(key);
       }
     }
 
@@ -533,7 +565,7 @@ class ConversationRuntimeImpl implements ConversationRuntime {
 
       const toEvict = this.conversationStates.size - MAX_SESSIONS;
       for (let i = 0; i < toEvict && i < idleSessions.length; i++) {
-        this.conversationStates.delete(idleSessions[i].key);
+        this.discardState(idleSessions[i].key);
       }
     }
   }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -7,6 +7,7 @@ import type {
   ConversationKind,
   PlatformNotifier,
   PlatformReactor,
+  PlatformUploader,
 } from "../adapter.js";
 import type {
   AdminTokenStoreLike,
@@ -67,6 +68,8 @@ export interface ConversationRuntimeOptions extends Omit<
   platformNotifier?: PlatformNotifier;
   /** Proactive emoji reactions for extensions (`api.react`). */
   platformReactor?: PlatformReactor;
+  /** Proactive file uploads for extensions (`api.uploadFile`). */
+  platformUploader?: PlatformUploader;
   /**
    * Optional platform capability packs (extra tools + per-run bind), as
    * factories — each runner instantiates its own pack because bind state is

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,12 @@ export interface MessagingBot {
    * adapters adopt it incrementally; callers must handle its absence.
    */
   addReaction?(channel: string, messageTs: string, emoji: string): Promise<void>;
+  /**
+   * Upload a host-side file into a conversation. Optional so adapters adopt
+   * it incrementally; callers must handle its absence. Existing adapter
+   * implementations (Slack/Discord/Telegram) already match this shape.
+   */
+  uploadFile?(channel: string, filePath: string, title?: string): Promise<void>;
   enqueueEvent(event: ConversationEvent): boolean;
   getMessagingInfo(): MessagingInfo;
   postPrivate?(conversationId: string, userId: string, text: string): Promise<void>;
@@ -169,6 +175,18 @@ export type PlatformReactor = (
   conversationId: string,
   messageTs: string,
   emoji: string,
+  platform?: string,
+) => Promise<void>;
+
+/**
+ * Upload a host-side file into a conversation without triggering an agent
+ * run. Backs extension `api.uploadFile`; implemented in main.ts over the
+ * platform bots. `platform` is required only when more than one is running.
+ */
+export type PlatformUploader = (
+  conversationId: string,
+  filePath: string,
+  title?: string,
   platform?: string,
 ) => Promise<void>;
 
@@ -210,6 +228,16 @@ export interface PiAgentWrapper {
   ): Promise<{ stopReason: string; errorMessage?: string }>;
   abort(): void;
   getCurrentStep(): { toolName?: string; label?: string } | undefined;
+  /**
+   * Dispatch a leading-slash message to an extension-registered command.
+   * Returns true when a command consumed the message (no agent run follows).
+   */
+  tryExtensionCommand(
+    message: ConversationMessage,
+    responder: ConversationResponder,
+  ): Promise<boolean>;
+  /** Run extension disposers. Call once when this wrapper is discarded. */
+  dispose(): Promise<void>;
 }
 
 // ── config ────────────────────────────────────────────────────────────────────

--- a/test/harness-extensions.test.ts
+++ b/test/harness-extensions.test.ts
@@ -513,3 +513,106 @@ describe("ExtensionRegistry", () => {
     expect(result).toEqual({ block: false });
   });
 });
+
+describe("ExtensionRegistry.emitBeforeAgentStart", () => {
+  const event = { prompt: "hi", systemPrompt: "base" };
+
+  test("returns undefined when no handler changes anything", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("observer", "before_agent_start", () => undefined);
+
+    expect(await registry.emitBeforeAgentStart({ ...event })).toBeUndefined();
+  });
+
+  test("systemPrompt and prompt rewrites chain across handlers", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("first", "before_agent_start", ({ systemPrompt }) => ({
+      systemPrompt: `${systemPrompt}+A`,
+    }));
+    registry.register("second", "before_agent_start", ({ systemPrompt, prompt }) => ({
+      systemPrompt: `${systemPrompt}+B`,
+      prompt: `${prompt}!`,
+    }));
+
+    const result = await registry.emitBeforeAgentStart({ ...event });
+    // The second handler saw the first handler's rewrite, not the original.
+    expect(result).toEqual({ systemPrompt: "base+A+B", prompt: "hi!" });
+  });
+
+  test("a block from any handler wins regardless of registration order", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("enricher", "before_agent_start", () => ({ systemPrompt: "rewritten" }));
+    registry.register("policy", "before_agent_start", () => ({
+      block: true,
+      reason: "quota exhausted",
+    }));
+
+    const result = await registry.emitBeforeAgentStart({ ...event });
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toBe("quota exhausted");
+  });
+
+  test("the first block's reason is kept", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("a", "before_agent_start", () => ({ block: true, reason: "first" }));
+    registry.register("b", "before_agent_start", () => ({ block: true, reason: "second" }));
+
+    const result = await registry.emitBeforeAgentStart({ ...event });
+    expect(result).toEqual({ block: true, reason: "first" });
+  });
+
+  test("handler errors are isolated and later handlers still run", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("bad", "before_agent_start", () => {
+      throw new Error("broken");
+    });
+    registry.register("good", "before_agent_start", () => ({ block: true }));
+
+    const result = await registry.emitBeforeAgentStart({ ...event });
+    expect(result?.block).toBe(true);
+  });
+});
+
+describe("ExtensionRegistry.emitToolResult", () => {
+  const event = {
+    toolCallId: "t1",
+    toolName: "bash",
+    args: {},
+    content: [{ type: "text" as const, text: "token=s3cret" }],
+    isError: false,
+  };
+
+  test("returns undefined when no handler changes anything", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("observer", "tool_result", () => undefined);
+
+    expect(await registry.emitToolResult({ ...event })).toBeUndefined();
+  });
+
+  test("content rewrites chain so redaction sees upstream rewrites", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("annotate", "tool_result", ({ content }) => ({
+      content: [...content, { type: "text" as const, text: "note: token=s3cret" }],
+    }));
+    registry.register("redact", "tool_result", ({ content }) => ({
+      content: content.map((part) =>
+        part.type === "text" ? { ...part, text: part.text.replaceAll("s3cret", "***") } : part,
+      ),
+    }));
+
+    const result = await registry.emitToolResult({ ...event });
+    // The redactor processed the annotator's output, so both parts are clean.
+    expect(result?.content).toEqual([
+      { type: "text", text: "token=***" },
+      { type: "text", text: "note: token=***" },
+    ]);
+  });
+
+  test("isError can be overridden independently of content", async () => {
+    const registry = new ExtensionRegistry();
+    registry.register("flagger", "tool_result", () => ({ isError: true }));
+
+    const result = await registry.emitToolResult({ ...event });
+    expect(result).toEqual({ isError: true });
+  });
+});

--- a/test/harness-extensions.test.ts
+++ b/test/harness-extensions.test.ts
@@ -448,7 +448,7 @@ describe("loadExtensions v2 api", () => {
     ]);
   });
 
-  test("service-less contexts surface informative errors for schedules, notify, react", async () => {
+  test("service-less contexts surface informative errors for schedules, notify, react, upload", async () => {
     const probe = writeProbeExtension(
       `export default async function activate(api) {
         const caught = [];
@@ -457,6 +457,10 @@ describe("loadExtensions v2 api", () => {
         try { await api.notify("x"); }
         catch (err) { caught.push(String(err)); }
         try { await api.react("1700000000.1", "eyes"); }
+        catch (err) { caught.push(String(err)); }
+        try { await api.uploadFile("/tmp/report.txt"); }
+        catch (err) { caught.push(String(err)); }
+        try { await api.triggerRun("go"); }
         catch (err) { caught.push(String(err)); }
         report({ caught });
       }`,
@@ -468,6 +472,170 @@ describe("loadExtensions v2 api", () => {
     expect(caught[0]).toMatch(/schedule store/);
     expect(caught[1]).toMatch(/platform messaging/);
     expect(caught[2]).toMatch(/reaction support/);
+    expect(caught[3]).toMatch(/file uploads/);
+    expect(caught[4]).toMatch(/schedule store/);
+  });
+
+  test("api.notify can target another conversation explicitly", async () => {
+    const posts: Array<{ conversationId: string; text: string }> = [];
+    writeProbeExtension(
+      `export default async function activate(api) {
+        await api.notify("here");
+        await api.notify("there", { conversationId: "C999" });
+      }`,
+    );
+
+    const { errors } = await loadExtensions({
+      dirs: [dir],
+      context,
+      services: {
+        postMessage: async (conversationId, text) => {
+          posts.push({ conversationId, text });
+        },
+      },
+    });
+    expect(errors).toHaveLength(0);
+    expect(posts).toEqual([
+      { conversationId: "C123", text: "here" },
+      { conversationId: "C999", text: "there" },
+    ]);
+  });
+
+  test("api.uploadFile sends a host file into the extension's conversation", async () => {
+    const uploads: Array<{ conversationId: string; filePath: string; title?: string }> = [];
+    writeProbeExtension(
+      'export default async function activate(api) { await api.uploadFile("/tmp/report.pdf", "Weekly"); }',
+    );
+
+    const { errors } = await loadExtensions({
+      dirs: [dir],
+      context,
+      services: {
+        uploadFile: async (conversationId, filePath, title) => {
+          uploads.push({ conversationId, filePath, title });
+        },
+      },
+    });
+    expect(errors).toHaveLength(0);
+    expect(uploads).toEqual([
+      { conversationId: "C123", filePath: "/tmp/report.pdf", title: "Weekly" },
+    ]);
+  });
+
+  test("api.triggerRun writes an immediate event outside the schedules namespace", async () => {
+    const { files, store } = createFakeScheduleStore();
+    const probe = writeProbeExtension(
+      `export default async function activate(api) {
+        await api.triggerRun("check the deploy now");
+        const listed = await api.schedules.list();
+        report({ scheduleNames: listed.map((info) => info.name) });
+      }`,
+    );
+
+    const { errors } = await loadExtensions({
+      dirs: [dir],
+      context,
+      services: { scheduleStore: store },
+    });
+    expect(errors).toHaveLength(0);
+
+    const runFiles = [...files.keys()].filter((name) => name.startsWith("extrun.probe.c123."));
+    expect(runFiles).toHaveLength(1);
+    expect(files.get(runFiles[0])).toEqual({
+      type: "immediate",
+      conversationId: "C123",
+      text: "check the deploy now",
+    });
+    // Run files must not leak into the extension's schedule inventory.
+    expect(probe.read()).toEqual({ scheduleNames: [] });
+  });
+
+  test("disposers from onDispose and the activate return value run LIFO on dispose", async () => {
+    const probe = writeProbeExtension(
+      `const order = [];
+      export default function activate(api) {
+        api.onDispose(() => { order.push("onDispose"); report({ order }); });
+        return () => { order.push("returned"); };
+      }`,
+    );
+
+    const result = await loadExtensions({ dirs: [dir], context });
+    expect(result.errors).toHaveLength(0);
+    await result.dispose();
+    // The activate-returned disposer registered last, so it runs first.
+    expect(probe.read()).toEqual({ order: ["returned", "onDispose"] });
+  });
+
+  test("api.registerCommand dispatches with args and user identity", async () => {
+    writeProbeExtension(
+      `export default function activate(api) {
+        api.registerCommand({
+          name: "PM",
+          description: "follow-up board",
+          handler: async ({ args, userId, respond }) => {
+            await respond("pm(" + args + ") for " + userId);
+          },
+        });
+      }`,
+    );
+
+    const { registry, errors } = await loadExtensions({ dirs: [dir], context });
+    expect(errors).toHaveLength(0);
+    expect(registry.getCommands().map((command) => command.name)).toEqual(["PM"]);
+
+    const replies: string[] = [];
+    // Matching is case-insensitive: /pm reaches the command registered as PM.
+    const handled = await registry.dispatchCommand("pm", {
+      args: "list open",
+      conversationId: "C123",
+      userId: "U1",
+      respond: async (text) => {
+        replies.push(text);
+      },
+    });
+    expect(handled).toBe(true);
+    expect(replies).toEqual(["pm(list open) for U1"]);
+
+    const unknown = await registry.dispatchCommand("nope", {
+      args: "",
+      conversationId: "C123",
+      respond: async () => {},
+    });
+    expect(unknown).toBe(false);
+  });
+
+  test("a failing command handler is consumed and reports the failure", async () => {
+    writeProbeExtension(
+      `export default function activate(api) {
+        api.registerCommand({ name: "boom", handler: () => { throw new Error("kaput"); } });
+      }`,
+    );
+
+    const { registry, errors } = await loadExtensions({ dirs: [dir], context });
+    expect(errors).toHaveLength(0);
+
+    const replies: string[] = [];
+    const handled = await registry.dispatchCommand("boom", {
+      args: "",
+      conversationId: "C123",
+      respond: async (text) => {
+        replies.push(text);
+      },
+    });
+    expect(handled).toBe(true);
+    expect(replies[0]).toMatch(/\/boom failed: kaput/);
+  });
+
+  test("an invalid command name fails that extension's activation", async () => {
+    writeProbeExtension(
+      `export default function activate(api) {
+        api.registerCommand({ name: "no spaces", handler: () => {} });
+      }`,
+    );
+
+    const { extensions, errors } = await loadExtensions({ dirs: [dir], context });
+    expect(extensions).toHaveLength(0);
+    expect(errors[0]?.error).toMatch(/Invalid extension command name/);
   });
 
   test("skills/ directory contributes inline skills", async () => {
@@ -511,6 +679,47 @@ describe("ExtensionRegistry", () => {
 
     const result = await registry.emit("tool_call", { toolCallId: "t", toolName: "x", args: {} });
     expect(result).toEqual({ block: false });
+  });
+
+  test("duplicate command names keep the first registration", async () => {
+    const registry = new ExtensionRegistry();
+    const replies: string[] = [];
+    registry.registerCommand("ext-a", {
+      name: "pm",
+      handler: async ({ respond }) => respond("from a"),
+    });
+    registry.registerCommand("ext-b", {
+      name: "PM",
+      handler: async ({ respond }) => respond("from b"),
+    });
+
+    await registry.dispatchCommand("pm", {
+      args: "",
+      conversationId: "C1",
+      respond: async (text) => {
+        replies.push(text);
+      },
+    });
+    expect(replies).toEqual(["from a"]);
+  });
+
+  test("dispose is idempotent and isolates disposer failures", async () => {
+    const registry = new ExtensionRegistry();
+    const ran: string[] = [];
+    registry.registerDisposer("bad", () => {
+      ran.push("bad");
+      throw new Error("broken disposer");
+    });
+    registry.registerDisposer("good", () => {
+      ran.push("good");
+    });
+
+    await registry.dispose();
+    // LIFO order, and the bad disposer's error does not stop the run.
+    expect(ran).toEqual(["good", "bad"]);
+
+    await registry.dispose();
+    expect(ran).toEqual(["good", "bad"]);
   });
 });
 

--- a/test/harness-runner.test.ts
+++ b/test/harness-runner.test.ts
@@ -162,6 +162,127 @@ describe("MikanAgentSession", () => {
     expect(JSON.stringify(toolResults)).toContain("blocked by test");
   });
 
+  test("a before_agent_start block stops the turn before the model runs", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([fauxAssistantMessage("should never be produced")]);
+
+    const extensions = new ExtensionRegistry();
+    extensions.register("policy", "before_agent_start", () => ({
+      block: true,
+      reason: "user not allowed",
+    }));
+
+    const sessionStore = SessionStore.create(join(dir, "session.jsonl"), dir);
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [],
+      models,
+      sessionStore,
+      extensions,
+    });
+
+    const outcome = await session.prompt("do something");
+    expect(outcome).toEqual({ blocked: true, reason: "user not allowed" });
+    // The model was never called and the blocked turn left no trace.
+    expect(session.messages).toHaveLength(0);
+    expect(sessionStore.getEntries().filter((entry) => entry.type === "message")).toHaveLength(0);
+  });
+
+  test("before_agent_start can rewrite the user prompt and sees the run origin", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([fauxAssistantMessage("ok")]);
+
+    const seenOrigins: unknown[] = [];
+    const extensions = new ExtensionRegistry();
+    extensions.register("rewriter", "before_agent_start", ({ prompt, origin }) => {
+      seenOrigins.push(origin);
+      return { prompt: `${prompt} [enriched]` };
+    });
+
+    const sessionStore = SessionStore.create(join(dir, "session.jsonl"), dir);
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [],
+      models,
+      sessionStore,
+      extensions,
+    });
+
+    const outcome = await session.prompt("original ask", {
+      origin: {
+        kind: "interactive",
+        platform: "slack",
+        messageTs: "1700000000.1",
+        userId: "U1",
+        userName: "kai",
+      },
+    });
+    expect(outcome).toBeUndefined();
+    expect(seenOrigins).toEqual([
+      {
+        kind: "interactive",
+        platform: "slack",
+        messageTs: "1700000000.1",
+        userId: "U1",
+        userName: "kai",
+      },
+    ]);
+
+    // The rewritten prompt is what entered the transcript and the store.
+    const userMessage = session.messages.find((message) => message.role === "user");
+    expect(JSON.stringify(userMessage)).toContain("original ask [enriched]");
+    expect(JSON.stringify(sessionStore.getEntries())).toContain("original ask [enriched]");
+  });
+
+  test("tool_result hooks rewrite tool output before the model and the store see it", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([
+      fauxAssistantMessage(fauxToolCall("echo", { text: "token=s3cret" })),
+      fauxAssistantMessage("done"),
+    ]);
+
+    const originKinds: unknown[] = [];
+    const extensions = new ExtensionRegistry();
+    extensions.register("redactor", "tool_result", ({ content, origin }) => {
+      originKinds.push(origin?.kind);
+      return {
+        content: content.map((part) =>
+          part.type === "text" ? { ...part, text: part.text.replaceAll("s3cret", "***") } : part,
+        ),
+      };
+    });
+
+    const sessionStore = SessionStore.create(join(dir, "session.jsonl"), dir);
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [echoTool],
+      models,
+      sessionStore,
+      extensions,
+    });
+
+    await session.prompt("run the tool", { origin: { kind: "event", platform: "slack" } });
+
+    expect(originKinds).toEqual(["event"]);
+    const persisted = JSON.stringify(
+      sessionStore
+        .getEntries()
+        .filter(
+          (entry) =>
+            entry.type === "message" &&
+            (entry as { message: { role: string } }).message.role === "toolResult",
+        ),
+    );
+    expect(persisted).toContain("echo: token=***");
+    expect(persisted).not.toContain("s3cret");
+  });
+
   test("budget circuit breaker aborts a run that exceeds the LLM-call cap", async () => {
     const { models, faux, model } = createFauxSetup();
     // Would take two LLM calls (tool call, then final); the cap stops it at one.

--- a/test/harness-runner.test.ts
+++ b/test/harness-runner.test.ts
@@ -283,6 +283,63 @@ describe("MikanAgentSession", () => {
     expect(persisted).not.toContain("s3cret");
   });
 
+  test("agent_error hook fires once when a turn settles on a non-retryable error", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([
+      fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid api key" }),
+    ]);
+
+    const errorsSeen: Array<{ errorMessage: string; originKind?: string }> = [];
+    const extensions = new ExtensionRegistry();
+    extensions.register("monitor", "agent_error", ({ errorMessage, origin }) => {
+      errorsSeen.push({ errorMessage, originKind: origin?.kind });
+    });
+
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [],
+      models,
+      sessionStore: SessionStore.create(join(dir, "session.jsonl"), dir),
+      extensions,
+    });
+
+    await session.prompt("hi", { origin: { kind: "interactive", platform: "slack" } });
+
+    expect(errorsSeen).toEqual([{ errorMessage: "invalid api key", originKind: "interactive" }]);
+  });
+
+  test("budget_exceeded hook fires when the circuit breaker trips", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([
+      fauxAssistantMessage(fauxToolCall("echo", { text: "ping" })),
+      fauxAssistantMessage("done"),
+    ]);
+
+    const tripped: Array<{ reason: string; llmCalls: number }> = [];
+    const extensions = new ExtensionRegistry();
+    extensions.register("monitor", "budget_exceeded", ({ reason, llmCalls }) => {
+      tripped.push({ reason, llmCalls });
+    });
+
+    const session = new MikanAgentSession({
+      systemPrompt: "test",
+      model,
+      thinkingLevel: "off",
+      tools: [echoTool],
+      models,
+      sessionStore: SessionStore.create(join(dir, "session.jsonl"), dir),
+      extensions,
+    });
+
+    await session.prompt("run the tool", { budget: { maxLlmCalls: 1 } });
+
+    expect(tripped).toHaveLength(1);
+    expect(tripped[0].llmCalls).toBe(1);
+    expect(tripped[0].reason).toContain("LLM calls");
+  });
+
   test("budget circuit breaker aborts a run that exceeds the LLM-call cap", async () => {
     const { models, faux, model } = createFauxSetup();
     // Would take two LLM calls (tool call, then final); the cap stops it at one.


### PR DESCRIPTION
## Summary

Closes the P0 + P1 gaps found in the extension API review: extensions go from observe-only to able to intervene (block turns, rewrite prompts and tool output), know who triggered a run, contribute slash commands, and clean up after themselves. Two commits, one per phase.

### P0 — consistency fixes (`931bae6`)

- **`RunOrigin` on hook events**: every per-turn hook event now carries `origin` (platform, `messageTs`, `userId`, `userName`, `threadTs`, attachments; `kind: "interactive" | "event"`). This makes `api.react` actually usable (it needed a message id no hook previously provided) and enables per-user policy. Autonomous event runs leave identity fields unset.
- **`before_agent_start` can rewrite the user prompt or block the turn**: a blocked turn returns before the model is called and leaves no trace in the transcript or session store; the block reason is shown as a diagnostic message.
- **`tool_result` can rewrite tool output** (`content` / `isError`) via pi-agent-core's existing `AfterToolCallResult` override — mikan was discarding the capability. Enables secret redaction and output truncation; the rewrite is what both the model and the persisted session see.
- **Per-hook merge semantics**: `before_agent_start` and `tool_result` now chain (each handler sees earlier handlers' rewrites) and any `block` wins regardless of registration order — previously a policy extension's block could be silently shadowed by an unrelated earlier handler under first-result-wins. `tool_call` keeps v1 semantics.

### P1 — new capabilities (`82a24e7`)

- **`api.registerCommand`**: extensions contribute `/name` chat commands, dispatched deterministically after built-ins miss — no model call, no tokens, no session entry. Case-insensitive; first registration wins; handler errors are reported in-conversation and logged. Unmatched slash text still reaches the agent.
- **Disposal lifecycle**: `activate` may return a disposer, or register via `api.onDispose`. Disposers run (LIFO, errors isolated) at every harness-discard point: `/pi-new`, idle eviction, `MAX_SESSIONS` eviction, stale-session replacement.
- **`api.triggerRun(text)`**: fire an immediate autonomous run via an `extrun.`-prefixed immediate event file — deliberately outside the `ext.` schedules namespace so `api.schedules.list()` never surfaces it.
- **`api.uploadFile(path, title)`**: proactive host-file upload backed by a new `PlatformUploader` host service; `MessagingBot` gains an optional `uploadFile` that Slack/Discord/Telegram already implement (GitHub throws an informative error).
- **`api.notify(text, { conversationId })`**: explicit cross-conversation posting for `sharedDataDir`-style multi-conversation extensions.
- **`agent_error` / `budget_exceeded` hooks**: monitoring extensions now see turn-level failure signals that only platform adapters had.

Backward compatibility: everything is additive (optional fields, `void`-returning handlers unchanged). The one signature change is `MikanAgentSession.prompt()` returning a possible blocked outcome instead of `void`; existing callers are unaffected.

## How I tested

- [x] `npm run lint`
- [x] `npm test` — 973 passed (+24 new: registry merge/chain/block-OR semantics, dispose LIFO/idempotency/error isolation, command dispatch/case-insensitivity/duplicate handling/failing handlers, origin passthrough, block-leaves-no-trace, prompt rewrite reaching transcript, redaction reaching the persisted store, triggerRun namespace isolation, cross-conversation notify, uploadFile, both new hooks)
- [x] `npm run build`
- [x] `npm run knip`, `npm run fmt:check`

## Notes for reviewers

- **`origin.platform` rides on the hook event, not `api.context`**: the harness is created with an `emptyPlatform` placeholder; the real `MessagingInfo` only arrives per run, so a context-level platform would be a lie at activation time.
- **Extension command interception point** is in `runSession` after `getOrCreateState` — by the time we know the text isn't a built-in command, the runner was about to be created anyway, so command dispatch adds no extra harness instantiation.
- **Dispose is fire-and-forget** in the runtime (`discardState`) so a slow disposer never stalls eviction or `/pi-new`; failures are logged.
- **Punted follow-ups**: `tool_call` args rewriting needs an upstream `pi-agent-core` change (`BeforeToolCallResult` only supports block today) — a mikan-side executor wrapper would make transcript args diverge from executed args, so it was deliberately not worked around. P2 items (webhook ingress, config schema, manifest apiVersion/permissions, `mikan ext dev`) are listed in the review discussion but not in scope here.
- The stale "there is no deactivate hook" lifecycle rule was updated in all four doc locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8xrMASDH9GhoKSFmuxJxZ