### PR TITLE
feat(subagent): share limits and normalize parent context

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1117,6 +1117,7 @@ async function createConfiguredAgentSession(params: {
   // Host-only dirs under the state dir: extension code runs in the mikan
   // process, so it must never load from workspace paths — those are mounted
   // into sandbox containers and agent-writable (sandbox escape otherwise).
+  let session: MikanAgentSession | undefined;
   const extensionsResult = await loadExtensions({
     dirs: defaultExtensionDirs(conversationId, effectiveStateDir()),
     context: { conversationId, workspaceDir, model, thinkingLevel },
@@ -1126,15 +1127,24 @@ async function createConfiguredAgentSession(params: {
       platformNotifier,
       platformReactor,
       platformUploader,
-      runSubagentService: (request, extensionTools) =>
-        runSubagent({
+      runSubagentService: (request, extensionTools) => {
+        const activeParent = session?.isActiveRun ? session : undefined;
+        return runSubagent({
           request,
           defaultModel: model,
           thinkingLevel,
           models,
           workspaceDir,
           availableTools: [...tools, ...extensionTools],
-        }),
+          slots: globalSubagentSlots,
+          ...(activeParent
+            ? {
+                parentMessages: [...activeParent.messages],
+                onUsage: (usage) => activeParent.foldExternalUsage(usage),
+              }
+            : {}),
+        });
+      },
     }),
   });
   const contributedTools = extensionsResult.registry.getContributedTools();
@@ -1147,24 +1157,21 @@ async function createConfiguredAgentSession(params: {
     );
   }
 
-  const subagentTool = createSubagentTool(
-    (request) =>
-      runSubagent({
-        request,
-        defaultModel: model,
-        thinkingLevel,
-        models,
-        workspaceDir,
-        availableTools: [...tools, ...contributedTools],
-        // `session` is the const below: the tool only executes inside that
-        // session's own prompt loop, and the temporal dead zone turns any
-        // earlier call into a loud error instead of a silently dropped fold.
-        onUsage: (usage) => session.foldExternalUsage(usage),
-      }),
-    globalSubagentSlots,
+  const subagentTool = createSubagentTool((request) =>
+    runSubagent({
+      request,
+      defaultModel: model,
+      thinkingLevel,
+      models,
+      workspaceDir,
+      availableTools: [...tools, ...contributedTools],
+      slots: globalSubagentSlots,
+      parentMessages: [...session!.messages],
+      onUsage: (usage) => session!.foldExternalUsage(usage),
+    }),
   );
 
-  const session = new MikanAgentSession({
+  session = new MikanAgentSession({
     systemPrompt,
     model,
     thinkingLevel,
@@ -1174,12 +1181,13 @@ async function createConfiguredAgentSession(params: {
     extensions: extensionsResult.registry,
   });
 
-  const reloaded = session.reloadFromSession();
+  const activeSession = session;
+  const reloaded = activeSession.reloadFromSession();
   if (reloaded > 0) {
     log.logInfo(`[${conversationId}] Reloaded ${reloaded} messages from session context`);
   }
   return {
-    session,
+    session: activeSession,
     extensionSkills: extensionsResult.skills,
     extensionRegistry: extensionsResult.registry,
     disposeExtensions: extensionsResult.dispose,

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -96,11 +96,13 @@ export type {
 } from "./extensions/types.js";
 export {
   type SubagentModelSpec,
+  type SubagentParentContext,
   type SubagentRunBudget,
   type SubagentRunOutput,
   type SubagentRunRequest,
   type SubagentRunResult,
   type SubagentRunStatus,
+  type SubagentUsage,
   CURRENT_SESSION_VERSION,
   type BranchSummaryEntry,
   type CompactionEntry,

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -141,6 +141,7 @@ export class MikanAgentSession {
   private overflowRecoveryAttempted = false;
   private retryAbortController: AbortController | undefined;
   private compactionAbortController: AbortController | undefined;
+  private runActive = false;
   private tally: RunTally = { tokens: 0, costUsd: 0, llmCalls: 0, startedAt: 0 };
   private runBudget: BudgetSettings = {};
   private budgetExceededReason: string | undefined;
@@ -203,6 +204,11 @@ export class MikanAgentSession {
     return this.agent.state.model;
   }
 
+  /** Whether this session currently owns a prompt, including pre-model hooks. */
+  get isActiveRun(): boolean {
+    return this.runActive;
+  }
+
   /** Resource totals and terminal budget state from the most recent prompt. */
   getLastRunStats(): Readonly<{
     tokens: number;
@@ -231,7 +237,7 @@ export class MikanAgentSession {
   async foldExternalUsage(usage: { tokens?: number; costUsd?: number }): Promise<void> {
     this.tally.tokens += usage.tokens ?? 0;
     this.tally.costUsd += usage.costUsd ?? 0;
-    if (this.budgetExceededReason || !this.agent.state.isStreaming) return;
+    if (this.budgetExceededReason || !this.runActive) return;
     const reason = this.resourceOverBudgetReason();
     if (reason) await this.exceedBudget(reason);
   }
@@ -266,10 +272,21 @@ export class MikanAgentSession {
     text: string,
     options?: { images?: ImageContent[]; budget?: BudgetSettings; origin?: RunOrigin },
   ): Promise<PromptBlockedOutcome | undefined> {
-    if (this.agent.state.isStreaming) {
+    if (this.runActive) {
       throw new Error("Agent is already processing a prompt");
     }
+    this.runActive = true;
+    try {
+      return await this.runPrompt(text, options);
+    } finally {
+      this.runActive = false;
+    }
+  }
 
+  private async runPrompt(
+    text: string,
+    options?: { images?: ImageContent[]; budget?: BudgetSettings; origin?: RunOrigin },
+  ): Promise<PromptBlockedOutcome | undefined> {
     const model = this.agent.state.model;
     await this.ensureAuthConfigured(model);
 

--- a/src/harness/subagent-runner.ts
+++ b/src/harness/subagent-runner.ts
@@ -13,7 +13,9 @@ import type {
   SubagentRunOutput,
   SubagentRunRequest,
   SubagentRunResult,
+  SubagentUsage,
 } from "./types.js";
+import { unboundedSlotPool, type SubagentSlotPool } from "../tools/subagent-slots.js";
 
 const subagentRunDepth = new AsyncLocalStorage<number>();
 const DEFAULT_SYSTEM_PROMPT =
@@ -132,14 +134,12 @@ interface RunSubagentOptions<TOutputSchema extends TSchema | undefined = undefin
   models: MikanModels;
   workspaceDir: string;
   availableTools: AgentTool[];
-  /**
-   * The one seam through which a run's spend reaches its initiator (e.g. the
-   * parent session's budget). Called exactly once per run with the final
-   * totals — on every terminal path, including never-reject failures —
-   * before the result is returned. Errors thrown here are logged and
-   * swallowed to preserve the never-reject contract.
-   */
-  onUsage?: (usage: { tokens: number; costUsd: number }) => void | Promise<void>;
+  /** Process-wide launch pool shared by tool and extension invocations. */
+  slots?: SubagentSlotPool;
+  /** Host-snapshotted parent transcript; never sourced from the public request. */
+  parentMessages?: AgentMessage[];
+  /** Usage attribution snapshotted when this invocation begins. */
+  onUsage?: (usage: SubagentUsage) => void | Promise<void>;
 }
 
 function resolveBudget(budget: RunSubagentOptions["request"]["budget"]) {
@@ -175,23 +175,79 @@ function selectTools(requested: string[] | undefined, available: AgentTool[]): A
   return selected;
 }
 
-function formatTask(task: string, input: unknown): string {
+function formatTask(task: string, input: unknown, parentContext?: string): string {
   const trimmed = task.trim();
   if (!trimmed) throw new Error("api.subagent.run requires a non-empty task");
-  if (input === undefined) return trimmed;
-  let serialized: string | undefined;
-  try {
-    serialized = JSON.stringify(input, null, 2);
-  } catch (err) {
-    throw new Error(
-      `api.subagent.run input must be JSON-serializable: ${err instanceof Error ? err.message : String(err)}`,
-      { cause: err },
-    );
+  let formatted = trimmed;
+  if (input !== undefined) {
+    let serialized: string | undefined;
+    try {
+      serialized = JSON.stringify(input, null, 2);
+    } catch (err) {
+      throw new Error(
+        `api.subagent.run input must be JSON-serializable: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+    if (serialized === undefined)
+      throw new Error("api.subagent.run input must be JSON-serializable");
+    formatted = `${trimmed}\n\nInput:\n${serialized}`;
   }
-  if (serialized === undefined) {
-    throw new Error("api.subagent.run input must be JSON-serializable");
+  return parentContext ? `${parentContext}\n\n${formatted}` : formatted;
+}
+
+function messageText(message: AgentMessage): string {
+  if (message.role === "compactionSummary" || message.role === "branchSummary") {
+    return message.summary;
   }
-  return `${trimmed}\n\nInput:\n${serialized}`;
+  if (!("content" in message)) return "";
+  if (typeof message.content === "string") return message.content;
+  if (!Array.isArray(message.content)) return "";
+  return message.content
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        typeof part === "object" && part !== null && part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("");
+}
+
+function normalizedParentContext(
+  request: SubagentRunRequest<TSchema | undefined>,
+  messages: AgentMessage[] | undefined,
+): string | undefined {
+  if (!request.parentContext || !messages) return undefined;
+  const recentTurns = request.parentContext.recentTurns ?? 3;
+  if (!Number.isInteger(recentTurns) || recentTurns < 1 || recentTurns > 8) {
+    throw new Error("api.subagent.run parentContext.recentTurns must be an integer from 1 to 8");
+  }
+  const conversation = messages.filter(
+    (message) => (message.role === "user" || message.role === "assistant") && messageText(message),
+  );
+  let first = conversation.length;
+  let users = 0;
+  while (first > 0 && users < recentTurns) {
+    first -= 1;
+    if (conversation[first].role === "user") users += 1;
+  }
+  const recent = conversation.slice(first);
+  const recentStart = recent[0] ? messages.indexOf(recent[0]) : messages.length;
+  let summary: AgentMessage | undefined;
+  for (let index = recentStart - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role === "compactionSummary" || message.role === "branchSummary") {
+      summary = message;
+      break;
+    }
+  }
+  return [
+    "<parent_reference_context>",
+    summary ? `Earlier summary: ${messageText(summary)}` : "[Earlier parent context omitted]",
+    ...recent.map(
+      (message) => `${message.role === "user" ? "User" : "Assistant"}: ${messageText(message)}`,
+    ),
+    "</parent_reference_context>",
+  ].join("\n");
 }
 
 function buildSystemPrompt(base: string | undefined, outputSchema: TSchema | undefined): string {
@@ -231,13 +287,44 @@ function assistantText(message: AssistantMessage | undefined): string {
 export async function runSubagent<TOutputSchema extends TSchema | undefined = undefined>(
   options: RunSubagentOptions<TOutputSchema>,
 ): Promise<SubagentRunResult<SubagentRunOutput<TOutputSchema>>> {
-  const result = await executeSubagentRun(options);
+  const result = await executeBoundedSubagentRun(options);
   try {
     await options.onUsage?.({ tokens: result.tokens, costUsd: result.costUsd });
   } catch (err) {
     log.logWarning("Subagent onUsage listener failed", String(err));
   }
   return result;
+}
+
+async function executeBoundedSubagentRun<TOutputSchema extends TSchema | undefined = undefined>(
+  options: RunSubagentOptions<TOutputSchema>,
+): Promise<SubagentRunResult<SubagentRunOutput<TOutputSchema>>> {
+  const startedAt = Date.now();
+  let release: (() => void) | undefined;
+  try {
+    release = await (options.slots ?? unboundedSlotPool()).acquire(options.request.signal);
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return {
+        runId: randomUUID(),
+        status: "cancelled",
+        model: options.request.model ?? {
+          provider: options.defaultModel.provider,
+          id: options.defaultModel.id,
+        },
+        turns: 0,
+        tokens: 0,
+        costUsd: 0,
+        durationMs: Date.now() - startedAt,
+      };
+    }
+    throw err;
+  }
+  try {
+    return await executeSubagentRun(options);
+  } finally {
+    release();
+  }
 }
 
 async function executeSubagentRun<TOutputSchema extends TSchema | undefined = undefined>(
@@ -269,7 +356,11 @@ async function executeSubagentRun<TOutputSchema extends TSchema | undefined = un
       : options.defaultModel;
     modelSpec = { provider: model.provider, id: model.id };
     const tools = selectTools(request.tools, options.availableTools);
-    const task = formatTask(request.task, request.input);
+    const task = formatTask(
+      request.task,
+      request.input,
+      normalizedParentContext(request, options.parentMessages),
+    );
     const budget = resolveBudget(request.budget);
     const session = new MikanAgentSession({
       systemPrompt: buildSystemPrompt(request.systemPrompt, request.outputSchema),

--- a/src/harness/types.ts
+++ b/src/harness/types.ts
@@ -59,9 +59,22 @@ export type SubagentRunStatus =
   | "budget_exceeded"
   | "invalid_output";
 
+export interface SubagentParentContext {
+  mode: "normalized";
+  /** Number of recent user/assistant turns to include. Defaults to 3. */
+  recentTurns?: number;
+}
+
+export interface SubagentUsage {
+  tokens: number;
+  costUsd: number;
+}
+
 /** A fresh, isolated subagent run. */
 export interface SubagentRunRequest<TOutputSchema extends TSchema | undefined = undefined> {
   task: string;
+  /** Opt in to a normalized textual snapshot of the active parent run. Defaults to fresh. */
+  parentContext?: SubagentParentContext;
   systemPrompt?: string;
   /** JSON-serializable input appended to the task. */
   input?: unknown;

--- a/src/tools/subagent-slots.ts
+++ b/src/tools/subagent-slots.ts
@@ -3,9 +3,13 @@
  * serialize agent runs, and each run's subagent tool bounds its own fan-out
  * — but without a shared ceiling, N busy conversations hold N × per-run-cap
  * live subagent sessions. Every subagent launch draws a slot from one shared
- * pool; the per-run cap and this global ceiling are the two bounds, both
- * enforced at the same seam (the tool's slot acquisition).
+ * pool; the per-run cap and this global ceiling are the two bounds, enforced
+ * where each concrete subagent session is launched.
  */
+
+function abortError(): Error {
+  return new DOMException("The operation was aborted", "AbortError");
+}
 
 /** Default process-wide ceiling on concurrently live subagent sessions. */
 export const DEFAULT_GLOBAL_SUBAGENT_SLOTS = 8;
@@ -13,7 +17,11 @@ export const DEFAULT_GLOBAL_SUBAGENT_SLOTS = 8;
 /** Async slot pool: at most `capacity` concurrent holders, FIFO waiters. */
 export class SubagentSlotPool {
   private held = 0;
-  private waiters: Array<() => void> = [];
+  private waiters: Array<{
+    resolve: (release: () => void) => void;
+    signal?: AbortSignal;
+    onAbort?: () => void;
+  }> = [];
 
   constructor(readonly capacity: number) {
     if (!(capacity >= 1)) {
@@ -30,16 +38,23 @@ export class SubagentSlotPool {
    * Resolve with a release function once a slot frees up. Call the release
    * exactly once; releasing hands the slot to the oldest waiter.
    */
-  async acquire(): Promise<() => void> {
+  async acquire(signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) throw abortError();
     if (this.held < this.capacity) {
       this.held += 1;
       return this.releaser();
     }
-    await new Promise<void>((resolve) => {
-      this.waiters.push(resolve);
+    return new Promise<() => void>((resolve, reject) => {
+      const waiter: (typeof this.waiters)[number] = { resolve, signal };
+      waiter.onAbort = () => {
+        const index = this.waiters.indexOf(waiter);
+        if (index < 0) return;
+        this.waiters.splice(index, 1);
+        reject(abortError());
+      };
+      signal?.addEventListener("abort", waiter.onAbort, { once: true });
+      this.waiters.push(waiter);
     });
-    this.held += 1;
-    return this.releaser();
   }
 
   private releaser(): () => void {
@@ -47,9 +62,13 @@ export class SubagentSlotPool {
     return () => {
       if (released) return;
       released = true;
-      this.held -= 1;
       const next = this.waiters.shift();
-      if (next) next();
+      if (next) {
+        next.signal?.removeEventListener("abort", next.onAbort!);
+        next.resolve(this.releaser());
+        return;
+      }
+      this.held -= 1;
     };
   }
 }

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -6,7 +6,6 @@ import type {
   SubagentRunResult,
   SubagentRunStatus,
 } from "../harness/types.js";
-import { unboundedSlotPool, type SubagentSlotPool } from "./subagent-slots.js";
 
 const MAX_DAG_NODES = 8;
 const MAX_DAG_EDGES = 16;
@@ -28,6 +27,12 @@ const taskProperties = {
 };
 
 const sharedProperties = {
+  parentContext: Type.Optional(
+    Type.Object({
+      mode: Type.Literal("normalized"),
+      recentTurns: Type.Optional(Type.Integer({ minimum: 1, maximum: 8, default: 3 })),
+    }),
+  ),
   model: Type.Optional(Type.Object({ provider: Type.String(), id: Type.String() })),
   tools: Type.Optional(
     Type.Array(Type.String(), {
@@ -88,7 +93,10 @@ const subagentSchema = Type.Union([
 type SubagentParams = Static<typeof subagentSchema>;
 type SubagentTask = Static<typeof subagentTaskSchema>;
 type DagNode = Static<typeof dagNodeSchema>;
-type SharedParams = Pick<SubagentParams, "model" | "tools" | "outputSchema" | "budget">;
+type SharedParams = Pick<
+  SubagentParams,
+  "parentContext" | "model" | "tools" | "outputSchema" | "budget"
+>;
 type RunSubagent = <TOutputSchema extends TSchema | undefined = undefined>(
   request: SubagentRunRequest<TOutputSchema>,
 ) => Promise<SubagentRunResult<SubagentRunOutput<TOutputSchema>>>;
@@ -197,6 +205,7 @@ function buildRequest(
     task: task.task,
     ...(task.systemPrompt ? { systemPrompt: task.systemPrompt } : {}),
     ...(task.input !== undefined ? { input: task.input } : {}),
+    ...(shared.parentContext ? { parentContext: shared.parentContext } : {}),
     ...(shared.model ? { model: shared.model } : {}),
     ...(shared.tools ? { tools: shared.tools } : {}),
     ...(outputSchema ? { outputSchema } : {}),
@@ -335,16 +344,14 @@ function planRequest(
 }
 
 /**
- * One executor for every mode: wave barriers, a bounded slot pool inside
- * each wave, and one global slot per actual subagent launch — the seam where
- * both the per-run cap and the process-wide ceiling are enforced.
+ * One executor for every mode: wave barriers and a per-invocation concurrency
+ * bound. Process-wide slots are acquired by the shared runner seam.
  */
 async function runWaves(
   plan: Plan,
   shared: SharedParams,
   runSubagent: RunSubagent,
   progress: SubagentProgressTracker,
-  globalSlots: SubagentSlotPool,
   signal?: AbortSignal,
 ): Promise<PlanOutcome[]> {
   const outcomes = new Map<string, PlanOutcome>();
@@ -362,14 +369,9 @@ async function runWaves(
         progress.update(item.id, "skipped");
         return;
       }
-      const release = await globalSlots.acquire();
       let result: SubagentRunResult<unknown>;
-      try {
-        progress.update(item.id, "running");
-        result = await runSubagent(planRequest(item, shared, outcomes, signal));
-      } finally {
-        release();
-      }
+      progress.update(item.id, "running");
+      result = await runSubagent(planRequest(item, shared, outcomes, signal));
       outcomes.set(item.id, { id: item.id, ...result });
       progress.update(item.id, result.status);
     });
@@ -382,16 +384,13 @@ async function runWaves(
  * `globalSlots` is the process-wide fan-out account shared across every
  * conversation's tool instance; omitted, fan-out is bounded per run only.
  */
-export function createSubagentTool(
-  runSubagent: RunSubagent,
-  globalSlots: SubagentSlotPool = unboundedSlotPool(),
-): AgentTool<typeof subagentSchema> {
+export function createSubagentTool(runSubagent: RunSubagent): AgentTool<typeof subagentSchema> {
   return {
     name: "subagent",
     label: "Subagent",
     description:
       `Run fresh isolated subagents. Use task for one subagent, tasks for independent concurrent work, or dag.nodes for a bounded dependency graph. At most ${MAX_CONCURRENT_SUBAGENTS} subagents run concurrently. DAG limits: ${MAX_DAG_NODES} nodes, ${MAX_DAG_EDGES} edges, depth ${MAX_DAG_DEPTH}; failed dependencies skip descendants, and dependency outputs larger than ${MAX_DEPENDENCY_OUTPUT_CHARS} characters reach downstream nodes as a truncated string. ` +
-      "Subagents have no history or tools unless explicitly provided; nested subagents are not allowed.",
+      "Subagents are fresh by default; parentContext.mode=normalized can include a sanitized reference snapshot of the active parent run. They have no tools unless explicitly provided; nested subagents are not allowed.",
     parameters: subagentSchema,
     execute: async (
       _toolCallId: string,
@@ -406,7 +405,7 @@ export function createSubagentTool(
         onUpdate,
       );
       progress.emit();
-      const ordered = await runWaves(plan, params, runSubagent, progress, globalSlots, signal);
+      const ordered = await runWaves(plan, params, runSubagent, progress, signal);
 
       switch (plan.mode) {
         case "dag":

--- a/test/harness-runner.test.ts
+++ b/test/harness-runner.test.ts
@@ -390,6 +390,7 @@ describe("MikanAgentSession", () => {
       description: "Simulate a subagent run folding its spend into the parent",
       parameters: { type: "object", properties: {} },
       execute: async () => {
+        expect(session.isActiveRun).toBe(true);
         await session.foldExternalUsage({ tokens: 5000, costUsd: 1.25 });
         return { content: [{ type: "text", text: "delegated" }] };
       },
@@ -410,6 +411,7 @@ describe("MikanAgentSession", () => {
 
     await session.prompt("delegate work", { budget: { maxCostUsd: 1 } });
 
+    expect(session.isActiveRun).toBe(false);
     const stats = session.getLastRunStats();
     expect(stats.tokens).toBeGreaterThanOrEqual(5000);
     expect(stats.costUsd).toBeGreaterThanOrEqual(1.25);

--- a/test/subagent-runner.test.ts
+++ b/test/subagent-runner.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 import {
   fauxAssistantMessage,
   fauxProvider,
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { runSubagent } from "../src/harness/subagent-runner.js";
 import { MikanAgentSession, MikanModels, SessionStore } from "../src/harness/index.js";
 import { createSubagentTool } from "../src/tools/subagent.js";
+import { SubagentSlotPool } from "../src/tools/subagent-slots.js";
 
 let dir: string;
 
@@ -84,6 +85,147 @@ describe("runSubagent", () => {
     const persisted = JSON.stringify(sessionStore.getEntries());
     expect(persisted).toContain("delegated result");
     expect(persisted).toContain("parent complete");
+  });
+
+  test("returns cancelled while queued without making a model call", async () => {
+    const { models, faux, model } = createFauxSetup();
+    const slots = new SubagentSlotPool(1);
+    const release = await slots.acquire();
+    const controller = new AbortController();
+    const pending = runSubagent({
+      request: { task: "Never launch", signal: controller.signal },
+      defaultModel: model,
+      thinkingLevel: "off",
+      models,
+      workspaceDir: dir,
+      availableTools: [],
+      slots,
+    });
+    controller.abort();
+    const result = await pending;
+    release();
+    expect(result.status).toBe("cancelled");
+    expect(faux.state.callCount).toBe(0);
+    expect(slots.inFlight).toBe(0);
+  });
+
+  test("defaults to fresh context and validates normalized recentTurns", async () => {
+    const { models, faux, model } = createFauxSetup();
+    faux.setResponses([fauxAssistantMessage("fresh")]);
+    const parentMessages: AgentMessage[] = [
+      { role: "user", content: [{ type: "text", text: "parent secret" }], timestamp: 1 },
+    ];
+    await runSubagent({
+      request: { task: "Fresh task" },
+      defaultModel: model,
+      thinkingLevel: "off",
+      models,
+      workspaceDir: dir,
+      availableTools: [],
+      parentMessages,
+    });
+    expect(faux.state.callCount).toBe(1);
+
+    const invalid = await runSubagent({
+      request: { task: "Invalid", parentContext: { mode: "normalized", recentTurns: 9 } },
+      defaultModel: model,
+      thinkingLevel: "off",
+      models,
+      workspaceDir: dir,
+      availableTools: [],
+      parentMessages,
+    });
+    expect(invalid).toMatchObject({ status: "failed", error: expect.stringContaining("1 to 8") });
+    expect(faux.state.callCount).toBe(1);
+  });
+
+  test("normalizes textual parent turns, reuses summary, and excludes noise", async () => {
+    const { models, faux, model } = createFauxSetup();
+    let prompt = "";
+    faux.setResponses([
+      (context) => {
+        prompt = JSON.stringify(context.messages);
+        return fauxAssistantMessage("normalized");
+      },
+    ]);
+    const parentMessages = [
+      { role: "compactionSummary", summary: "existing summary", timestamp: 1 },
+      { role: "user", content: [{ type: "text", text: "old turn" }], timestamp: 2 },
+      { role: "assistant", content: [{ type: "text", text: "old answer" }], timestamp: 3 },
+      { role: "user", content: [{ type: "text", text: "recent turn" }], timestamp: 4 },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "private reasoning" },
+          { type: "text", text: "recent answer" },
+          { type: "toolCall", id: "x", name: "echo", arguments: { secret: true } },
+        ],
+        api: "faux",
+        provider: "faux",
+        model: model.id,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 5,
+      },
+    ] as AgentMessage[];
+    const result = await runSubagent({
+      request: { task: "Use context", parentContext: { mode: "normalized", recentTurns: 1 } },
+      defaultModel: model,
+      thinkingLevel: "off",
+      models,
+      workspaceDir: dir,
+      availableTools: [],
+      parentMessages,
+    });
+    expect(result.status).toBe("completed");
+    expect(prompt).toContain("existing summary");
+    expect(prompt).toContain("recent turn");
+    expect(prompt).toContain("recent answer");
+    expect(prompt).not.toContain("old turn");
+    expect(prompt).not.toContain("private reasoning");
+    expect(prompt).not.toContain("secret");
+    expect(faux.state.callCount).toBe(1);
+  });
+
+  test("uses omitted marker without a summary and falls back to fresh without a parent", async () => {
+    const { models, faux, model } = createFauxSetup();
+    const prompts: string[] = [];
+    faux.setResponses([
+      (context) => {
+        prompts.push(JSON.stringify(context.messages));
+        return fauxAssistantMessage("one");
+      },
+      (context) => {
+        prompts.push(JSON.stringify(context.messages));
+        return fauxAssistantMessage("two");
+      },
+    ]);
+    const common = {
+      defaultModel: model,
+      thinkingLevel: "off" as const,
+      models,
+      workspaceDir: dir,
+      availableTools: [],
+    };
+    await runSubagent({
+      ...common,
+      request: { task: "With parent", parentContext: { mode: "normalized" } },
+      parentMessages: [{ role: "user", content: [{ type: "text", text: "parent" }], timestamp: 1 }],
+    });
+    await runSubagent({
+      ...common,
+      request: { task: "No parent", parentContext: { mode: "normalized" } },
+    });
+    expect(prompts[0]).toContain("Earlier parent context omitted");
+    expect(prompts[1]).not.toContain("parent_reference_context");
+    expect(faux.state.callCount).toBe(2);
   });
 
   test("runs with fresh context and returns final text plus usage", async () => {

--- a/test/subagent-tool.test.ts
+++ b/test/subagent-tool.test.ts
@@ -27,6 +27,78 @@ function completedRun(output: unknown): RunSubagent {
 }
 
 describe("subagent tool", () => {
+  test("supports abortable FIFO slot handoff and idempotent release", async () => {
+    const pool = new SubagentSlotPool(1);
+    const first = await pool.acquire();
+    const aborted = new AbortController();
+    aborted.abort();
+    await expect(pool.acquire(aborted.signal)).rejects.toMatchObject({ name: "AbortError" });
+
+    const queuedAbort = new AbortController();
+    const cancelled = pool.acquire(queuedAbort.signal);
+    const order: string[] = [];
+    const second = pool.acquire().then((release) => {
+      order.push("second");
+      return release;
+    });
+    const third = pool.acquire().then((release) => {
+      order.push("third");
+      return release;
+    });
+    queuedAbort.abort();
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+
+    first();
+    first();
+    const secondRelease = await second;
+    expect(order).toEqual(["second"]);
+    expect(pool.inFlight).toBe(1);
+    secondRelease();
+    const thirdRelease = await third;
+    expect(order).toEqual(["second", "third"]);
+    thirdRelease();
+    thirdRelease();
+    expect(pool.inFlight).toBe(0);
+  });
+
+  test("cancels while queued without launching a subagent", async () => {
+    const pool = new SubagentSlotPool(1);
+    const release = await pool.acquire();
+    const controller = new AbortController();
+    const runSubagent = vi.fn(completedRun("should not run"));
+    const tool = createSubagentTool(runSubagent);
+    const bounded = (request: SubagentRunRequest) =>
+      (async () => {
+        let slot: (() => void) | undefined;
+        try {
+          slot = await pool.acquire(request.signal);
+        } catch {
+          return {
+            runId: "cancelled",
+            status: "cancelled",
+            model: { provider: "test", id: "model" },
+            turns: 0,
+            tokens: 0,
+            costUsd: 0,
+            durationMs: 0,
+          } as const;
+        }
+        try {
+          return await runSubagent(request);
+        } finally {
+          slot();
+        }
+      })() as ReturnType<RunSubagent>;
+    const boundedTool = createSubagentTool(bounded as RunSubagent);
+    const pending = boundedTool.execute("queued", { task: "queued" }, controller.signal);
+    controller.abort();
+    const result = await pending;
+    release();
+    expect(result.details).toMatchObject({ status: "cancelled" });
+    expect(runSubagent).not.toHaveBeenCalled();
+    expect(tool.name).toBe("subagent");
+  });
+
   test("a shared slot pool bounds fan-out across tool instances", async () => {
     let active = 0;
     let maxActive = 0;
@@ -51,8 +123,16 @@ describe("subagent tool", () => {
     // Two conversations' tool instances draw from ONE process-wide account:
     // each could run 2 concurrently on its own, but the shared ceiling is 2.
     const shared = new SubagentSlotPool(2);
-    const toolA = createSubagentTool(runSubagent, shared);
-    const toolB = createSubagentTool(runSubagent, shared);
+    const bounded = (async (request: SubagentRunRequest) => {
+      const release = await shared.acquire(request.signal);
+      try {
+        return await runSubagent(request);
+      } finally {
+        release();
+      }
+    }) as RunSubagent;
+    const toolA = createSubagentTool(bounded);
+    const toolB = createSubagentTool(bounded);
     const params = { tasks: [{ task: "one" }, { task: "two" }] };
 
     await Promise.all([toolA.execute("a", params), toolB.execute("b", params)]);


### PR DESCRIPTION
## Summary

- route tool and extension subagent launches through the same process-wide slot pool
- make queued slot acquisition abortable without launching a model or leaking capacity
- attribute extension-launched subagent usage only to the active parent run
- add opt-in normalized parent context for single, parallel, and DAG subagents

## Context behavior

`parentContext: { mode: "normalized", recentTurns?: number }` remains opt-in. It includes only recent user/assistant text, reuses an earlier compaction or branch summary when available, and excludes reasoning, tool calls/results, images, system/platform noise, and provider metadata. Without an active parent, the run stays fresh.

## Verification

- `npm run build`
- `npm test` — 106 files, 1283 tests passed
- `npm run lint` — passed with 3 pre-existing warnings
- `npm run fmt:check`
- `git diff --check`


## Before / After

| 面向 | Before | After |
|---|---|---|
| 全域並行限制 | 只有主 `subagent` tool 使用 process-wide slot pool；Extension API 可繞過限制 | Tool 與 Extension API 共用同一個 process-wide slot pool |
| Slot 取得位置 | Slot 由 tool orchestration 層取得 | Slot 下沉至每個實際 subagent session 的共同執行 seam |
| 排隊取消 | 等待 slot 時無法立即取消 | `acquire(signal)` 支援 `AbortSignal`，排隊中的請求可立即取消 |
| 取消後資源 | 取消請求仍可能等到取得 slot 才釋放 | Waiter 立即從 FIFO queue 移除，不占用或洩漏 slot |
| Slot handoff | 釋放後喚醒 waiter，再重新增加計數 | Slot 直接 FIFO handoff，並支援 idempotent release |
| 排隊取消結果 | 沒有標準排隊取消流程 | 回傳標準 `cancelled` result，且不啟動模型 |
| Extension usage | Extension 啟動的 subagent usage 不回算至 parent run | 若呼叫起始時存在 active parent，tokens/cost 回算至該 run |
| Usage 歸因時機 | 無 Extension parent attribution | Invocation 開始時 snapshot parent，避免完成時誤算至其他 run |
| Standalone Extension | 缺少明確 parent usage/context 語義 | Activation、command 等 standalone 呼叫不污染上一個 parent run |
| Parent context | Subagent 永遠使用 fresh context | 預設仍為 fresh，可 opt-in 使用 normalized parent context |
| Context interface | 無 | `parentContext: { mode: "normalized", recentTurns?: number }` |
| Recent turns | 無 | 預設 3，允許 1–8 個 user turns |
| Context 內容 | 無父 context | 只保留近期 user/assistant 純文字 |
| 敏感／噪音內容 | 不適用 | 排除 reasoning、tool calls/results、圖片、system/platform noise 與 provider metadata |
| 舊 context | 不適用 | 優先重用既有 compaction/branch summary |
| 無既有摘要 | 不適用 | 使用固定 omitted marker，不額外呼叫模型產生摘要 |
| 無 active parent | 不適用 | 即使要求 normalized context，也安全退回 fresh |
| 支援模式 | Context 不適用 | single、parallel、DAG 都支援共同的 `parentContext` 設定 |
| Active run 判定 | 只依底層 model streaming 狀態，無法涵蓋 pre-model hooks | Session 追蹤完整 prompt lifecycle，包括 Extension hooks |
| 測試 | 主要涵蓋既有 runner、parallel 與 DAG | 新增 abort、FIFO、slot leak、usage attribution、context normalization 與 noise exclusion 測試 |
