### PR TITLE
test: cover events scheduling/delivery, log formatting, disabled vault

### DIFF
--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -4,6 +4,13 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { MessagingBot, ConversationEvent } from "../src/adapter.js";
 import { EventsWatcher } from "../src/events.js";
+import { reportUserFacingError } from "../src/observability/sentry.js";
+
+vi.mock("../src/observability/sentry.js", () => ({
+  reportUserFacingError: vi.fn(),
+}));
+
+const mockReportUserFacingError = vi.mocked(reportUserFacingError);
 
 function makeMessagingBot(platform: string) {
   const enqueueEvent = vi.fn<(event: ConversationEvent) => boolean>().mockReturnValue(true);
@@ -256,5 +263,305 @@ describe("EventsWatcher platform routing", () => {
       ].join("\n"),
       ts: "event:deploy-reminder",
     });
+  });
+});
+
+describe("EventsWatcher scheduling", () => {
+  let tmpDir: string;
+  let eventsDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mikan-events-sched-${Date.now()}-${Math.random()}`);
+    eventsDir = join(tmpDir, "events");
+    mkdirSync(eventsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("deletes a one-shot event scheduled in the past without executing", () => {
+    const { bot, enqueueEvent } = makeMessagingBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+    const filename = "past.json";
+    const filePath = join(eventsDir, filename);
+    writeFileSync(filePath, "{}");
+
+    watcher.handleOneShot(filename, {
+      type: "one-shot",
+      platform: "slack",
+      conversationId: "D1",
+      conversationKind: "direct",
+      text: "too late",
+      at: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    expect(watcher.timers.has(filename)).toBe(false);
+    expect(existsSync(filePath)).toBe(false);
+    expect(enqueueEvent).not.toHaveBeenCalled();
+  });
+
+  test("stores a timer for a one-shot event scheduled in the future", () => {
+    const { bot } = makeMessagingBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+    const filename = "future.json";
+
+    watcher.handleOneShot(filename, {
+      type: "one-shot",
+      platform: "slack",
+      conversationId: "D1",
+      conversationKind: "direct",
+      text: "later",
+      at: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    expect(watcher.timers.has(filename)).toBe(true);
+    watcher.stop();
+    expect(watcher.timers.has(filename)).toBe(false);
+  });
+
+  test("schedules a periodic event and exposes it via getPeriodicEvents", () => {
+    const { bot } = makeMessagingBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+    const filename = "daily.json";
+    writeFileSync(
+      join(eventsDir, filename),
+      JSON.stringify({
+        type: "periodic",
+        platform: "slack",
+        conversationId: "C1",
+        conversationKind: "shared",
+        text: "standup",
+        schedule: "0 9 * * *",
+        timezone: "UTC",
+      }),
+    );
+
+    watcher.handlePeriodic(filename, {
+      type: "periodic",
+      platform: "slack",
+      conversationId: "C1",
+      conversationKind: "shared",
+      text: "standup",
+      schedule: "0 9 * * *",
+      timezone: "UTC",
+    });
+
+    expect(watcher.crons.has(filename)).toBe(true);
+
+    const infos = watcher.getPeriodicEvents();
+    expect(infos).toHaveLength(1);
+    expect(infos[0]).toMatchObject({
+      filename,
+      platform: "slack",
+      conversationId: "C1",
+      schedule: "0 9 * * *",
+      timezone: "UTC",
+    });
+    expect(infos[0].nextRun).toEqual(expect.any(String));
+
+    watcher.stop();
+    expect(watcher.crons.has(filename)).toBe(false);
+  });
+
+  test("deletes a periodic event with an invalid cron schedule", () => {
+    const { bot } = makeMessagingBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+    const filename = "broken.json";
+    const filePath = join(eventsDir, filename);
+    writeFileSync(filePath, "{}");
+
+    watcher.handlePeriodic(filename, {
+      type: "periodic",
+      platform: "slack",
+      conversationId: "C1",
+      conversationKind: "shared",
+      text: "oops",
+      schedule: "not a cron",
+      timezone: "UTC",
+    });
+
+    expect(watcher.crons.has(filename)).toBe(false);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  test("deletes a stale immediate event created before startup", () => {
+    const filename = "stale.json";
+    const filePath = join(eventsDir, filename);
+    // Write the file first so its mtime precedes the watcher's start time.
+    writeFileSync(filePath, "{}");
+
+    const { bot, enqueueEvent } = makeMessagingBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+    watcher.handleImmediate(filename, {
+      type: "immediate",
+      platform: "slack",
+      conversationId: "D1",
+      conversationKind: "direct",
+      text: "old news",
+    });
+
+    expect(existsSync(filePath)).toBe(false);
+    expect(enqueueEvent).not.toHaveBeenCalled();
+  });
+
+  test("executes a fresh immediate event created after startup", () => {
+    const { bot, enqueueEvent } = makeMessagingBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+    // Pin startup before the file's mtime so the event reads as fresh regardless
+    // of filesystem timestamp granularity.
+    watcher.startTime = 0;
+
+    const filename = "fresh.json";
+    const filePath = join(eventsDir, filename);
+    writeFileSync(filePath, "{}");
+
+    watcher.handleImmediate(filename, {
+      type: "immediate",
+      platform: "slack",
+      conversationId: "D1",
+      conversationKind: "direct",
+      text: "breaking",
+    });
+
+    expect(enqueueEvent).toHaveBeenCalledTimes(1);
+    // Immediate events are deleted after a successful enqueue.
+    expect(existsSync(filePath)).toBe(false);
+  });
+});
+
+describe("EventsWatcher delivery failures", () => {
+  let tmpDir: string;
+  let eventsDir: string;
+
+  beforeEach(() => {
+    mockReportUserFacingError.mockClear();
+    tmpDir = join(tmpdir(), `mikan-events-fail-${Date.now()}-${Math.random()}`);
+    eventsDir = join(tmpDir, "events");
+    mkdirSync(eventsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("reports a delivery failure when no bot is configured for the platform", () => {
+    const { bot } = makeMessagingBot("slack");
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+    watcher.execute("orphan.json", {
+      type: "immediate",
+      platform: "discord",
+      conversationId: "C1",
+      conversationKind: "shared",
+      text: "nobody home",
+    });
+
+    expect(mockReportUserFacingError).toHaveBeenCalledTimes(1);
+    const [, options] = mockReportUserFacingError.mock.calls[0];
+    expect(options).toMatchObject({
+      domain: "events",
+      surface: "event_delivery",
+      platform: "discord",
+      context: expect.objectContaining({ failure: "missing_bot", filename: "orphan.json" }),
+    });
+  });
+
+  test("reports a delivery failure when the bot queue is full", () => {
+    const { bot, enqueueEvent } = makeMessagingBot("slack");
+    enqueueEvent.mockReturnValue(false);
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+    const filename = "full.json";
+    const filePath = join(eventsDir, filename);
+    writeFileSync(filePath, "{}");
+
+    watcher.execute(filename, {
+      type: "one-shot",
+      platform: "slack",
+      conversationId: "D1",
+      conversationKind: "direct",
+      text: "dropped",
+      at: new Date().toISOString(),
+    });
+
+    expect(mockReportUserFacingError).toHaveBeenCalledTimes(1);
+    const [, options] = mockReportUserFacingError.mock.calls[0];
+    expect(options.context).toMatchObject({ failure: "queue_full", filename });
+    // One-shot events are removed even when discarded.
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  test("keeps periodic events on disk when the queue is full", () => {
+    const { bot, enqueueEvent } = makeMessagingBot("slack");
+    enqueueEvent.mockReturnValue(false);
+    const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+    const filename = "periodic-full.json";
+    const filePath = join(eventsDir, filename);
+    writeFileSync(filePath, "{}");
+
+    watcher.execute(
+      filename,
+      {
+        type: "periodic",
+        platform: "slack",
+        conversationId: "C1",
+        conversationKind: "shared",
+        text: "recurring",
+        schedule: "0 9 * * *",
+        timezone: "UTC",
+      },
+      false,
+    );
+
+    expect(mockReportUserFacingError).toHaveBeenCalledTimes(1);
+    // Periodic events must survive a transient queue-full so the next tick can retry.
+    expect(existsSync(filePath)).toBe(true);
+  });
+});
+
+describe("EventsWatcher prompt building", () => {
+  const eventsDir = join(tmpdir(), "mikan-events-prompt");
+  const { bot } = makeMessagingBot("slack");
+  const watcher = new EventsWatcher(eventsDir, { slack: bot }) as any;
+
+  test("builds a reminder prompt for one-shot events", () => {
+    const prompt = watcher.buildEventPrompt({
+      type: "one-shot",
+      platform: "slack",
+      conversationId: "D1",
+      conversationKind: "direct",
+      text: "call the dentist",
+      at: new Date().toISOString(),
+    });
+    expect(prompt).toContain("Reminder: call the dentist");
+    expect(prompt).toContain("deliver the following reminder");
+  });
+
+  test("builds a recurring-task prompt with a silent-reply hint for periodic events", () => {
+    const prompt = watcher.buildEventPrompt({
+      type: "periodic",
+      platform: "slack",
+      conversationId: "C1",
+      conversationKind: "shared",
+      text: "post the standup summary",
+      schedule: "0 9 * * *",
+      timezone: "UTC",
+    });
+    expect(prompt).toContain("Task: post the standup summary");
+    expect(prompt).toContain("[SILENT]");
+  });
+
+  test("builds an event prompt for immediate events", () => {
+    const prompt = watcher.buildEventPrompt({
+      type: "immediate",
+      platform: "slack",
+      conversationId: "D1",
+      conversationKind: "direct",
+      text: "deploy finished",
+    });
+    expect(prompt).toContain("Event: deploy finished");
   });
 });

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -1,5 +1,22 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import * as log from "../src/log.js";
+import type { LogContext } from "../src/types.js";
+
+// eslint-disable-next-line no-control-regex
+const ANSI = /\[[0-9;]*m/g;
+
+function captureConsole() {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(
+      args
+        .map((a) => String(a))
+        .join(" ")
+        .replace(ANSI, ""),
+    );
+  });
+  return { lines, spy, output: () => lines.join("\n") };
+}
 
 describe("log functions exist", () => {
   test("all expected log functions are exported", () => {
@@ -15,5 +32,221 @@ describe("log functions exist", () => {
     expect(typeof log.logStartup).toBe("function");
     expect(typeof log.logConnected).toBe("function");
     expect(typeof log.logDisconnected).toBe("function");
+  });
+});
+
+describe("log context formatting", () => {
+  let cap: ReturnType<typeof captureConsole>;
+
+  beforeEach(() => {
+    cap = captureConsole();
+  });
+
+  afterEach(() => {
+    cap.spy.mockRestore();
+  });
+
+  test("formats DM conversations using the user name", () => {
+    const ctx: LogContext = { conversationId: "D123", userName: "alice" };
+    log.logUserMessage(ctx, "hi there");
+    expect(cap.output()).toContain("[DM:alice]");
+    expect(cap.output()).toContain("hi there");
+  });
+
+  test("falls back to the conversation id for DMs without a user name", () => {
+    log.logUserMessage({ conversationId: "D999" }, "anon");
+    expect(cap.output()).toContain("[DM:D999]");
+  });
+
+  test("prefixes channel names with # and includes the session id", () => {
+    const ctx: LogContext = {
+      conversationId: "C1",
+      conversationName: "general",
+      userName: "bob",
+      sessionId: "s7",
+    };
+    log.logUserMessage(ctx, "hello");
+    expect(cap.output()).toContain("[#general:bob:s7]");
+  });
+
+  test("does not double-prefix a conversation name already starting with #", () => {
+    log.logUserMessage({ conversationId: "C1", conversationName: "#ops", userName: "bob" }, "x");
+    expect(cap.output()).toContain("[#ops:bob]");
+    expect(cap.output()).not.toContain("##ops");
+  });
+
+  test("uses 'unknown' for a channel message without a user name", () => {
+    log.logUserMessage({ conversationId: "C1", conversationName: "general" }, "x");
+    expect(cap.output()).toContain("[#general:unknown]");
+  });
+});
+
+describe("log tool + response output", () => {
+  let cap: ReturnType<typeof captureConsole>;
+  const ctx: LogContext = { conversationId: "C1", conversationName: "general", userName: "bob" };
+
+  beforeEach(() => {
+    cap = captureConsole();
+  });
+
+  afterEach(() => {
+    cap.spy.mockRestore();
+  });
+
+  test("logs tool start with a label and indented args", () => {
+    log.logToolStart(ctx, "bash", "run tests", { command: "npm test" });
+    const out = cap.output();
+    expect(out).toContain("↳ bash: run tests");
+    expect(out).toContain("npm test");
+  });
+
+  test("logs tool start without an args block when there are no args", () => {
+    log.logToolStart(ctx, "noop", "nothing", {});
+    expect(cap.lines.length).toBe(1);
+    expect(cap.output()).toContain("↳ noop: nothing");
+  });
+
+  test("logs tool success with a formatted duration", () => {
+    log.logToolSuccess(ctx, "bash", 1500, "ok");
+    const out = cap.output();
+    expect(out).toContain("✓ bash (1.5s)");
+    expect(out).toContain("ok");
+  });
+
+  test("logs tool errors with the error body", () => {
+    log.logToolError(ctx, "bash", 500, "boom");
+    const out = cap.output();
+    expect(out).toContain("✗ bash (0.5s)");
+    expect(out).toContain("boom");
+  });
+
+  test("truncates long previews and notes the cut", () => {
+    log.logToolSuccess(ctx, "read", 100, "x".repeat(2000));
+    expect(cap.output()).toContain("(truncated at 1000 chars)");
+  });
+
+  test("logs thinking and response bodies", () => {
+    log.logThinking(ctx, "pondering");
+    log.logResponse(ctx, "the answer");
+    const out = cap.output();
+    expect(out).toContain("💭 Thinking");
+    expect(out).toContain("pondering");
+    expect(out).toContain("💬 Response");
+    expect(out).toContain("the answer");
+  });
+
+  test("shows the model display name only when it differs from the model id", () => {
+    log.logAgentRunStart(ctx, "anthropic", "claude-x", "Claude X");
+    log.logAgentRunStart(ctx, "anthropic", "claude-y", "claude-y");
+    const [withName, withoutName] = cap.lines;
+    expect(withName).toContain("anthropic/claude-x (Claude X)");
+    expect(withoutName).toContain("anthropic/claude-y");
+    expect(withoutName).not.toContain("(claude-y)");
+  });
+
+  test("routes agent errors for both a context and the system channel", () => {
+    log.logAgentError(ctx, "ctx failure");
+    log.logAgentError("system", "system failure");
+    const out = cap.output();
+    expect(out).toContain("[#general:bob]");
+    expect(out).toContain("[system]");
+    expect(out).toContain("ctx failure");
+    expect(out).toContain("system failure");
+  });
+});
+
+describe("log usage summary", () => {
+  let cap: ReturnType<typeof captureConsole>;
+  const ctx: LogContext = { conversationId: "C1", conversationName: "general", userName: "bob" };
+  const usage = {
+    input: 1200,
+    output: 3400,
+    cacheRead: 800,
+    cacheWrite: 0,
+    cost: { input: 0.01, output: 0.02, cacheRead: 0.005, cacheWrite: 0, total: 0.035 },
+  };
+
+  beforeEach(() => {
+    cap = captureConsole();
+  });
+
+  afterEach(() => {
+    cap.spy.mockRestore();
+  });
+
+  test("returns a markdown summary and computes the cache-hit percentage", () => {
+    const summary = log.logUsageSummary(ctx, usage);
+    expect(summary).toContain("_Usage Summary_");
+    expect(summary).toContain("Input: 1,200 tokens");
+    expect(summary).toContain("Output: 3,400 tokens");
+    // 800 / (1200 + 800 + 0) = 40.0%
+    expect(summary).toContain("CH 40.0%");
+    expect(summary).toContain("= *$0.0350*");
+    expect(summary).not.toContain("Context:");
+  });
+
+  test("reports 0.0% cache hit when there is no cacheable input", () => {
+    const summary = log.logUsageSummary(ctx, {
+      ...usage,
+      input: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+    expect(summary).toContain("CH 0.0%");
+  });
+
+  test("includes a context line with human-friendly token counts when provided", () => {
+    const summary = log.logUsageSummary(ctx, usage, 5_000, 200_000);
+    // formatTokenCount: 5000 (<10k) -> "5.0k", 200000 -> "200k"
+    expect(summary).toContain("Context: 5.0k / 200k (2.5%)");
+  });
+
+  test("formats sub-thousand context counts without a suffix", () => {
+    const summary = log.logUsageSummary(ctx, usage, 500, 1_000_000);
+    // 500 -> "500", 1_000_000 -> "1.0M"
+    expect(summary).toContain("Context: 500 / 1.0M");
+  });
+});
+
+describe("log system + startup messages", () => {
+  let cap: ReturnType<typeof captureConsole>;
+
+  beforeEach(() => {
+    cap = captureConsole();
+  });
+
+  afterEach(() => {
+    cap.spy.mockRestore();
+  });
+
+  test("logInfo and logWarning emit system-tagged lines", () => {
+    log.logInfo("booted");
+    log.logWarning("careful", "extra detail");
+    const out = cap.output();
+    expect(out).toContain("[system] booted");
+    expect(out).toContain("⚠ careful");
+    expect(out).toContain("extra detail");
+  });
+
+  test("logWarning omits the detail block when no details are given", () => {
+    log.logWarning("just a warning");
+    expect(cap.lines.length).toBe(1);
+  });
+
+  test("startup, connect, disconnect and backfill lines render", () => {
+    log.logStartup("/work", "host");
+    log.logConnected("slack");
+    log.logDisconnected();
+    log.logBackfillStart(3);
+    log.logBackfillChannel("general", 42);
+    log.logBackfillComplete(100, 2500);
+    const out = cap.output();
+    expect(out).toContain("Working directory: /work");
+    expect(out).toContain("Sandbox: host");
+    expect(out).toContain("connected to slack");
+    expect(out).toContain("Mikan disconnected.");
+    expect(out).toContain("Backfilling 3 channels");
+    expect(out).toContain("#general: 42 messages");
+    expect(out).toContain("Backfill complete: 100 messages in 2.5s");
   });
 });

--- a/test/vault-disabled.test.ts
+++ b/test/vault-disabled.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { disabledVaultManager } from "../src/vault/disabled.js";
+import type { SandboxConfig } from "../src/sandbox/index.js";
+
+describe("disabledVaultManager", () => {
+  test("reports the vault as disabled and empty", () => {
+    expect(disabledVaultManager.isEnabled()).toBe(false);
+    expect(disabledVaultManager.hasEntry("anyone")).toBe(false);
+    expect(disabledVaultManager.resolve("anyone")).toBeUndefined();
+    expect(disabledVaultManager.list()).toEqual([]);
+    expect(disabledVaultManager.listSharedVaults()).toEqual([]);
+    expect(disabledVaultManager.deleteSharedVault("shared")).toBe(false);
+    expect(disabledVaultManager.copySharedVaultTo("shared", "user")).toEqual({
+      filesCopied: 0,
+      envKeysCopied: 0,
+    });
+  });
+
+  test("returns the base sandbox config unchanged", () => {
+    const baseConfig = { mode: "host" } as unknown as SandboxConfig;
+    expect(disabledVaultManager.getSandboxConfig("user", baseConfig)).toBe(baseConfig);
+  });
+
+  test("fails loudly on write paths so misconfiguration surfaces", () => {
+    expect(() => disabledVaultManager.upsertEnv("user", { API_KEY: "x" })).toThrow(
+      "Vault not configured",
+    );
+    expect(() => disabledVaultManager.upsertFile("user", "creds.json", "{}")).toThrow(
+      "Vault not configured",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,10 +31,10 @@ export default defineConfig({
       thresholds: {
         // Global ratchet: set just below current actuals so coverage can only
         // move up. Raise these as under-tested areas gain tests.
-        statements: 72,
-        branches: 62,
-        functions: 72,
-        lines: 73,
+        statements: 75,
+        branches: 65,
+        functions: 75,
+        lines: 77,
         // Files that already meet a high bar stay held to it.
         "src/{commands/auto-reply,commands/utils,sessions/metadata,tools/event,tools/truncate,tools/write}.ts":
           {
@@ -44,6 +44,12 @@ export default defineConfig({
             lines: 95,
           },
         "src/utils/{date,env,file-guards,fs-atomic,html}.ts": {
+          statements: 95,
+          branches: 90,
+          functions: 95,
+          lines: 95,
+        },
+        "src/log.ts": {
           statements: 95,
           branches: 90,
           functions: 95,


### PR DESCRIPTION
Fill the biggest coverage gaps in three under-tested modules and ratchet
the coverage gate up to match:

- events.ts (41% -> 67% lines): one-shot past/future scheduling, periodic
  cron valid/invalid + getPeriodicEvents, stale/fresh immediate handling,
  and missing-bot / queue-full delivery-failure reporting.
- log.ts (53% -> 100% lines): context formatting branches (DM vs channel,
  session id, # prefixing), truncation, usage summary + token formatting,
  and system/startup/backfill lines.
- vault/disabled.ts (9% -> 100%): inert read paths and fail-loud writes.

Bump global thresholds (72/62/72/73 -> 75/65/75/77) and pin log.ts to the
high-bar tier so the gains cannot regress.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hPXfrcbFyQfVrK1vhk6Wq