### PR TITLE
Broaden coverage gate to all of src and test the biggest gaps

### DIFF
--- a/test/bash-tool.test.ts
+++ b/test/bash-tool.test.ts
@@ -1,0 +1,116 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { HostExecutor } from "../src/sandbox/host.js";
+import type { Executor } from "../src/sandbox/index.js";
+import { createBashTool } from "../src/tools/bash.js";
+import { DEFAULT_MAX_LINES } from "../src/tools/truncate.js";
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+  const first = result.content[0];
+  if (first.type !== "text" || first.text === undefined) {
+    throw new Error(`Expected text content, got ${first.type}`);
+  }
+  return first.text;
+}
+
+describe("createBashTool", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `mikan-bash-test-${Date.now()}-${Math.random()}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  });
+
+  test("returns stdout of a successful command", async () => {
+    const tool = createBashTool(new HostExecutor());
+    const result = await tool.execute("1", { label: "echo", command: "echo hello" });
+    expect(textOf(result)).toContain("hello");
+    expect(result.details).toBeUndefined();
+  });
+
+  test("combines stdout and stderr", async () => {
+    const tool = createBashTool(new HostExecutor());
+    const result = await tool.execute("1", {
+      label: "both streams",
+      command: "echo out; echo err >&2",
+    });
+    const text = textOf(result);
+    expect(text).toContain("out");
+    expect(text).toContain("err");
+  });
+
+  test("reports '(no output)' for silent commands", async () => {
+    const tool = createBashTool(new HostExecutor());
+    const result = await tool.execute("1", { label: "silent", command: "true" });
+    expect(textOf(result)).toBe("(no output)");
+  });
+
+  test("throws on non-zero exit, including output and exit code", async () => {
+    const tool = createBashTool(new HostExecutor());
+    await expect(
+      tool.execute("1", { label: "fail", command: "echo boom; exit 3" }),
+    ).rejects.toThrow(/boom[\s\S]*Command exited with code 3/);
+  });
+
+  test("spills oversized output into the workspace and reports the path", async () => {
+    const tool = createBashTool(new HostExecutor(), { hostWorkspaceRoot: dir });
+    // seq 1..30000 is ~170KB over 30000 lines: exceeds both line and byte limits
+    const result = await tool.execute("1", { label: "big", command: "seq 1 30000" });
+    const text = textOf(result);
+
+    expect(result.details?.truncation?.truncated).toBe(true);
+    const spillPath = result.details?.fullOutputPath;
+    expect(spillPath).toBeDefined();
+    expect(spillPath).toContain(join(dir, ".mikan", "bash-output"));
+    expect(text).toContain(`Full output: ${spillPath}`);
+
+    // The truncated view keeps the tail; the spill file holds everything
+    expect(text).toContain("30000");
+    expect(text).not.toContain("\n1\n");
+    const full = readFileSync(spillPath!, "utf-8");
+    expect(full.startsWith("1\n")).toBe(true);
+    expect(full).toContain("\n30000");
+    expect(result.details?.truncation?.outputLines).toBeLessThanOrEqual(DEFAULT_MAX_LINES);
+  });
+
+  test("notes when spilling the full output fails", async () => {
+    const host = new HostExecutor();
+    const failingWrites: Executor = {
+      exec: (cmd, opts) => host.exec(cmd, opts),
+      readFile: (path, opts) => host.readFile(path, opts),
+      writeFile: async () => {
+        throw new Error("disk full");
+      },
+      getWorkspacePath: (p) => host.getWorkspacePath(p),
+      getPathContext: (root) => host.getPathContext(root),
+    };
+    const tool = createBashTool(failingWrites, { hostWorkspaceRoot: dir });
+    const result = await tool.execute("1", { label: "big", command: "seq 1 30000" });
+    expect(result.details?.fullOutputPath).toBeUndefined();
+    expect(textOf(result)).toContain("Full output unavailable (spill failed).");
+  });
+
+  test("truncates by line count without spilling when output is small in bytes", async () => {
+    const tool = createBashTool(new HostExecutor(), { hostWorkspaceRoot: dir });
+    // 3000 one-character lines: over the line limit, well under 50KB
+    const result = await tool.execute("1", { label: "lines", command: "yes x | head -n 3000" });
+    expect(result.details?.truncation?.truncatedBy).toBe("lines");
+    expect(result.details?.fullOutputPath).toBeUndefined();
+    // The trailing newline counts as a final empty line, hence 3001
+    expect(textOf(result)).toMatch(/Showing lines 1002-3001 of 3001\./);
+    expect(existsSync(join(dir, ".mikan"))).toBe(false);
+  });
+
+  test("kills commands that exceed the timeout", async () => {
+    const tool = createBashTool(new HostExecutor());
+    await expect(
+      tool.execute("1", { label: "slow", command: "sleep 10", timeout: 1 }),
+    ).rejects.toThrow(/timed out/);
+  }, 15_000);
+});

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -1,0 +1,306 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, rmdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ChannelStore } from "../src/store.js";
+
+function okResponse(body: string): Response {
+  return new Response(Buffer.from(body), { status: 200 });
+}
+
+function jsonLines(path: string): Array<Record<string, unknown>> {
+  return readFileSync(path, "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+}
+
+describe("ChannelStore", () => {
+  let dir: string;
+  let store: ChannelStore;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `mikan-store-test-${Date.now()}-${Math.random()}`);
+    store = new ChannelStore({ workingDir: dir, botToken: "xoxb-test-token" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  });
+
+  test("constructor creates the working directory", () => {
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  test("getChannelDir creates and returns the channel directory", () => {
+    const channelDir = store.getChannelDir("C123");
+    expect(channelDir).toBe(join(dir, "C123"));
+    expect(existsSync(channelDir)).toBe(true);
+  });
+
+  describe("generateLocalFilename", () => {
+    test("prefixes the millisecond timestamp and sanitizes the name", () => {
+      expect(store.generateLocalFilename("my file (1).png", "1234567890.123456")).toBe(
+        "1234567890123_my_file__1_.png",
+      );
+    });
+
+    test("keeps safe characters intact", () => {
+      expect(store.generateLocalFilename("report-v2_final.txt", "1000.5")).toBe(
+        "1000500_report-v2_final.txt",
+      );
+    });
+  });
+
+  describe("logMessage", () => {
+    test("appends a JSONL line and returns true", async () => {
+      const logged = await store.logMessage("C1", {
+        date: "2026-01-01T00:00:00.000Z",
+        ts: "1.0",
+        user: "U1",
+        text: "hello",
+        attachments: [],
+        isMessagingBot: false,
+      });
+      expect(logged).toBe(true);
+      const lines = jsonLines(join(dir, "C1", "log.jsonl"));
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ user: "U1", text: "hello", ts: "1.0" });
+    });
+
+    test("returns false for a duplicate channel+ts", async () => {
+      const message = {
+        date: "2026-01-01T00:00:00.000Z",
+        ts: "42.0",
+        user: "U1",
+        text: "once",
+        attachments: [],
+        isMessagingBot: false,
+      };
+      expect(await store.logMessage("C1", message)).toBe(true);
+      expect(await store.logMessage("C1", { ...message, text: "twice" })).toBe(false);
+      expect(jsonLines(join(dir, "C1", "log.jsonl"))).toHaveLength(1);
+    });
+
+    test("suppresses concurrent duplicate logging", async () => {
+      const message = {
+        date: "2026-01-01T00:00:00.000Z",
+        ts: "7.0",
+        user: "U1",
+        text: "racy",
+        attachments: [],
+        isMessagingBot: false,
+      };
+      const results = await Promise.all([
+        store.logMessage("C1", message),
+        store.logMessage("C1", { ...message }),
+      ]);
+      expect(results.filter((r) => r).length).toBe(1);
+      expect(jsonLines(join(dir, "C1", "log.jsonl"))).toHaveLength(1);
+    });
+
+    test("same ts in different channels is not a duplicate", async () => {
+      const message = {
+        date: "2026-01-01T00:00:00.000Z",
+        ts: "9.0",
+        user: "U1",
+        text: "hi",
+        attachments: [],
+        isMessagingBot: false,
+      };
+      expect(await store.logMessage("C1", message)).toBe(true);
+      expect(await store.logMessage("C2", { ...message })).toBe(true);
+    });
+
+    test("derives date from a Slack-style fractional timestamp", async () => {
+      await store.logMessage("C1", {
+        date: "",
+        ts: "1234567890.123456",
+        user: "U1",
+        text: "x",
+        attachments: [],
+        isMessagingBot: false,
+      });
+      const [line] = jsonLines(join(dir, "C1", "log.jsonl"));
+      expect(line.date).toBe("2009-02-13T23:31:30.123Z");
+    });
+
+    test("derives date from an epoch-milliseconds timestamp", async () => {
+      await store.logMessage("C1", {
+        date: "",
+        ts: "1700000000000",
+        user: "U1",
+        text: "x",
+        attachments: [],
+        isMessagingBot: false,
+      });
+      const [line] = jsonLines(join(dir, "C1", "log.jsonl"));
+      expect(line.date).toBe("2023-11-14T22:13:20.000Z");
+    });
+
+    test("a failed append does not poison the dedupe cache", async () => {
+      const message = {
+        date: "2026-01-01T00:00:00.000Z",
+        ts: "5.0",
+        user: "U1",
+        text: "retry me",
+        attachments: [],
+        isMessagingBot: false,
+      };
+      // Make the append fail by occupying log.jsonl with a directory
+      mkdirSync(join(dir, "C1", "log.jsonl"), { recursive: true });
+      await expect(store.logMessage("C1", message)).rejects.toThrow();
+
+      rmdirSync(join(dir, "C1", "log.jsonl"));
+      expect(await store.logMessage("C1", message)).toBe(true);
+      expect(jsonLines(join(dir, "C1", "log.jsonl"))).toHaveLength(1);
+    });
+  });
+
+  test("logBotResponse writes a bot-attributed entry", async () => {
+    await store.logBotResponse("C1", "response text", "99.0");
+    const [line] = jsonLines(join(dir, "C1", "log.jsonl"));
+    expect(line).toMatchObject({
+      user: "bot",
+      text: "response text",
+      ts: "99.0",
+      isMessagingBot: true,
+    });
+  });
+
+  describe("getLastTimestamp", () => {
+    test("returns null when no log exists", () => {
+      expect(store.getLastTimestamp("C-missing")).toBeNull();
+    });
+
+    test("returns the ts of the last line", async () => {
+      for (const ts of ["1.0", "2.0", "3.0"]) {
+        await store.logMessage("C1", {
+          date: "2026-01-01T00:00:00.000Z",
+          ts,
+          user: "U1",
+          text: ts,
+          attachments: [],
+          isMessagingBot: false,
+        });
+      }
+      expect(store.getLastTimestamp("C1")).toBe("3.0");
+    });
+
+    test("returns null for an empty log file", () => {
+      mkdirSync(join(dir, "C1"), { recursive: true });
+      writeFileSync(join(dir, "C1", "log.jsonl"), "");
+      expect(store.getLastTimestamp("C1")).toBeNull();
+    });
+
+    test("returns null when the last line is malformed", () => {
+      mkdirSync(join(dir, "C1"), { recursive: true });
+      writeFileSync(join(dir, "C1", "log.jsonl"), "not json\n");
+      expect(store.getLastTimestamp("C1")).toBeNull();
+    });
+
+    test("returns null when the last entry has no ts", () => {
+      mkdirSync(join(dir, "C1"), { recursive: true });
+      writeFileSync(join(dir, "C1", "log.jsonl"), `${JSON.stringify({ text: "no ts" })}\n`);
+      expect(store.getLastTimestamp("C1")).toBeNull();
+    });
+  });
+
+  describe("processAttachments", () => {
+    test("downloads attachments with the bot token and returns local paths", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okResponse("file body"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const attachments = await store.processAttachments(
+        "C1",
+        [{ name: "report.pdf", url_private_download: "https://files.example/report" }],
+        "1.5",
+      );
+
+      expect(attachments).toEqual([
+        { original: "report.pdf", localPath: "C1/attachments/1500_report.pdf" },
+      ]);
+      expect(readFileSync(join(dir, "C1", "attachments", "1500_report.pdf"), "utf-8")).toBe(
+        "file body",
+      );
+      expect(fetchMock).toHaveBeenCalledWith("https://files.example/report", {
+        headers: { Authorization: "Bearer xoxb-test-token" },
+      });
+    });
+
+    test("falls back to url_private and skips files without any URL", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okResponse("x"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const attachments = await store.processAttachments(
+        "C1",
+        [{ name: "a.txt", url_private: "https://files.example/a" }, { name: "no-url.txt" }],
+        "2.0",
+      );
+
+      expect(attachments).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith("https://files.example/a", expect.anything());
+    });
+
+    test("rejects when an attachment has a URL but no name", async () => {
+      vi.stubGlobal("fetch", vi.fn());
+      await expect(
+        store.processAttachments("C1", [{ url_private: "https://files.example/x" }], "3.0"),
+      ).rejects.toThrow(/missing name/);
+    });
+
+    test("does not retry non-retryable HTTP errors", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response("nope", { status: 404, statusText: "Not Found" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        store.processAttachments(
+          "C1",
+          [{ name: "gone.txt", url_private_download: "https://files.example/gone" }],
+          "4.0",
+        ),
+      ).rejects.toThrow(/Failed to download attachment .*HTTP 404/);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("retries server errors up to three attempts", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response("boom", { status: 500, statusText: "Server Error" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        store.processAttachments(
+          "C1",
+          [{ name: "flaky.txt", url_private_download: "https://files.example/flaky" }],
+          "5.0",
+        ),
+      ).rejects.toThrow(/HTTP 500/);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    }, 10_000);
+
+    test("retries network errors and succeeds on a later attempt", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValue(okResponse("recovered"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const attachments = await store.processAttachments(
+        "C1",
+        [{ name: "net.txt", url_private_download: "https://files.example/net" }],
+        "6.0",
+      );
+
+      expect(attachments).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(readFileSync(join(dir, "C1", "attachments", "6000_net.txt"), "utf-8")).toBe(
+        "recovered",
+      );
+    }, 10_000);
+  });
+});

--- a/test/read-tool.test.ts
+++ b/test/read-tool.test.ts
@@ -1,0 +1,145 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { HostExecutor } from "../src/sandbox/host.js";
+import { createReadTool } from "../src/tools/read.js";
+import { DEFAULT_MAX_LINES } from "../src/tools/truncate.js";
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+  const first = result.content[0];
+  if (first.type !== "text" || first.text === undefined) {
+    throw new Error(`Expected text content, got ${first.type}`);
+  }
+  return first.text;
+}
+
+describe("createReadTool", () => {
+  let dir: string;
+  const tool = createReadTool(new HostExecutor());
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `mikan-read-test-${Date.now()}-${Math.random()}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  });
+
+  test("reads a small text file without truncation", async () => {
+    const path = join(dir, "hello.txt");
+    writeFileSync(path, "line one\nline two\n");
+    const result = await tool.execute("1", { label: "read", path });
+    expect(textOf(result)).toContain("line one");
+    expect(textOf(result)).toContain("line two");
+    expect(result.details).toBeUndefined();
+  });
+
+  test("throws for a missing file", async () => {
+    await expect(
+      tool.execute("1", { label: "read", path: join(dir, "nope.txt") }),
+    ).rejects.toThrow();
+  });
+
+  test("reads from a 1-indexed offset", async () => {
+    const path = join(dir, "lines.txt");
+    writeFileSync(path, Array.from({ length: 10 }, (_, i) => `l${i + 1}`).join("\n") + "\n");
+    const result = await tool.execute("1", { label: "read", path, offset: 5 });
+    const text = textOf(result);
+    expect(text.startsWith("l5")).toBe(true);
+    expect(text).toContain("l10");
+    expect(text).not.toContain("l4\n");
+  });
+
+  test("throws when offset is beyond end of file", async () => {
+    const path = join(dir, "short.txt");
+    writeFileSync(path, "a\nb\n");
+    await expect(tool.execute("1", { label: "read", path, offset: 100 })).rejects.toThrow(
+      /beyond end of file/,
+    );
+  });
+
+  test("applies a user limit and points at the next offset", async () => {
+    const path = join(dir, "limited.txt");
+    writeFileSync(path, Array.from({ length: 10 }, (_, i) => `l${i + 1}`).join("\n") + "\n");
+    const result = await tool.execute("1", { label: "read", path, limit: 3 });
+    const text = textOf(result);
+    expect(text).toContain("l3");
+    expect(text).not.toContain("l4");
+    expect(text).toMatch(/more lines in file\. Use offset=4 to continue/);
+  });
+
+  test("omits the continuation notice when the limit covers the whole file", async () => {
+    const path = join(dir, "covered.txt");
+    writeFileSync(path, "a\nb\n");
+    const result = await tool.execute("1", { label: "read", path, limit: 100 });
+    expect(textOf(result)).not.toContain("more lines in file");
+  });
+
+  test("truncates by line count and reports the next offset", async () => {
+    const path = join(dir, "big.txt");
+    const totalLines = DEFAULT_MAX_LINES + 500;
+    writeFileSync(path, Array.from({ length: totalLines }, (_, i) => `line-${i + 1}`).join("\n"));
+    const result = await tool.execute("1", { label: "read", path });
+    const text = textOf(result);
+    expect(text).toContain(`line-${DEFAULT_MAX_LINES}`);
+    expect(text).not.toContain(`line-${DEFAULT_MAX_LINES + 1}\n`);
+    expect(text).toContain(`Use offset=${DEFAULT_MAX_LINES + 1} to continue`);
+    expect(result.details?.truncation?.truncated).toBe(true);
+    expect(result.details?.truncation?.truncatedBy).toBe("lines");
+  });
+
+  test("truncates by byte size for wide files", async () => {
+    const path = join(dir, "wide.txt");
+    // 100 lines x ~1KB stays under the line limit but blows the 50KB byte limit
+    writeFileSync(path, Array.from({ length: 100 }, () => "x".repeat(1024)).join("\n"));
+    const result = await tool.execute("1", { label: "read", path });
+    expect(result.details?.truncation?.truncated).toBe(true);
+    expect(result.details?.truncation?.truncatedBy).toBe("bytes");
+    expect(textOf(result)).toMatch(/limit\)\. Use offset=\d+ to continue/);
+  });
+
+  test("directs the model to bash when a single line exceeds the byte limit", async () => {
+    const path = join(dir, "oneline.txt");
+    writeFileSync(path, "a".repeat(60_000));
+    const result = await tool.execute("1", { label: "read", path });
+    const text = textOf(result);
+    expect(text).toContain("exceeds");
+    expect(text).toContain("sed -n '1p'");
+    expect(result.details?.truncation?.firstLineExceedsLimit).toBe(true);
+  });
+
+  test("returns images as base64 attachments", async () => {
+    const path = join(dir, "pic.png");
+    writeFileSync(path, Buffer.from("fake image bytes"));
+    const result = await tool.execute("1", { label: "read", path });
+    expect(textOf(result)).toContain("image/png");
+    const image = result.content[1];
+    expect(image.type).toBe("image");
+    if (image.type === "image") {
+      expect(image.mimeType).toBe("image/png");
+      expect(Buffer.from(image.data, "base64").toString("utf-8")).toBe("fake image bytes");
+    }
+  });
+
+  test("detects image extensions case-insensitively", async () => {
+    const path = join(dir, "photo.JPEG");
+    writeFileSync(path, Buffer.from("jpeg bytes"));
+    const result = await tool.execute("1", { label: "read", path });
+    expect(textOf(result)).toContain("image/jpeg");
+  });
+
+  test("throws when an image file cannot be read", async () => {
+    await expect(
+      tool.execute("1", { label: "read", path: join(dir, "missing.png") }),
+    ).rejects.toThrow();
+  });
+
+  test("handles paths containing shell metacharacters", async () => {
+    const path = join(dir, "we ird '$(name)'.txt");
+    writeFileSync(path, "safe content\n");
+    const result = await tool.execute("1", { label: "read", path });
+    expect(textOf(result)).toContain("safe content");
+  });
+});

--- a/test/sandbox-utils.test.ts
+++ b/test/sandbox-utils.test.ts
@@ -1,0 +1,106 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { HostExecutor } from "../src/sandbox/host.js";
+import {
+  execReadFile,
+  execSimple,
+  execWriteFile,
+  killProcessTree,
+  shellEscape,
+} from "../src/sandbox/utils.js";
+
+describe("shellEscape", () => {
+  test("wraps plain strings in single quotes", () => {
+    expect(shellEscape("hello")).toBe("'hello'");
+  });
+
+  test("escapes embedded single quotes", () => {
+    expect(shellEscape("it's")).toBe("'it'\\''s'");
+  });
+
+  test("keeps shell metacharacters literal through a real shell", async () => {
+    const tricky = `$(touch /tmp/pwn) \`id\` "; rm -rf ~" 'quoted' \\backslash`;
+    const result = await new HostExecutor().exec(`printf '%s' ${shellEscape(tricky)}`);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe(tricky);
+  });
+});
+
+describe("execSimple", () => {
+  test("resolves with stdout on success", async () => {
+    await expect(execSimple("echo", ["hi"])).resolves.toBe("hi\n");
+  });
+
+  test("rejects with stderr on failure", async () => {
+    await expect(execSimple("sh", ["-c", "echo bad >&2; exit 2"])).rejects.toThrow(/bad/);
+  });
+
+  test("rejects with the exit code when stderr is empty", async () => {
+    await expect(execSimple("sh", ["-c", "exit 7"])).rejects.toThrow(/Exit code 7/);
+  });
+});
+
+describe("killProcessTree", () => {
+  test("kills a detached process group", async () => {
+    const child = spawn("sh", ["-c", "sleep 30"], { detached: true, stdio: "ignore" });
+    const closed = new Promise<string | null>((resolve) => {
+      child.on("close", (_code, signal) => resolve(signal));
+    });
+    killProcessTree(child.pid!);
+    expect(await closed).toBe("SIGKILL");
+  });
+
+  test("ignores already-dead processes", () => {
+    expect(() => killProcessTree(2 ** 30)).not.toThrow();
+  });
+});
+
+describe("execReadFile / execWriteFile", () => {
+  let dir: string;
+  const executor = new HostExecutor();
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `mikan-sbx-utils-${Date.now()}-${Math.random()}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  });
+
+  test("round-trips content with quotes, unicode, and newlines", async () => {
+    const path = join(dir, "nested", "deep", "file.txt");
+    const content = "héllo 🍊 'single' \"double\" $VAR `tick`\nline two\n";
+    await execWriteFile(executor, path, content);
+    await expect(execReadFile(executor, path)).resolves.toBe(content);
+  });
+
+  test("writes empty files", async () => {
+    const path = join(dir, "empty.txt");
+    await execWriteFile(executor, path, "");
+    await expect(execReadFile(executor, path)).resolves.toBe("");
+  });
+
+  test("chunks large content and leaves no staging files behind", async () => {
+    const path = join(dir, "large.bin");
+    // ~150KB of content encodes to >196K base64 chars: several 64K chunks
+    const content = "abcdefghij".repeat(15_000);
+    await execWriteFile(executor, path, content);
+    await expect(execReadFile(executor, path)).resolves.toBe(content);
+    expect(readdirSync(dir)).toEqual(["large.bin"]);
+  });
+
+  test("execReadFile throws for missing files", async () => {
+    await expect(execReadFile(executor, join(dir, "missing.txt"))).rejects.toThrow();
+  });
+
+  test("execWriteFile throws when the destination is unwritable", async () => {
+    writeFileSync(join(dir, "blocker"), "");
+    await expect(
+      execWriteFile(executor, join(dir, "blocker", "child.txt"), "content"),
+    ).rejects.toThrow();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,24 +13,48 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],
-      include: [
-        "src/commands/auto-reply.ts",
-        "src/commands/utils.ts",
-        "src/sessions/metadata.ts",
-        "src/tools/event.ts",
-        "src/tools/truncate.ts",
-        "src/tools/write.ts",
-        "src/utils/date.ts",
-        "src/utils/env.ts",
-        "src/utils/file-guards.ts",
-        "src/utils/fs-atomic.ts",
-        "src/utils/html.ts",
+      include: ["src/**/*.ts"],
+      exclude: [
+        // Starlight docs content, not runtime code
+        "src/content/**",
+        "src/content.config.ts",
+        // Type-only / entrypoint wiring with no unit-testable surface
+        "src/types.ts",
+        "src/main.ts",
+        "src/cli/download.ts",
+        "src/observability/instrument.ts",
+        // Dominated by server-rendered HTML/JS template strings; covered
+        // behavior lives in the sibling service/store modules
+        "src/web/admin/portal.ts",
+        "src/web/session-view/portal.ts",
       ],
       thresholds: {
-        statements: 95,
-        branches: 90,
-        functions: 95,
-        lines: 95,
+        // Global ratchet: set just below current actuals so coverage can only
+        // move up. Raise these as under-tested areas gain tests.
+        statements: 72,
+        branches: 62,
+        functions: 72,
+        lines: 73,
+        // Files that already meet a high bar stay held to it.
+        "src/{commands/auto-reply,commands/utils,sessions/metadata,tools/event,tools/truncate,tools/write}.ts":
+          {
+            statements: 95,
+            branches: 90,
+            functions: 95,
+            lines: 95,
+          },
+        "src/utils/{date,env,file-guards,fs-atomic,html}.ts": {
+          statements: 95,
+          branches: 90,
+          functions: 95,
+          lines: 95,
+        },
+        "src/{store,tools/read,tools/bash,sandbox/utils}.ts": {
+          statements: 90,
+          branches: 75,
+          functions: 90,
+          lines: 90,
+        },
       },
     },
   },


### PR DESCRIPTION
The coverage check previously instrumented only 11 hand-picked files, so
regressions anywhere else in src/ could not fail CI. The gate now covers
src/**/*.ts (minus docs content, type-only/entrypoint wiring, and the two
template-string-dominated web portals) with global thresholds set just
below current actuals as a ratchet, while the previously curated files
keep their 95% bar via per-glob thresholds.

New test suites for the worst-covered runtime code:

- tools/read.ts (5% -> 98% lines): offset/limit windowing, line- and
  byte-truncation notices, oversized single lines, image attachments,
  shell-metacharacter paths
- tools/bash.ts (6% -> 91%): stdout/stderr merging, non-zero exit,
  oversized-output spill into the workspace (and spill failure), line
  truncation, timeout kill
- sandbox/utils.ts (49% -> 95%): shellEscape injection safety through a
  real shell, execSimple, killProcessTree, chunked base64 read/write
  file transport round-trips
- store.ts (0% -> 100%): log.jsonl dedupe (including concurrent and
  failed-append cases), timestamp derivation, last-timestamp parsing,
  attachment downloads with retry classification (404 no-retry, 500
  retried, network errors recovered)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VNRi5aQRBK6BFSMA7b2Mth