### PR TITLE
fix(gondolin): harden dial-home reconnects

### DIFF
--- a/src/content/docs/sandbox/gondolin-remote-worker.md
+++ b/src/content/docs/sandbox/gondolin-remote-worker.md
@@ -53,6 +53,13 @@ abort-by-disconnect semantics are identical in both modes. On every reconnect it
 re-registers with its machine info and the runtimes that survived the gap, and mikan
 logs the join and reconciles placements. mikan enables the gateway with:
 
+The control connection is hardened for NAT and stateful firewalls: the worker sends
+an application heartbeat every 15 seconds, requires a pong within 10 seconds, and
+reconnects a half-open connection with exponential backoff plus jitter. Backoff resets
+after a minute-long healthy session. TCP keepalives provide an independent fallback,
+but application heartbeats are authoritative because some middleboxes silently drop
+idle mappings without closing either endpoint.
+
 ```jsonc
 "sandbox": { "gondolin": { "remote": {
   "imageSelector": "mikan-sandbox:latest",

--- a/src/sandbox/gondolin-gateway.ts
+++ b/src/sandbox/gondolin-gateway.ts
@@ -52,7 +52,14 @@ interface RegisteredWorker {
   lastSeen: number;
   activeRuntimes: number;
   workspaceError?: string;
-  pendingRpc: Map<number, { resolve: (frame: ControlFrame) => void; timer: NodeJS.Timeout }>;
+  pendingRpc: Map<
+    number,
+    {
+      resolve: (frame: ControlFrame) => void;
+      reject: (error: Error) => void;
+      timer: NodeJS.Timeout;
+    }
+  >;
   nextRpcId: number;
 }
 
@@ -210,7 +217,7 @@ class GondolinWorkerGateway {
   stop(): void {
     for (const worker of this.workers.values()) {
       worker.socket.destroy();
-      for (const pending of worker.pendingRpc.values()) clearTimeout(pending.timer);
+      this.rejectPendingRpc(worker, "gateway stopped");
     }
     this.workers.clear();
     for (const pending of this.pendingTunnels.values()) clearTimeout(pending.timer);
@@ -222,6 +229,7 @@ class GondolinWorkerGateway {
   /** Routes one inbound connection by its first frame: control or tunnel. */
   private handleConnection(socket: Socket): void {
     socket.setNoDelay(true);
+    socket.setKeepAlive(true, 30_000);
     let routed = false;
     const authorized = (this.overrides.isAuthorized ?? defaultIsAuthorized)(socket);
     const reader = createControlFrameReader((frame, leftover) => {
@@ -304,10 +312,9 @@ class GondolinWorkerGateway {
     void gondolinFleet.reconcile();
 
     socket.on("close", () => {
+      this.rejectPendingRpc(worker, `worker '${name}' disconnected`);
       const current = this.workers.get(name);
       if (current !== worker) return; // superseded
-      for (const pending of worker.pendingRpc.values()) clearTimeout(pending.timer);
-      worker.pendingRpc.clear();
       log.logWarning(`Gondolin worker disconnected: ${name} (placements fence until lease expiry)`);
       gondolinFleet.detachWorker(name);
       this.workers.delete(name);
@@ -386,6 +393,7 @@ class GondolinWorkerGateway {
       timer.unref?.();
       worker.pendingRpc.set(id, {
         timer,
+        reject,
         resolve: (frame) =>
           resolve({
             status: frame.status ?? 0,
@@ -394,6 +402,14 @@ class GondolinWorkerGateway {
       });
       worker.socket.write(encodeControlFrame({ type: "request", id, method, path, body, headers }));
     });
+  }
+
+  private rejectPendingRpc(worker: RegisteredWorker, reason: string): void {
+    for (const pending of worker.pendingRpc.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new GondolinWorkerUnreachableError(reason));
+    }
+    worker.pendingRpc.clear();
   }
 
   /** Ask the worker to dial back a data connection for one session tunnel. */

--- a/test/gondolin-gateway.test.ts
+++ b/test/gondolin-gateway.test.ts
@@ -58,6 +58,7 @@ class FakeDialhomeWorker extends EventEmitter {
   nextSession = 0;
   execResponse = { stdout: "ok", code: 0 };
   workspaceError?: string;
+  respondToRequests = true;
 
   constructor(
     readonly port: number,
@@ -116,8 +117,10 @@ class FakeDialhomeWorker extends EventEmitter {
         path: frame.path as string,
         body: frame.body,
       });
-      const { status, body } = this.serve(frame);
-      this.control.write(encodeFrame({ type: "response", id: frame.id, status, body }));
+      if (this.respondToRequests) {
+        const { status, body } = this.serve(frame);
+        this.control.write(encodeFrame({ type: "response", id: frame.id, status, body }));
+      }
     } else if (frame.type === "open-tunnel") {
       this.emit("open-tunnel", frame);
       if (this.runtime?.sessionId === frame.sessionId) {
@@ -346,6 +349,24 @@ describe("Gondolin worker gateway", () => {
 
     const again = await gondolinFleet.ensure("c1", SPEC);
     expect(again.workerName).toBe("linux-1");
+  });
+
+  test("disconnect rejects an in-flight RPC instead of leaving it pending", async () => {
+    const worker = await joinWorker("linux-1");
+    worker.respondToRequests = false;
+
+    const pending = gondolinFleet.ensure("c1", SPEC);
+    await vi.waitFor(() => expect(worker.requests.length).toBeGreaterThan(0));
+    worker.close();
+
+    let timeout: NodeJS.Timeout | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => reject(new Error("in-flight RPC remained pending")), 500);
+    });
+    await expect(Promise.race([pending, deadline])).rejects.toThrow(
+      "no gondolin remote worker is reachable",
+    );
+    clearTimeout(timeout);
   });
 
   test("a new registration under the same name supersedes the old connection", async () => {

--- a/worker/cmd/mikan-worker/main.go
+++ b/worker/cmd/mikan-worker/main.go
@@ -296,7 +296,16 @@ func runConnect(args []string) {
 	server := buildDaemon(daemon, logger)
 	client := &dialhome.Client{
 		Dial: func() (net.Conn, error) {
-			return tls.DialWithDialer(&net.Dialer{Timeout: 10 * time.Second}, "tcp", address, tlsConfig)
+			return tls.DialWithDialer(&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 30 * time.Second,
+				KeepAliveConfig: net.KeepAliveConfig{
+					Enable:   true,
+					Idle:     30 * time.Second,
+					Interval: 10 * time.Second,
+					Count:    3,
+				},
+			}, "tcp", address, tlsConfig)
 		},
 		Server:      server,
 		Name:        *name,

--- a/worker/internal/dialhome/dialhome.go
+++ b/worker/internal/dialhome/dialhome.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"runtime"
@@ -117,9 +118,19 @@ type Client struct {
 	Log       *slog.Logger
 
 	PingInterval time.Duration
+	// PongTimeout bounds how long a ping may remain unacknowledged before the
+	// control channel is treated as half-open and reconnected.
+	PongTimeout time.Duration
 	// ReconnectMin/Max bound the exponential backoff between attempts.
 	ReconnectMin time.Duration
 	ReconnectMax time.Duration
+	// ReconnectResetAfter resets accumulated backoff after a session stayed
+	// healthy for this long. ReconnectJitter is the fractional random spread
+	// applied to waits so a gateway restart does not synchronize the fleet.
+	ReconnectResetAfter time.Duration
+	ReconnectJitter     float64
+	// RandomFloat is overridden by tests. Production uses math/rand/v2.
+	RandomFloat func() float64
 
 	// handler is built once: Server.Handler() resets idempotency state.
 	handler http.Handler
@@ -135,11 +146,23 @@ func (c *Client) Run(stop <-chan struct{}) {
 	if c.PingInterval == 0 {
 		c.PingInterval = 15 * time.Second
 	}
+	if c.PongTimeout == 0 {
+		c.PongTimeout = 10 * time.Second
+	}
 	if c.ReconnectMin == 0 {
 		c.ReconnectMin = time.Second
 	}
 	if c.ReconnectMax == 0 {
 		c.ReconnectMax = 30 * time.Second
+	}
+	if c.ReconnectResetAfter == 0 {
+		c.ReconnectResetAfter = time.Minute
+	}
+	if c.ReconnectJitter == 0 {
+		c.ReconnectJitter = 0.2
+	}
+	if c.RandomFloat == nil {
+		c.RandomFloat = rand.Float64
 	}
 	c.handler = c.Server.Handler()
 	backoff := c.ReconnectMin
@@ -149,15 +172,20 @@ func (c *Client) Run(stop <-chan struct{}) {
 			return
 		default:
 		}
+		started := time.Now()
 		err := c.session(stop)
 		if err == nil {
 			return // stop requested during a healthy session
 		}
-		c.Log.Warn("dial-home session ended; reconnecting", "error", err, "backoff", backoff)
+		if time.Since(started) >= c.ReconnectResetAfter {
+			backoff = c.ReconnectMin
+		}
+		delay := jitterDelay(backoff, c.ReconnectJitter, c.RandomFloat())
+		c.Log.Warn("dial-home session ended; reconnecting", "error", err, "backoff", delay)
 		select {
 		case <-stop:
 			return
-		case <-time.After(backoff):
+		case <-time.After(delay):
 		}
 		backoff *= 2
 		if backoff > c.ReconnectMax {
@@ -182,26 +210,55 @@ func (c *Client) session(stop <-chan struct{}) error {
 
 	frames := make(chan Frame)
 	readErr := make(chan error, 1)
+	readerDone := make(chan struct{})
+	defer close(readerDone)
 	go func() {
 		for {
 			frame, err := ReadFrame(conn)
 			if err != nil {
-				readErr <- err
+				select {
+				case readErr <- err:
+				case <-readerDone:
+				}
 				return
 			}
-			frames <- frame
+			select {
+			case frames <- frame:
+			case <-readerDone:
+				return
+			}
 		}
 	}()
 
 	ping := time.NewTicker(c.PingInterval)
 	defer ping.Stop()
+	var pongTimer *time.Timer
+	var pongTimeout <-chan time.Time
+	stopPongTimer := func() {
+		if pongTimer != nil && !pongTimer.Stop() {
+			select {
+			case <-pongTimer.C:
+			default:
+			}
+		}
+		pongTimeout = nil
+	}
+	defer stopPongTimer()
 	for {
 		select {
 		case <-stop:
 			return nil
 		case err := <-readErr:
 			return err
+		case <-pongTimeout:
+			return fmt.Errorf("gateway pong timeout after %s", c.PongTimeout)
 		case <-ping.C:
+			// Only one ping may be outstanding. The timeout owns liveness until
+			// its matching pong arrives, preventing traffic from masking a
+			// one-way or half-open control channel.
+			if pongTimeout != nil {
+				continue
+			}
 			frame := Frame{
 				Type:           "ping",
 				ActiveRuntimes: c.Server.Runtimes.Count(),
@@ -210,6 +267,8 @@ func (c *Client) session(stop <-chan struct{}) error {
 			if err := WriteFrame(writes, frame); err != nil {
 				return err
 			}
+			pongTimer = time.NewTimer(c.PongTimeout)
+			pongTimeout = pongTimer.C
 		case frame := <-frames:
 			switch frame.Type {
 			case "request":
@@ -217,12 +276,23 @@ func (c *Client) session(stop <-chan struct{}) error {
 			case "open-tunnel":
 				go c.dialBackTunnel(frame)
 			case "pong":
-				// host acknowledged; lastSeen is host-side state
+				stopPongTimer()
 			default:
 				c.Log.Warn("unknown control frame", "type", frame.Type)
 			}
 		}
 	}
+}
+
+func jitterDelay(base time.Duration, fraction, randomFloat float64) time.Duration {
+	if fraction <= 0 {
+		return base
+	}
+	if fraction > 1 {
+		fraction = 1
+	}
+	factor := 1 + ((randomFloat * 2) - 1) * fraction
+	return time.Duration(float64(base) * factor)
 }
 
 func (c *Client) registerFrame() Frame {

--- a/worker/internal/dialhome/dialhome.go
+++ b/worker/internal/dialhome/dialhome.go
@@ -291,7 +291,7 @@ func jitterDelay(base time.Duration, fraction, randomFloat float64) time.Duratio
 	if fraction > 1 {
 		fraction = 1
 	}
-	factor := 1 + ((randomFloat * 2) - 1) * fraction
+	factor := 1 + ((randomFloat*2)-1)*fraction
 	return time.Duration(float64(base) * factor)
 }
 

--- a/worker/internal/dialhome/dialhome_test.go
+++ b/worker/internal/dialhome/dialhome_test.go
@@ -256,3 +256,93 @@ func TestReconnectsAndReregisters(t *testing.T) {
 		t.Fatalf("expected re-register, got %+v", register)
 	}
 }
+
+func TestMissingPongReconnectsHalfOpenControlChannel(t *testing.T) {
+	server := newTestServer(t, "/nonexistent.sock")
+	gateway := &fakeGateway{conns: make(chan net.Conn, 8)}
+	client := &Client{
+		Dial:         gateway.dial,
+		Server:       server,
+		Name:         "test-worker",
+		PingInterval: 10 * time.Millisecond,
+		PongTimeout:  15 * time.Millisecond,
+		ReconnectMin: time.Millisecond,
+		ReconnectMax: time.Millisecond,
+	}
+	stop := make(chan struct{})
+	go client.Run(stop)
+	t.Cleanup(func() { close(stop) })
+
+	first := awaitConn(t, gateway)
+	if _, err := ReadFrame(first); err != nil { // register
+		t.Fatal(err)
+	}
+	ping, err := ReadFrame(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ping.Type != "ping" {
+		t.Fatalf("expected ping, got %+v", ping)
+	}
+
+	second := awaitConn(t, gateway)
+	register, err := ReadFrame(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if register.Type != "register" {
+		t.Fatalf("expected re-register after pong timeout, got %+v", register)
+	}
+}
+
+func TestPongKeepsControlChannelAlive(t *testing.T) {
+	server := newTestServer(t, "/nonexistent.sock")
+	gateway := &fakeGateway{conns: make(chan net.Conn, 8)}
+	client := &Client{
+		Dial:         gateway.dial,
+		Server:       server,
+		Name:         "test-worker",
+		PingInterval: 10 * time.Millisecond,
+		PongTimeout:  30 * time.Millisecond,
+		ReconnectMin: time.Millisecond,
+		ReconnectMax: time.Millisecond,
+	}
+	stop := make(chan struct{})
+	go client.Run(stop)
+	t.Cleanup(func() { close(stop) })
+
+	control := awaitConn(t, gateway)
+	if _, err := ReadFrame(control); err != nil { // register
+		t.Fatal(err)
+	}
+	for range 3 {
+		ping, err := ReadFrame(control)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ping.Type != "ping" {
+			t.Fatalf("expected ping, got %+v", ping)
+		}
+		if err := WriteFrame(control, Frame{Type: "pong"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	select {
+	case <-gateway.conns:
+		t.Fatal("client reconnected despite acknowledged pings")
+	case <-time.After(15 * time.Millisecond):
+	}
+}
+
+func TestJitterDelay(t *testing.T) {
+	base := 10 * time.Second
+	if got := jitterDelay(base, 0.2, 0); got != 8*time.Second {
+		t.Fatalf("low jitter = %s", got)
+	}
+	if got := jitterDelay(base, 0.2, 0.5); got != base {
+		t.Fatalf("mid jitter = %s", got)
+	}
+	if got := jitterDelay(base, 0.2, 1); got != 12*time.Second {
+		t.Fatalf("high jitter = %s", got)
+	}
+}


### PR DESCRIPTION
## What changed

- require each worker heartbeat to receive a pong within 10 seconds, reconnecting half-open control channels
- add exponential reconnect backoff with ±20% jitter and reset it after a minute-long healthy session
- enable TCP keepalives on both worker and gateway sockets as a secondary liveness signal
- reject in-flight gateway RPCs immediately when a worker disconnects or is superseded, instead of leaving promises pending
- document the NAT/stateful-firewall behavior and add regression coverage

## Why

Dial-home workers may sit behind NAT or stateful firewalls that silently discard idle mappings without sending FIN/RST. The previous worker sent pings but never required a pong, so a one-way or half-open channel could remain falsely healthy. Gateway disconnect cleanup also cleared RPC timers without rejecting their promises, which could hang an active session indefinitely.

## Impact

Workers now recover automatically from silent connection loss, avoid synchronized reconnect storms after a gateway outage, and fail active RPCs promptly so normal fleet retry/fencing behavior can take over.

## Validation

- `npm test` — 101 files, 1,200 tests passed
- `npm run fmt:check`
- `npm run lint` — passed with three pre-existing warnings
- `npm run build`
- `git diff --check`

Go tests were added for pong timeout, acknowledged heartbeat stability, and jitter bounds. They were not executed locally because the available implementation environment did not include the Go toolchain; CI should run them.