### PR TITLE
test(slack): broaden e2e coverage to DM, isolation, uploads, and queueing

### DIFF
--- a/.github/workflows/slack-e2e.yml
+++ b/.github/workflows/slack-e2e.yml
@@ -49,6 +49,10 @@ jobs:
             wait "$MIKAN_PID" 2>/dev/null || true
             echo "----- mikan log -----"
             cat "$LOG_FILE" || true
+            # Which conversations produced history distinguishes "event never
+            # delivered" (no dir) from "delivered but not triggered" (dir, no run).
+            echo "----- workspace conversations -----"
+            find "$WORKING_DIR" -maxdepth 2 2>/dev/null | head -80 || true
             [ "$exit_code" -eq 0 ] && rm -rf "$WORKSPACE_TMP" || true
           }
           trap cleanup EXIT

--- a/.github/workflows/slack-e2e.yml
+++ b/.github/workflows/slack-e2e.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run Slack E2E
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_QA_USER_TOKEN: ${{ secrets.SLACK_QA_USER_TOKEN }}
@@ -40,6 +40,16 @@ jobs:
           mkdir -p "$WORKING_DIR"
 
           node dist/main.js --onboard --state-dir "$STATE_DIR"
+          # E2E runs on OpenRouter; onboard defaults to Anthropic, so point
+          # both the main model and the auto-reply judge at deepseek.
+          node -e '
+            const fs = require("fs");
+            const p = process.argv[1];
+            const s = JSON.parse(fs.readFileSync(p, "utf8"));
+            const model = { provider: "openrouter", model: "deepseek/deepseek-v4-flash" };
+            s.llm = { ...s.llm, ...model, autoReply: { ...model } };
+            fs.writeFileSync(p, JSON.stringify(s, null, 2));
+          ' "$STATE_DIR/settings.json"
           node dist/main.js --state-dir "$STATE_DIR" "$WORKING_DIR" >"$LOG_FILE" 2>&1 &
           MIKAN_PID=$!
 

--- a/.github/workflows/slack-e2e.yml
+++ b/.github/workflows/slack-e2e.yml
@@ -53,6 +53,8 @@ jobs:
             # delivered" (no dir) from "delivered but not triggered" (dir, no run).
             echo "----- workspace conversations -----"
             find "$WORKING_DIR" -maxdepth 2 2>/dev/null | head -80 || true
+            echo "----- dm history -----"
+            head -c 4000 "$WORKING_DIR"/D*/log.jsonl 2>/dev/null || true
             [ "$exit_code" -eq 0 ] && rm -rf "$WORKSPACE_TMP" || true
           }
           trap cleanup EXIT

--- a/e2e/slack/busy-queue.e2e.ts
+++ b/e2e/slack/busy-queue.e2e.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { loadContextOrSkip } from "./helpers/client.js";
+import {
+  nowSeconds,
+  postMessage,
+  sleep,
+  summarizeMessage,
+  waitForBotReply,
+} from "./helpers/slack.js";
+
+const ctx = loadContextOrSkip();
+
+describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack busy queue", () => {
+  if (!ctx || !ctx.env.mikanBotUserId) return;
+  const { client, env } = ctx;
+  const botUserId = ctx.env.mikanBotUserId;
+
+  it("S-023 message sent while mikan is busy is queued and answered", async () => {
+    const busyToken = `QA_BUSY_${Date.now()}`;
+    const queuedToken = `QA_QUEUED_${Date.now()}`;
+    const startedAt = nowSeconds();
+    const busyRootTs = await postMessage(
+      client,
+      env.channel,
+      `<@${botUserId}> busy-queue e2e：請使用 bash 執行 sleep 10，完成後回覆這個 token：${busyToken}`,
+    );
+    await sleep(2_000);
+    const queuedRootTs = await postMessage(
+      client,
+      env.channel,
+      `<@${botUserId}> 排隊測試：請直接回覆這個 token：${queuedToken}`,
+    );
+
+    const busyReply = await waitForBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      rootTs: busyRootTs,
+      startedAt,
+      timeoutMs: Math.max(env.timeoutMs, 90_000),
+      pollMs: env.pollMs,
+      textIncludes: busyToken,
+    });
+    expect(busyReply, `no reply to the busy task containing ${busyToken}`).not.toBeNull();
+
+    const queuedReply = await waitForBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      rootTs: queuedRootTs,
+      startedAt,
+      timeoutMs: Math.max(env.timeoutMs, 90_000),
+      pollMs: env.pollMs,
+      textIncludes: queuedToken,
+    });
+    expect(queuedReply, `no reply to the queued message containing ${queuedToken}`).not.toBeNull();
+    console.log(`busy reply ts=${busyReply!.ts}: ${summarizeMessage(busyReply!)}`);
+    console.log(`queued reply ts=${queuedReply!.ts}: ${summarizeMessage(queuedReply!)}`);
+  }, 240_000);
+});

--- a/e2e/slack/dm.e2e.ts
+++ b/e2e/slack/dm.e2e.ts
@@ -5,12 +5,14 @@ import {
   openDmChannel,
   postMessage,
   summarizeMessage,
-  waitForRecentBotReply,
+  waitForBotReply,
 } from "./helpers/slack.js";
 
 const ctx = loadContextOrSkip();
 
-describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack DM", () => {
+// Opt-in via SLACK_QA_DM_E2E=1: the live QA Slack App must deliver
+// `message.im` events for these to pass (see helpers/env.ts).
+describe.skipIf(!ctx || !ctx.env.mikanBotUserId || !ctx.env.dmEnabled)("Slack DM", () => {
   if (!ctx || !ctx.env.mikanBotUserId) return;
   const { client, env } = ctx;
   const botUserId = ctx.env.mikanBotUserId;
@@ -19,17 +21,13 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack DM", () => {
     const dmChannel = await openDmChannel(client, botUserId);
     const token = `QA_DM_${Date.now()}`;
     const startedAt = nowSeconds();
-    const messageTs = await postMessage(
-      client,
-      dmChannel,
-      `DM e2e：請直接回覆這個 token：${token}`,
-    );
-    const reply = await waitForRecentBotReply({
+    const rootTs = await postMessage(client, dmChannel, `DM e2e：請直接回覆這個 token：${token}`);
+    const reply = await waitForBotReply({
       client,
       channel: dmChannel,
       botUserId,
+      rootTs,
       startedAt,
-      afterTs: messageTs,
       timeoutMs: Math.max(env.timeoutMs, 45_000),
       pollMs: env.pollMs,
       textIncludes: token,
@@ -47,28 +45,29 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack DM", () => {
       dmChannel,
       `請記住這個 token：${token}。現在只需回覆 OK，不要重複 token。`,
     );
-    const firstReply = await waitForRecentBotReply({
+    const firstReply = await waitForBotReply({
       client,
       channel: dmChannel,
       botUserId,
+      rootTs: firstTs,
       startedAt: firstStartedAt,
-      afterTs: firstTs,
       timeoutMs: Math.max(env.timeoutMs, 45_000),
       pollMs: env.pollMs,
     });
     expect(firstReply, "no reply to the first DM turn").not.toBeNull();
 
+    const followupStartedAt = nowSeconds();
     const followupTs = await postMessage(
       client,
       dmChannel,
       "請只回覆我上一則訊息要你記住的 token，不要加其他文字。",
     );
-    const reply = await waitForRecentBotReply({
+    const reply = await waitForBotReply({
       client,
       channel: dmChannel,
       botUserId,
-      startedAt: firstStartedAt,
-      afterTs: followupTs,
+      rootTs: followupTs,
+      startedAt: followupStartedAt,
       timeoutMs: Math.max(env.timeoutMs, 45_000),
       pollMs: env.pollMs,
       textIncludes: token,

--- a/e2e/slack/dm.e2e.ts
+++ b/e2e/slack/dm.e2e.ts
@@ -10,9 +10,7 @@ import {
 
 const ctx = loadContextOrSkip();
 
-// Opt-in via SLACK_QA_DM_E2E=1: the live QA Slack App must deliver
-// `message.im` events for these to pass (see helpers/env.ts).
-describe.skipIf(!ctx || !ctx.env.mikanBotUserId || !ctx.env.dmEnabled)("Slack DM", () => {
+describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack DM", () => {
   if (!ctx || !ctx.env.mikanBotUserId) return;
   const { client, env } = ctx;
   const botUserId = ctx.env.mikanBotUserId;

--- a/e2e/slack/dm.e2e.ts
+++ b/e2e/slack/dm.e2e.ts
@@ -35,7 +35,7 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack DM", () => {
     const token = `QA_DM_${Date.now()}`;
     const startedAt = nowSeconds();
     const rootTs = await postMessage(client, dmChannel, `DM e2e：請直接回覆這個 token：${token}`);
-    const reply = await waitForBotReply({
+    let reply = await waitForBotReply({
       client,
       channel: dmChannel,
       botUserId,
@@ -45,9 +45,28 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack DM", () => {
       pollMs: env.pollMs,
       textIncludes: token,
     });
+    if (!reply) {
+      // Budget models occasionally reply without the token; one
+      // conversational repair keeps the assertion strict without flaking.
+      const retryTs = await postMessage(
+        client,
+        dmChannel,
+        `你剛才的回覆沒有包含 token。請重新回覆，務必原樣包含 token ${token}`,
+      );
+      reply = await waitForBotReply({
+        client,
+        channel: dmChannel,
+        botUserId,
+        rootTs: retryTs,
+        startedAt,
+        timeoutMs: Math.max(env.timeoutMs, 45_000),
+        pollMs: env.pollMs,
+        textIncludes: token,
+      });
+    }
     expect(reply, `no DM reply containing ${token}`).not.toBeNull();
     console.log(`dm reply ts=${reply!.ts}: ${summarizeMessage(reply!)}`);
-  });
+  }, 180_000);
 
   it("S-018 DM session retains multi-turn context", async () => {
     const dmChannel = await openDmChannel(client, botUserId);

--- a/e2e/slack/dm.e2e.ts
+++ b/e2e/slack/dm.e2e.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { loadContextOrSkip } from "./helpers/client.js";
+import {
+  nowSeconds,
+  openDmChannel,
+  postMessage,
+  summarizeMessage,
+  waitForRecentBotReply,
+} from "./helpers/slack.js";
+
+const ctx = loadContextOrSkip();
+
+describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack DM", () => {
+  if (!ctx || !ctx.env.mikanBotUserId) return;
+  const { client, env } = ctx;
+  const botUserId = ctx.env.mikanBotUserId;
+
+  it("S-017 mikan replies to a DM without mention", async () => {
+    const dmChannel = await openDmChannel(client, botUserId);
+    const token = `QA_DM_${Date.now()}`;
+    const startedAt = nowSeconds();
+    const messageTs = await postMessage(
+      client,
+      dmChannel,
+      `DM e2e：請直接回覆這個 token：${token}`,
+    );
+    const reply = await waitForRecentBotReply({
+      client,
+      channel: dmChannel,
+      botUserId,
+      startedAt,
+      afterTs: messageTs,
+      timeoutMs: Math.max(env.timeoutMs, 45_000),
+      pollMs: env.pollMs,
+      textIncludes: token,
+    });
+    expect(reply, `no DM reply containing ${token}`).not.toBeNull();
+    console.log(`dm reply ts=${reply!.ts}: ${summarizeMessage(reply!)}`);
+  });
+
+  it("S-018 DM session retains multi-turn context", async () => {
+    const dmChannel = await openDmChannel(client, botUserId);
+    const token = `QA_DM_CTX_${Date.now()}`;
+    const firstStartedAt = nowSeconds();
+    const firstTs = await postMessage(
+      client,
+      dmChannel,
+      `請記住這個 token：${token}。現在只需回覆 OK，不要重複 token。`,
+    );
+    const firstReply = await waitForRecentBotReply({
+      client,
+      channel: dmChannel,
+      botUserId,
+      startedAt: firstStartedAt,
+      afterTs: firstTs,
+      timeoutMs: Math.max(env.timeoutMs, 45_000),
+      pollMs: env.pollMs,
+    });
+    expect(firstReply, "no reply to the first DM turn").not.toBeNull();
+
+    const followupTs = await postMessage(
+      client,
+      dmChannel,
+      "請只回覆我上一則訊息要你記住的 token，不要加其他文字。",
+    );
+    const reply = await waitForRecentBotReply({
+      client,
+      channel: dmChannel,
+      botUserId,
+      startedAt: firstStartedAt,
+      afterTs: followupTs,
+      timeoutMs: Math.max(env.timeoutMs, 45_000),
+      pollMs: env.pollMs,
+      textIncludes: token,
+    });
+    expect(reply, `no context-carrying DM reply containing ${token}`).not.toBeNull();
+    console.log(`dm context reply ts=${reply!.ts}: ${summarizeMessage(reply!)}`);
+  }, 180_000);
+});

--- a/e2e/slack/dm.e2e.ts
+++ b/e2e/slack/dm.e2e.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { loadContextOrSkip } from "./helpers/client.js";
 import {
   nowSeconds,
@@ -14,6 +14,21 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack DM", () => {
   if (!ctx || !ctx.env.mikanBotUserId) return;
   const { client, env } = ctx;
   const botUserId = ctx.env.mikanBotUserId;
+
+  // mikan ignores DMs from bots by design (loop protection), so these
+  // scenarios only make sense when the QA token belongs to a human user.
+  // Fail fast with the misconfiguration instead of timing out on a reply
+  // that can never come.
+  beforeAll(async () => {
+    const auth = await client.auth.test();
+    if (typeof auth.bot_id === "string" && auth.bot_id.length > 0) {
+      throw new Error(
+        `SLACK_QA_USER_TOKEN authenticates as bot ${auth.bot_id} (${String(auth.user)}). ` +
+          "DM scenarios need a human User OAuth Token (xoxp-, auth.test without bot_id); " +
+          "mikan deliberately does not reply to DMs from bots.",
+      );
+    }
+  });
 
   it("S-017 mikan replies to a DM without mention", async () => {
     const dmChannel = await openDmChannel(client, botUserId);

--- a/e2e/slack/file-upload.e2e.ts
+++ b/e2e/slack/file-upload.e2e.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { loadContextOrSkip } from "./helpers/client.js";
-import { nowSeconds, uploadTextFile, waitForRecentBotReply } from "./helpers/slack.js";
+import { nowSeconds, postMessage, uploadTextFile, waitForRecentBotReply } from "./helpers/slack.js";
 
 const ctx = loadContextOrSkip();
 
@@ -19,7 +19,7 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack file upload", () => {
       `Slack E2E file content. Token: ${token}\n請摘要這個檔案並原樣包含 token。\n`,
       `<@${botUserId}> 請摘要這個小文字檔，並在回覆中原樣包含 token ${token}`,
     );
-    const reply = await waitForRecentBotReply({
+    let reply = await waitForRecentBotReply({
       client,
       channel: env.channel,
       botUserId,
@@ -28,6 +28,24 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack file upload", () => {
       pollMs: env.pollMs,
       textIncludes: token,
     });
+    if (!reply) {
+      // Budget models occasionally reply without the token; one
+      // conversational repair keeps the assertion strict without flaking.
+      await postMessage(
+        client,
+        env.channel,
+        `<@${botUserId}> 你剛才的回覆沒有包含 token。請重新回覆，務必原樣包含 token ${token}`,
+      );
+      reply = await waitForRecentBotReply({
+        client,
+        channel: env.channel,
+        botUserId,
+        startedAt,
+        timeoutMs: Math.max(env.timeoutMs, 45_000),
+        pollMs: env.pollMs,
+        textIncludes: token,
+      });
+    }
     expect(reply, `no file summary reply containing ${token}`).not.toBeNull();
-  });
+  }, 180_000);
 });

--- a/e2e/slack/helpers/env.ts
+++ b/e2e/slack/helpers/env.ts
@@ -10,6 +10,12 @@ export interface SlackE2eEnv {
   channel: string;
   mikanBotUserId: string | undefined;
   streamingBotToken: string | undefined;
+  /**
+   * Opt-in for DM scenarios (S-017/S-018). Requires the live Slack App to
+   * deliver `message.im` events (subscription + `im:history` bot scope, per
+   * `examples/slack-app-manifest.e2e.json`); the QA app does not yet.
+   */
+  dmEnabled: boolean;
   timeoutMs: number;
   pollMs: number;
   eventsDir: string;
@@ -25,6 +31,7 @@ export function readSlackE2eEnv(): SlackE2eEnv {
     channel,
     mikanBotUserId: env.SLACK_QA_BOT_USER_ID || undefined,
     streamingBotToken: env.SLACK_BOT_TOKEN || undefined,
+    dmEnabled: env.SLACK_QA_DM_E2E === "1",
     timeoutMs: Number(env.SLACK_QA_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS),
     pollMs: Number(env.SLACK_QA_POLL_MS ?? DEFAULT_POLL_MS),
     eventsDir: env.SLACK_QA_EVENTS_DIR ?? join(REPO_ROOT, ".workspace/mikan-workspace/events"),

--- a/e2e/slack/helpers/env.ts
+++ b/e2e/slack/helpers/env.ts
@@ -10,12 +10,6 @@ export interface SlackE2eEnv {
   channel: string;
   mikanBotUserId: string | undefined;
   streamingBotToken: string | undefined;
-  /**
-   * Opt-in for DM scenarios (S-017/S-018). Requires the live Slack App to
-   * deliver `message.im` events (subscription + `im:history` bot scope, per
-   * `examples/slack-app-manifest.e2e.json`); the QA app does not yet.
-   */
-  dmEnabled: boolean;
   timeoutMs: number;
   pollMs: number;
   eventsDir: string;
@@ -31,7 +25,6 @@ export function readSlackE2eEnv(): SlackE2eEnv {
     channel,
     mikanBotUserId: env.SLACK_QA_BOT_USER_ID || undefined,
     streamingBotToken: env.SLACK_BOT_TOKEN || undefined,
-    dmEnabled: env.SLACK_QA_DM_E2E === "1",
     timeoutMs: Number(env.SLACK_QA_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS),
     pollMs: Number(env.SLACK_QA_POLL_MS ?? DEFAULT_POLL_MS),
     eventsDir: env.SLACK_QA_EVENTS_DIR ?? join(REPO_ROOT, ".workspace/mikan-workspace/events"),

--- a/e2e/slack/helpers/slack.ts
+++ b/e2e/slack/helpers/slack.ts
@@ -57,6 +57,38 @@ export async function uploadTextFile(
   if (!res.ok) throw new Error(`files.uploadV2 failed: ${res.error ?? "unknown"}`);
 }
 
+export interface FileUploadSpec {
+  filename: string;
+  content: string | Buffer;
+}
+
+export async function uploadFiles(
+  client: WebClient,
+  channel: string,
+  files: FileUploadSpec[],
+  initialComment: string,
+): Promise<void> {
+  const res = await client.files.uploadV2({
+    channel_id: channel,
+    initial_comment: initialComment,
+    file_uploads: files.map((spec) => ({
+      file: Buffer.isBuffer(spec.content) ? spec.content : Buffer.from(spec.content),
+      filename: spec.filename,
+      title: spec.filename,
+    })),
+  });
+  if (!res.ok) throw new Error(`files.uploadV2 failed: ${res.error ?? "unknown"}`);
+}
+
+export async function openDmChannel(client: WebClient, userId: string): Promise<string> {
+  const res = await client.conversations.open({ users: userId });
+  const channelId = res.channel?.id;
+  if (!res.ok || !channelId) {
+    throw new Error(`conversations.open failed: ${res.error ?? "missing channel id"}`);
+  }
+  return channelId;
+}
+
 export async function fetchThreadMessages(
   client: WebClient,
   channel: string,
@@ -187,6 +219,8 @@ export interface WaitForRecentBotReplyOptions {
   startedAt: number;
   timeoutMs: number;
   pollMs: number;
+  /** Slack ts lower bound: only messages with ts strictly greater match (no local-clock skew). */
+  afterTs?: string;
   textIncludes?: string;
   textMatches?: RegExp;
 }
@@ -194,8 +228,17 @@ export interface WaitForRecentBotReplyOptions {
 export async function waitForRecentBotReply(
   opts: WaitForRecentBotReplyOptions,
 ): Promise<SlackMessage | null> {
-  const { client, channel, botUserId, startedAt, timeoutMs, pollMs, textIncludes, textMatches } =
-    opts;
+  const {
+    client,
+    channel,
+    botUserId,
+    startedAt,
+    timeoutMs,
+    pollMs,
+    afterTs,
+    textIncludes,
+    textMatches,
+  } = opts;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const recentMessages = await fetchRecentMessages(client, channel, startedAt).catch(
@@ -203,6 +246,7 @@ export async function waitForRecentBotReply(
     );
     const reply = recentMessages
       .filter((message) => isTargetBotMessage(message, botUserId))
+      .filter((message) => !afterTs || Number(message.ts) > Number(afterTs))
       .find((message) => {
         const text = messageText(message);
         if (textIncludes && !text.includes(textIncludes)) return false;

--- a/e2e/slack/image-upload.e2e.ts
+++ b/e2e/slack/image-upload.e2e.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { loadContextOrSkip } from "./helpers/client.js";
+import {
+  nowSeconds,
+  summarizeMessage,
+  uploadFiles,
+  waitForRecentBotReply,
+} from "./helpers/slack.js";
+
+// Valid 1x1 orange PNG (8-bit RGB), generated offline and verified with `file`.
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP438AAAAQBAYDFKhhdAAAAAElFTkSuQmCC",
+  "base64",
+);
+
+const ctx = loadContextOrSkip();
+
+describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack image upload", () => {
+  if (!ctx || !ctx.env.mikanBotUserId) return;
+  const { client, env } = ctx;
+  const botUserId = ctx.env.mikanBotUserId;
+
+  it("S-022 mikan handles an image upload without crashing", async () => {
+    const token = `QA_IMG_${Date.now()}`;
+    const startedAt = nowSeconds();
+    await uploadFiles(
+      client,
+      env.channel,
+      [{ filename: `mikan-slack-e2e-image-${token}.png`, content: PNG_1X1 }],
+      `<@${botUserId}> 這是一張測試圖片。無論你能否讀取圖片內容，請在回覆中原樣包含 token ${token}`,
+    );
+    const reply = await waitForRecentBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      startedAt,
+      timeoutMs: Math.max(env.timeoutMs, 60_000),
+      pollMs: env.pollMs,
+      textIncludes: token,
+    });
+    expect(reply, `no image-upload reply containing ${token}`).not.toBeNull();
+    console.log(`image reply ts=${reply!.ts}: ${summarizeMessage(reply!)}`);
+  }, 180_000);
+});

--- a/e2e/slack/image-upload.e2e.ts
+++ b/e2e/slack/image-upload.e2e.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { loadContextOrSkip } from "./helpers/client.js";
 import {
   nowSeconds,
+  postMessage,
   summarizeMessage,
   uploadFiles,
   waitForRecentBotReply,
@@ -29,7 +30,7 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack image upload", () => {
       [{ filename: `mikan-slack-e2e-image-${token}.png`, content: PNG_1X1 }],
       `<@${botUserId}> 這是一張測試圖片。無論你能否讀取圖片內容，請在回覆中原樣包含 token ${token}`,
     );
-    const reply = await waitForRecentBotReply({
+    let reply = await waitForRecentBotReply({
       client,
       channel: env.channel,
       botUserId,
@@ -38,6 +39,24 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack image upload", () => {
       pollMs: env.pollMs,
       textIncludes: token,
     });
+    if (!reply) {
+      // Budget models occasionally reply without the token; one
+      // conversational repair keeps the assertion strict without flaking.
+      await postMessage(
+        client,
+        env.channel,
+        `<@${botUserId}> 你剛才的回覆沒有包含 token。請重新回覆，務必原樣包含 token ${token}`,
+      );
+      reply = await waitForRecentBotReply({
+        client,
+        channel: env.channel,
+        botUserId,
+        startedAt,
+        timeoutMs: Math.max(env.timeoutMs, 45_000),
+        pollMs: env.pollMs,
+        textIncludes: token,
+      });
+    }
     expect(reply, `no image-upload reply containing ${token}`).not.toBeNull();
     console.log(`image reply ts=${reply!.ts}: ${summarizeMessage(reply!)}`);
   }, 180_000);

--- a/e2e/slack/multi-file-upload.e2e.ts
+++ b/e2e/slack/multi-file-upload.e2e.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { loadContextOrSkip } from "./helpers/client.js";
+import {
+  nowSeconds,
+  summarizeMessage,
+  uploadFiles,
+  waitForRecentBotReply,
+} from "./helpers/slack.js";
+
+const ctx = loadContextOrSkip();
+
+describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack multi-file upload", () => {
+  if (!ctx || !ctx.env.mikanBotUserId) return;
+  const { client, env } = ctx;
+  const botUserId = ctx.env.mikanBotUserId;
+
+  it("S-021 mikan reads multiple uploaded files and echoes both tokens", async () => {
+    const tokenA = `QA_MULTI_A_${Date.now()}`;
+    const tokenB = `QA_MULTI_B_${Date.now()}`;
+    const startedAt = nowSeconds();
+    await uploadFiles(
+      client,
+      env.channel,
+      [
+        {
+          filename: `mikan-slack-e2e-multi-a-${tokenA}.txt`,
+          content: `Slack E2E multi-file A. Token: ${tokenA}\n`,
+        },
+        {
+          filename: `mikan-slack-e2e-multi-b-${tokenB}.txt`,
+          content: `Slack E2E multi-file B. Token: ${tokenB}\n`,
+        },
+      ],
+      `<@${botUserId}> 請閱讀這兩個檔案，並在同一則回覆中原樣包含兩個 token`,
+    );
+    const reply = await waitForRecentBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      startedAt,
+      timeoutMs: Math.max(env.timeoutMs, 60_000),
+      pollMs: env.pollMs,
+      textIncludes: tokenA,
+    });
+    expect(reply, `no multi-file reply containing ${tokenA}`).not.toBeNull();
+
+    // The second token normally lands in the same message; poll again so a
+    // split reply still passes.
+    const replyWithB = await waitForRecentBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      startedAt,
+      timeoutMs: Math.max(env.timeoutMs, 30_000),
+      pollMs: env.pollMs,
+      textIncludes: tokenB,
+    });
+    expect(replyWithB, `no multi-file reply containing ${tokenB}`).not.toBeNull();
+    console.log(`multi-file reply ts=${reply!.ts}: ${summarizeMessage(reply!)}`);
+  }, 180_000);
+});

--- a/e2e/slack/short-task.e2e.ts
+++ b/e2e/slack/short-task.e2e.ts
@@ -17,7 +17,7 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack short task", () => {
       env.channel,
       `<@${botUserId}> 短任務 e2e：請直接回覆這個 token：${token}`,
     );
-    const reply = await waitForBotReply({
+    let reply = await waitForBotReply({
       client,
       channel: env.channel,
       botUserId,
@@ -27,6 +27,26 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack short task", () => {
       pollMs: env.pollMs,
       textIncludes: token,
     });
+    if (!reply) {
+      // Budget models occasionally reply without the token; one
+      // conversational repair keeps the assertion strict without flaking.
+      await postMessage(
+        client,
+        env.channel,
+        `<@${botUserId}> 你剛才的回覆沒有包含 token。請重新回覆，務必原樣包含 token ${token}`,
+        rootTs,
+      );
+      reply = await waitForBotReply({
+        client,
+        channel: env.channel,
+        botUserId,
+        rootTs,
+        startedAt,
+        timeoutMs: Math.max(env.timeoutMs, 45_000),
+        pollMs: env.pollMs,
+        textIncludes: token,
+      });
+    }
     expect(reply, `no mikan task reply containing ${token}`).not.toBeNull();
-  });
+  }, 180_000);
 });

--- a/e2e/slack/stop-idle.e2e.ts
+++ b/e2e/slack/stop-idle.e2e.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { loadContextOrSkip } from "./helpers/client.js";
+import {
+  nowSeconds,
+  postMessage,
+  sleep,
+  summarizeMessage,
+  waitForRecentBotReply,
+} from "./helpers/slack.js";
+
+const ctx = loadContextOrSkip();
+
+describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack stop while idle", () => {
+  if (!ctx || !ctx.env.mikanBotUserId) return;
+  const { client, env } = ctx;
+  const botUserId = ctx.env.mikanBotUserId;
+
+  it("S-019 addressed stop with nothing running reports idle", async () => {
+    // First stop clears anything a previous scenario may have left running,
+    // so the second stop deterministically hits the idle path.
+    const startedAt = nowSeconds();
+    const firstTs = await postMessage(client, env.channel, `<@${botUserId}> stop`);
+    const firstAck = await waitForRecentBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      startedAt,
+      afterTs: firstTs,
+      timeoutMs: Math.max(env.timeoutMs, 45_000),
+      pollMs: env.pollMs,
+      textMatches: /Stopped|Stopping|Nothing running|Force stopped/i,
+    });
+    expect(firstAck, "no acknowledgement for the first stop").not.toBeNull();
+    await sleep(Math.max(env.pollMs, 3_000));
+
+    const secondTs = await postMessage(client, env.channel, `<@${botUserId}> stop`);
+    const idleReply = await waitForRecentBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      startedAt,
+      afterTs: secondTs,
+      timeoutMs: Math.max(env.timeoutMs, 45_000),
+      pollMs: env.pollMs,
+      textMatches: /Nothing running/i,
+    });
+    expect(idleReply, "no 'Nothing running' reply to an idle stop").not.toBeNull();
+    console.log(`idle stop reply ts=${idleReply!.ts}: ${summarizeMessage(idleReply!)}`);
+  }, 180_000);
+});

--- a/e2e/slack/thread-isolation.e2e.ts
+++ b/e2e/slack/thread-isolation.e2e.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { loadContextOrSkip } from "./helpers/client.js";
+import {
+  nowSeconds,
+  postMessage,
+  summarizeMessage,
+  waitForThreadBotReply,
+} from "./helpers/slack.js";
+
+const ctx = loadContextOrSkip();
+
+describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack thread session isolation", () => {
+  if (!ctx || !ctx.env.mikanBotUserId) return;
+  const { client, env } = ctx;
+  const botUserId = ctx.env.mikanBotUserId;
+
+  it("S-020 thread sessions do not leak context into each other", async () => {
+    const tokenA = `QA_ISOLATE_A_${Date.now()}`;
+    const tokenB = `QA_ISOLATE_B_${Date.now()}`;
+    const rootA = await postMessage(
+      client,
+      env.channel,
+      `QA thread isolation root A ${new Date().toISOString()}`,
+    );
+    const rootB = await postMessage(
+      client,
+      env.channel,
+      `QA thread isolation root B ${new Date().toISOString()}`,
+    );
+
+    const tellAStartedAt = nowSeconds();
+    const tellATs = await postMessage(
+      client,
+      env.channel,
+      `<@${botUserId}> 請記住這個 token：${tokenA}。現在只需回覆 OK，不要重複 token。`,
+      rootA,
+    );
+    const tellAReply = await waitForThreadBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      rootTs: rootA,
+      startedAt: tellAStartedAt,
+      excludeTs: new Set([rootA, tellATs]),
+      timeoutMs: Math.max(env.timeoutMs, 45_000),
+      pollMs: env.pollMs,
+    });
+    expect(tellAReply, "no reply in thread A after storing the token").not.toBeNull();
+
+    const tellBStartedAt = nowSeconds();
+    const tellBTs = await postMessage(
+      client,
+      env.channel,
+      `<@${botUserId}> 請記住這個 token：${tokenB}。現在只需回覆 OK，不要重複 token。`,
+      rootB,
+    );
+    const tellBReply = await waitForThreadBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      rootTs: rootB,
+      startedAt: tellBStartedAt,
+      excludeTs: new Set([rootB, tellBTs]),
+      timeoutMs: Math.max(env.timeoutMs, 45_000),
+      pollMs: env.pollMs,
+    });
+    expect(tellBReply, "no reply in thread B after storing the token").not.toBeNull();
+
+    const askAStartedAt = nowSeconds();
+    const askATs = await postMessage(
+      client,
+      env.channel,
+      `<@${botUserId}> 請只回覆我在這個 thread 要你記住的 token，不要加其他文字。`,
+      rootA,
+    );
+    const askAReply = await waitForThreadBotReply({
+      client,
+      channel: env.channel,
+      botUserId,
+      rootTs: rootA,
+      startedAt: askAStartedAt,
+      excludeTs: new Set([rootA, tellATs, String(tellAReply!.ts), askATs]),
+      timeoutMs: Math.max(env.timeoutMs, 45_000),
+      pollMs: env.pollMs,
+      textIncludes: tokenA,
+    });
+    expect(askAReply, `no thread A reply containing ${tokenA}`).not.toBeNull();
+    expect(
+      askAReply!.text ?? "",
+      "thread A reply leaked thread B's token — sessions are not isolated",
+    ).not.toContain(tokenB);
+    console.log(`thread A recall ts=${askAReply!.ts}: ${summarizeMessage(askAReply!)}`);
+  }, 240_000);
+});

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -1097,7 +1097,14 @@ export class SlackMessagingBot implements MessagingBot {
       return;
     }
 
-    const isExternalMessagingBotMessage = !!e.bot_id || e.subtype === "bot_message";
+    // API posts made with a user token carry the posting app's bot_id/app_id
+    // alongside the human `user` — bot_id alone does not make the author a
+    // bot. Only treat the message as bot-authored when the author is not a
+    // known human user (bot users have is_bot=true; unknown authors stay on
+    // the conservative bot path so loop protection holds).
+    const authorIsKnownHuman = !!e.user && this.users.get(e.user)?.isBot === false;
+    const isExternalMessagingBotMessage =
+      e.subtype === "bot_message" || (!!e.bot_id && !authorIsKnownHuman);
     if (isExternalMessagingBotMessage) {
       if (e.subtype !== undefined && e.subtype !== "bot_message" && e.subtype !== "file_share") {
         ack();
@@ -1629,7 +1636,13 @@ export class SlackMessagingBot implements MessagingBot {
     do {
       const result = await this.webClient.users.list({ limit: 200, cursor });
       const members = result.members as
-        | Array<{ id?: string; name?: string; real_name?: string; deleted?: boolean }>
+        | Array<{
+            id?: string;
+            name?: string;
+            real_name?: string;
+            deleted?: boolean;
+            is_bot?: boolean;
+          }>
         | undefined;
       if (members) {
         for (const u of members) {
@@ -1638,6 +1651,7 @@ export class SlackMessagingBot implements MessagingBot {
               id: u.id,
               userName: u.name,
               displayName: u.real_name || u.name,
+              isBot: !!u.is_bot,
             });
           }
         }

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -1127,7 +1127,11 @@ export class SlackMessagingBot implements MessagingBot {
       return;
     }
 
-    const isDM = e.channel_type === "im";
+    // message.im normally carries channel_type "im", but fall back to the
+    // D-prefix convention (used by handleAppMention and session keys) so a
+    // missing channel_type cannot silently demote a DM to an auto-reply
+    // candidate that never triggers.
+    const isDM = e.channel_type === "im" || e.channel.startsWith("D");
     const conversationKind: ConversationKind = isDM ? "direct" : "shared";
     const isMessagingBotMention = e.text?.includes(`<@${this.botUserId}>`);
 

--- a/src/adapters/slack/types.ts
+++ b/src/adapters/slack/types.ts
@@ -21,6 +21,8 @@ export interface SlackUser {
   id: string;
   userName: string;
   displayName: string;
+  /** From users.list is_bot; absent when the entry predates the flag. */
+  isBot?: boolean;
 }
 
 export interface SlackChannel {

--- a/src/content/docs/ja/slack-qa-test-plan.md
+++ b/src/content/docs/ja/slack-qa-test-plan.md
@@ -69,8 +69,8 @@ npm run test:e2e:slack
 - mikan small text-file upload handling。
 - 複数ファイルアップロード処理。
 - 画像アップロード処理。
-- mention 不要の DM 応答（opt-in：`SLACK_QA_DM_E2E=1`、live App が `message.im` を配信する必要あり）。
-- DM のマルチターン文脈保持（opt-in：`SLACK_QA_DM_E2E=1`）。
+- mention 不要の DM 応答。
+- DM のマルチターン文脈保持。
 - Thread session の分離。
 - Busy-queue のキュー済みメッセージ配信。
 - bot-to-bot loop observation。

--- a/src/content/docs/ja/slack-qa-test-plan.md
+++ b/src/content/docs/ja/slack-qa-test-plan.md
@@ -65,7 +65,14 @@ npm run test:e2e:slack
 - mikan thread reply routing。
 - mikan short task completion。
 - mikan stop command acknowledgement。
+- Idle stop（"Nothing running"）acknowledgement。
 - mikan small text-file upload handling。
+- 複数ファイルアップロード処理。
+- 画像アップロード処理。
+- mention 不要の DM 応答。
+- DM のマルチターン文脈保持。
+- Thread session の分離。
+- Busy-queue のキュー済みメッセージ配信。
 - bot-to-bot loop observation。
 - one-shot event delivery。
 - No-mention false-reply check。

--- a/src/content/docs/ja/slack-qa-test-plan.md
+++ b/src/content/docs/ja/slack-qa-test-plan.md
@@ -87,7 +87,7 @@ Workflow `.github/workflows/slack-e2e.yml` は **Actions → Slack E2E → Run w
 
 必要な repository secrets：
 
-- `ANTHROPIC_API_KEY`
+- `OPENROUTER_API_KEY`
 - `SLACK_APP_TOKEN`
 - `SLACK_BOT_TOKEN`
 - `SLACK_QA_USER_TOKEN`

--- a/src/content/docs/ja/slack-qa-test-plan.md
+++ b/src/content/docs/ja/slack-qa-test-plan.md
@@ -69,8 +69,8 @@ npm run test:e2e:slack
 - mikan small text-file upload handling。
 - 複数ファイルアップロード処理。
 - 画像アップロード処理。
-- mention 不要の DM 応答。
-- DM のマルチターン文脈保持。
+- mention 不要の DM 応答（opt-in：`SLACK_QA_DM_E2E=1`、live App が `message.im` を配信する必要あり）。
+- DM のマルチターン文脈保持（opt-in：`SLACK_QA_DM_E2E=1`）。
 - Thread session の分離。
 - Busy-queue のキュー済みメッセージ配信。
 - bot-to-bot loop observation。

--- a/src/content/docs/ja/slack-qa-test-plan.md
+++ b/src/content/docs/ja/slack-qa-test-plan.md
@@ -79,7 +79,7 @@ npm run test:e2e:slack
 
 ローカル E2E に必要な変数は 4 つだけです：`SLACK_QA_USER_TOKEN`、`SLACK_QA_CHANNEL_ID`、`SLACK_QA_BOT_USER_ID`、`SLACK_BOT_TOKEN`。Event directory は現在の workspace から推定されます。
 
-QA user token は、テスト channel への投稿、channel history/replies の読み取り、S-009 のファイルアップロードが可能である必要があります。`examples/slack-app-manifest.e2e.json` の E2E manifest にはこれらの必要な user scopes が含まれています。通常の `examples/slack-app-manifest.json` には含まれていません。
+QA user token は、テスト channel への投稿、channel history/replies の読み取り、S-009 のファイルアップロードが可能である必要があります。DM scenario ではさらに人間ユーザーの身分（`auth.test` に `bot_id` なし）が必要です：mikan は設計上 bot からの DM に応答しないため、bot 身分の token では S-017/S-018 は設定エラーとして即座に fail します。`examples/slack-app-manifest.e2e.json` の E2E manifest にはこれらの必要な user scopes が含まれています。通常の `examples/slack-app-manifest.json` には含まれていません。
 
 ### GitHub Actions
 

--- a/src/content/docs/slack-qa-test-plan.md
+++ b/src/content/docs/slack-qa-test-plan.md
@@ -69,8 +69,8 @@ Each scenario has its own `*.e2e.ts` file. When required env vars (`SLACK_QA_USE
 - mikan small text-file upload handling
 - multi-file upload handling
 - image upload handling
-- DM reply without mention (opt-in: `SLACK_QA_DM_E2E=1`, requires live `message.im` delivery)
-- DM multi-turn context retention (opt-in: `SLACK_QA_DM_E2E=1`)
+- DM reply without mention
+- DM multi-turn context retention
 - thread session isolation
 - busy-queue follow-up delivery
 - bot-to-bot loop observation

--- a/src/content/docs/slack-qa-test-plan.md
+++ b/src/content/docs/slack-qa-test-plan.md
@@ -69,8 +69,8 @@ Each scenario has its own `*.e2e.ts` file. When required env vars (`SLACK_QA_USE
 - mikan small text-file upload handling
 - multi-file upload handling
 - image upload handling
-- DM reply without mention
-- DM multi-turn context retention
+- DM reply without mention (opt-in: `SLACK_QA_DM_E2E=1`, requires live `message.im` delivery)
+- DM multi-turn context retention (opt-in: `SLACK_QA_DM_E2E=1`)
 - thread session isolation
 - busy-queue follow-up delivery
 - bot-to-bot loop observation

--- a/src/content/docs/slack-qa-test-plan.md
+++ b/src/content/docs/slack-qa-test-plan.md
@@ -87,7 +87,7 @@ Workflow `.github/workflows/slack-e2e.yml` runs the same smoke test manually thr
 
 Required repository secrets:
 
-- `ANTHROPIC_API_KEY`
+- `OPENROUTER_API_KEY`
 - `SLACK_APP_TOKEN`
 - `SLACK_BOT_TOKEN`
 - `SLACK_QA_USER_TOKEN`

--- a/src/content/docs/slack-qa-test-plan.md
+++ b/src/content/docs/slack-qa-test-plan.md
@@ -79,7 +79,7 @@ Each scenario has its own `*.e2e.ts` file. When required env vars (`SLACK_QA_USE
 
 Local E2E needs only four variables: `SLACK_QA_USER_TOKEN`, `SLACK_QA_CHANNEL_ID`, `SLACK_QA_BOT_USER_ID`, and `SLACK_BOT_TOKEN`. The event directory is derived from the current workspace.
 
-The QA user token must be able to post messages, read channel history/replies, and upload files for S-009 in the test channel. The E2E manifest in `examples/slack-app-manifest.e2e.json` includes these required user scopes; the normal `examples/slack-app-manifest.json` does not.
+The QA user token must be able to post messages, read channel history/replies, and upload files for S-009 in the test channel. For the DM scenarios it must also authenticate as a human user (`auth.test` without `bot_id`): mikan deliberately does not reply to DMs from bots, so a bot-flavored token makes S-017/S-018 fail fast with a misconfiguration error. The E2E manifest in `examples/slack-app-manifest.e2e.json` includes these required user scopes; the normal `examples/slack-app-manifest.json` does not.
 
 ### GitHub Actions
 

--- a/src/content/docs/slack-qa-test-plan.md
+++ b/src/content/docs/slack-qa-test-plan.md
@@ -65,7 +65,14 @@ Each scenario has its own `*.e2e.ts` file. When required env vars (`SLACK_QA_USE
 - mikan thread reply routing
 - mikan short task completion
 - mikan stop command acknowledgement
+- idle stop ("Nothing running") acknowledgement
 - mikan small text-file upload handling
+- multi-file upload handling
+- image upload handling
+- DM reply without mention
+- DM multi-turn context retention
+- thread session isolation
+- busy-queue follow-up delivery
 - bot-to-bot loop observation
 - one-shot event delivery
 - no-mention false-reply check

--- a/src/content/docs/zh-cn/slack-qa-test-plan.md
+++ b/src/content/docs/zh-cn/slack-qa-test-plan.md
@@ -65,7 +65,14 @@ npm run test:e2e:slack
 - mikan thread reply routing。
 - mikan short task completion。
 - mikan stop command acknowledgement。
+- Idle stop（"Nothing running"）acknowledgement。
 - mikan small text-file upload handling。
+- 多文件上传处理。
+- 图片上传处理。
+- 不需 mention 的 DM 回复。
+- DM 多轮上下文保留。
+- Thread session 隔离。
+- Busy-queue 排队消息送达。
 - bot-to-bot loop observation。
 - one-shot event delivery。
 - No-mention false-reply check。

--- a/src/content/docs/zh-cn/slack-qa-test-plan.md
+++ b/src/content/docs/zh-cn/slack-qa-test-plan.md
@@ -79,7 +79,7 @@ npm run test:e2e:slack
 
 本机 E2E 只需要四个变数：`SLACK_QA_USER_TOKEN`、`SLACK_QA_CHANNEL_ID`、`SLACK_QA_BOT_USER_ID` 与 `SLACK_BOT_TOKEN`。Event directory 会从目前 workspace 推导。
 
-QA user token 必须能在测试 channel 发文、读取 channel history/replies，并为 S-009 上传档案。`examples/slack-app-manifest.e2e.json` 的 E2E manifest 包含这些必要 user scopes；一般的 `examples/slack-app-manifest.json` 不包含。
+QA user token 必须能在测试 channel 发文、读取 channel history/replies，并为 S-009 上传档案。DM scenario 另外要求 token 是人类使用者身分（`auth.test` 不带 `bot_id`）：mikan 依设计不回复来自 bot 的 DM，bot 身分的 token 会让 S-017/S-018 直接以设定错误 fail fast。`examples/slack-app-manifest.e2e.json` 的 E2E manifest 包含这些必要 user scopes；一般的 `examples/slack-app-manifest.json` 不包含。
 
 ### GitHub Actions
 

--- a/src/content/docs/zh-cn/slack-qa-test-plan.md
+++ b/src/content/docs/zh-cn/slack-qa-test-plan.md
@@ -87,7 +87,7 @@ Workflow `.github/workflows/slack-e2e.yml` 会透过 **Actions → Slack E2E →
 
 必要 repository secrets：
 
-- `ANTHROPIC_API_KEY`
+- `OPENROUTER_API_KEY`
 - `SLACK_APP_TOKEN`
 - `SLACK_BOT_TOKEN`
 - `SLACK_QA_USER_TOKEN`

--- a/src/content/docs/zh-cn/slack-qa-test-plan.md
+++ b/src/content/docs/zh-cn/slack-qa-test-plan.md
@@ -69,8 +69,8 @@ npm run test:e2e:slack
 - mikan small text-file upload handling。
 - 多文件上传处理。
 - 图片上传处理。
-- 不需 mention 的 DM 回复。
-- DM 多轮上下文保留。
+- 不需 mention 的 DM 回复（opt-in：`SLACK_QA_DM_E2E=1`，live App 需投递 `message.im`）。
+- DM 多轮上下文保留（opt-in：`SLACK_QA_DM_E2E=1`）。
 - Thread session 隔离。
 - Busy-queue 排队消息送达。
 - bot-to-bot loop observation。

--- a/src/content/docs/zh-cn/slack-qa-test-plan.md
+++ b/src/content/docs/zh-cn/slack-qa-test-plan.md
@@ -69,8 +69,8 @@ npm run test:e2e:slack
 - mikan small text-file upload handling。
 - 多文件上传处理。
 - 图片上传处理。
-- 不需 mention 的 DM 回复（opt-in：`SLACK_QA_DM_E2E=1`，live App 需投递 `message.im`）。
-- DM 多轮上下文保留（opt-in：`SLACK_QA_DM_E2E=1`）。
+- 不需 mention 的 DM 回复。
+- DM 多轮上下文保留。
 - Thread session 隔离。
 - Busy-queue 排队消息送达。
 - bot-to-bot loop observation。

--- a/src/content/docs/zh-tw/slack-qa-test-plan.md
+++ b/src/content/docs/zh-tw/slack-qa-test-plan.md
@@ -69,8 +69,8 @@ npm run test:e2e:slack
 - mikan small text-file upload handling。
 - 多檔案上傳處理。
 - 圖片上傳處理。
-- 不需 mention 的 DM 回覆。
-- DM 多輪上下文保留。
+- 不需 mention 的 DM 回覆（opt-in：`SLACK_QA_DM_E2E=1`，live App 需投遞 `message.im`）。
+- DM 多輪上下文保留（opt-in：`SLACK_QA_DM_E2E=1`）。
 - Thread session 隔離。
 - Busy-queue 排隊訊息送達。
 - bot-to-bot loop observation。

--- a/src/content/docs/zh-tw/slack-qa-test-plan.md
+++ b/src/content/docs/zh-tw/slack-qa-test-plan.md
@@ -87,7 +87,7 @@ Workflow `.github/workflows/slack-e2e.yml` 會透過 **Actions → Slack E2E →
 
 必要 repository secrets：
 
-- `ANTHROPIC_API_KEY`
+- `OPENROUTER_API_KEY`
 - `SLACK_APP_TOKEN`
 - `SLACK_BOT_TOKEN`
 - `SLACK_QA_USER_TOKEN`

--- a/src/content/docs/zh-tw/slack-qa-test-plan.md
+++ b/src/content/docs/zh-tw/slack-qa-test-plan.md
@@ -65,7 +65,14 @@ npm run test:e2e:slack
 - mikan thread reply routing。
 - mikan short task completion。
 - mikan stop command acknowledgement。
+- Idle stop（"Nothing running"）acknowledgement。
 - mikan small text-file upload handling。
+- 多檔案上傳處理。
+- 圖片上傳處理。
+- 不需 mention 的 DM 回覆。
+- DM 多輪上下文保留。
+- Thread session 隔離。
+- Busy-queue 排隊訊息送達。
 - bot-to-bot loop observation。
 - one-shot event delivery。
 - No-mention false-reply check。

--- a/src/content/docs/zh-tw/slack-qa-test-plan.md
+++ b/src/content/docs/zh-tw/slack-qa-test-plan.md
@@ -69,8 +69,8 @@ npm run test:e2e:slack
 - mikan small text-file upload handling。
 - 多檔案上傳處理。
 - 圖片上傳處理。
-- 不需 mention 的 DM 回覆（opt-in：`SLACK_QA_DM_E2E=1`，live App 需投遞 `message.im`）。
-- DM 多輪上下文保留（opt-in：`SLACK_QA_DM_E2E=1`）。
+- 不需 mention 的 DM 回覆。
+- DM 多輪上下文保留。
 - Thread session 隔離。
 - Busy-queue 排隊訊息送達。
 - bot-to-bot loop observation。

--- a/src/content/docs/zh-tw/slack-qa-test-plan.md
+++ b/src/content/docs/zh-tw/slack-qa-test-plan.md
@@ -79,7 +79,7 @@ npm run test:e2e:slack
 
 本機 E2E 只需要四個變數：`SLACK_QA_USER_TOKEN`、`SLACK_QA_CHANNEL_ID`、`SLACK_QA_BOT_USER_ID` 與 `SLACK_BOT_TOKEN`。Event directory 會從目前 workspace 推導。
 
-QA user token 必須能在測試 channel 發文、讀取 channel history/replies，並為 S-009 上傳檔案。`examples/slack-app-manifest.e2e.json` 的 E2E manifest 包含這些必要 user scopes；一般的 `examples/slack-app-manifest.json` 不包含。
+QA user token 必須能在測試 channel 發文、讀取 channel history/replies，並為 S-009 上傳檔案。DM scenario 另外要求 token 是人類使用者身分（`auth.test` 不帶 `bot_id`）：mikan 依設計不回覆來自 bot 的 DM，bot 身分的 token 會讓 S-017/S-018 直接以設定錯誤 fail fast。`examples/slack-app-manifest.e2e.json` 的 E2E manifest 包含這些必要 user scopes；一般的 `examples/slack-app-manifest.json` 不包含。
 
 ### GitHub Actions
 

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -1522,6 +1522,70 @@ describe("SlackMessagingBot queues follow-up messages", () => {
     expect(handler.handleEvent).not.toHaveBeenCalled();
   });
 
+  test("DM message without channel_type still routes as a direct message", async () => {
+    const handler = makeHandler();
+
+    const bot = new SlackMessagingBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    let messageHandler:
+      | ((payload: {
+          event: {
+            text?: string;
+            channel: string;
+            user?: string;
+            ts: string;
+            channel_type?: string;
+          };
+          ack: () => void;
+        }) => void)
+      | undefined;
+
+    (bot as any).startupTs = "0";
+    (bot as any).botUserId = "B123";
+    (bot as any).logUserMessage = vi.fn().mockReturnValue([]);
+    (bot as any).postMessage = vi.fn().mockResolvedValue("3000.0001");
+    (bot as any).socketClient = {
+      on: vi.fn((event: string, fn: unknown) => {
+        if (event === "message") messageHandler = fn as typeof messageHandler;
+      }),
+    };
+
+    (bot as any).setupEventHandlers();
+
+    const queue = (bot as any).getQueue("D999");
+    queue.processing = true;
+    const ack = vi.fn();
+
+    messageHandler?.({
+      event: {
+        text: "dm without channel_type",
+        channel: "D999",
+        user: "U123",
+        ts: "2001.0001",
+      },
+      ack,
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(queue.size()).toBe(1);
+
+    queue.processing = false;
+    await queue.processNext();
+
+    expect(handler.handleEvent).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(handler.handleEvent).mock.calls[0]?.[0]).toMatchObject({
+      conversationId: "D999",
+      conversationKind: "direct",
+      sessionKey: "D999",
+      text: "dm without channel_type",
+    });
+  });
+
   test("DM thread follow-up messages are queued on the thread session key once the thread session exists", async () => {
     const handler = makeHandler();
     vi.mocked(handler.isRunning).mockImplementation(

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -1586,6 +1586,142 @@ describe("SlackMessagingBot queues follow-up messages", () => {
     });
   });
 
+  test("DM posted via a user token (human user plus bot_id) routes as a user message", async () => {
+    const handler = makeHandler();
+
+    const bot = new SlackMessagingBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    let messageHandler:
+      | ((payload: {
+          event: {
+            text?: string;
+            channel: string;
+            user?: string;
+            ts: string;
+            channel_type?: string;
+            bot_id?: string;
+            app_id?: string;
+          };
+          ack: () => void;
+        }) => void)
+      | undefined;
+
+    (bot as any).startupTs = "0";
+    (bot as any).botUserId = "B123";
+    (bot as any).users.set("UHUMAN", {
+      id: "UHUMAN",
+      userName: "qa-human",
+      displayName: "QA Human",
+      isBot: false,
+    });
+    (bot as any).logUserMessage = vi.fn().mockReturnValue([]);
+    (bot as any).postMessage = vi.fn().mockResolvedValue("3000.0001");
+    (bot as any).socketClient = {
+      on: vi.fn((event: string, fn: unknown) => {
+        if (event === "message") messageHandler = fn as typeof messageHandler;
+      }),
+    };
+
+    (bot as any).setupEventHandlers();
+
+    const queue = (bot as any).getQueue("D999");
+    queue.processing = true;
+    const ack = vi.fn();
+
+    messageHandler?.({
+      event: {
+        text: "dm posted with a user token",
+        channel: "D999",
+        user: "UHUMAN",
+        ts: "2001.0001",
+        channel_type: "im",
+        bot_id: "BPOSTINGAPP",
+        app_id: "APOSTINGAPP",
+      },
+      ack,
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(queue.size()).toBe(1);
+
+    queue.processing = false;
+    await queue.processNext();
+
+    expect(handler.handleEvent).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(handler.handleEvent).mock.calls[0]?.[0]).toMatchObject({
+      conversationId: "D999",
+      user: "UHUMAN",
+      text: "dm posted with a user token",
+    });
+  });
+
+  test("DM from a bot user keeps the external-bot ignore path", async () => {
+    const handler = makeHandler();
+
+    const bot = new SlackMessagingBot(handler, {
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      workingDir,
+      store: {} as any,
+    });
+
+    let messageHandler:
+      | ((payload: {
+          event: {
+            text?: string;
+            channel: string;
+            user?: string;
+            ts: string;
+            channel_type?: string;
+            bot_id?: string;
+          };
+          ack: () => void;
+        }) => void)
+      | undefined;
+
+    (bot as any).startupTs = "0";
+    (bot as any).botUserId = "B123";
+    (bot as any).users.set("UOTHERBOT", {
+      id: "UOTHERBOT",
+      userName: "other-bot",
+      displayName: "Other Bot",
+      isBot: true,
+    });
+    (bot as any).logUserMessage = vi.fn().mockReturnValue([]);
+    (bot as any).logExternalMessagingBotMessage = vi.fn().mockResolvedValue([]);
+    (bot as any).postMessage = vi.fn().mockResolvedValue("3000.0001");
+    (bot as any).socketClient = {
+      on: vi.fn((event: string, fn: unknown) => {
+        if (event === "message") messageHandler = fn as typeof messageHandler;
+      }),
+    };
+
+    (bot as any).setupEventHandlers();
+    const ack = vi.fn();
+
+    messageHandler?.({
+      event: {
+        text: "bot dm",
+        channel: "D999",
+        user: "UOTHERBOT",
+        ts: "2001.0001",
+        channel_type: "im",
+        bot_id: "BOTHERBOT",
+      },
+      ack,
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect((bot as any).logExternalMessagingBotMessage).toHaveBeenCalledTimes(1);
+    expect(handler.handleEvent).not.toHaveBeenCalled();
+    expect((bot as any).getQueue("D999").size()).toBe(0);
+  });
+
   test("DM thread follow-up messages are queued on the thread session key once the thread session exists", async () => {
     const handler = makeHandler();
     vi.mocked(handler.isRunning).mockImplementation(


### PR DESCRIPTION
## Summary

Automates six previously manual Slack QA scenarios (S-017..S-023) in `e2e/slack/`:

- **`dm.e2e.ts`** — S-017 DM reply without mention, S-018 DM multi-turn context retention (M-001/M-020). Requires a human-user QA token, see below.
- **`stop-idle.e2e.ts`** — S-019 addressed `stop` while idle replies "Nothing running." (M-024). A first stop clears any leftover task so the second deterministically hits the idle path.
- **`thread-isolation.e2e.ts`** — S-020 two threads each store a token; recalling in thread A must return token A and must NOT leak token B (M-005/M-021).
- **`multi-file-upload.e2e.ts`** — S-021 one message with two files; reply must echo both tokens (M-033).
- **`image-upload.e2e.ts`** — S-022 uploads a valid 1x1 PNG; bot must handle the image attachment path gracefully and echo the token (M-031).
- **`busy-queue.e2e.ts`** — S-023 a mention sent while the agent is busy (`bash sleep 10`) is queued and still answered (intake `busyPolicy: "queue"`).

Helper additions (`helpers/slack.ts`): `openDmChannel()`, multi-file/binary `uploadFiles()`, and an `afterTs` Slack-ts lower bound on `waitForRecentBotReply` (immune to local-clock skew). QA test-plan docs (en/ja/zh-cn/zh-tw) updated.

## Product fix

- `fix(slack)`: `handleMessageEvent` now falls back to the D-prefix convention (already used by `handleAppMention` and session keys) when `channel_type` is absent, so a DM can't be silently demoted to a never-triggering auto-reply candidate. Unit-tested.

## DM root cause (fixed here)

CI's history dump showed QA-posted DMs arriving with `bot_id`/`app_id` of the posting app even for a genuine human `user` — Slack attaches the posting app's identity to user-token API posts. Intake's "any bot_id = external bot" rule therefore silently swallowed human DMs (mentions were unaffected: `app_mention` has no bot filter).

Fixes shipped in this PR:
- `fix(slack)`: classify bot messages by author — `bot_id` only marks a bot message when `users.list is_bot` says the author is not human. Bot users and unknown authors keep the conservative ignore path, so loop protection holds. Unit-tested.
- `dm.e2e.ts` preflights `auth.test` and fails fast if the QA token is bot-flavored.

## CI model

The workflow now runs the daemon on **OpenRouter `deepseek/deepseek-v4-flash`** (secret `OPENROUTER_API_KEY`; Anthropic no longer required). deepseek intermittently returns empty content, so single-shot token-echo scenarios send one conversational repair follow-up before asserting; systematic breakage still fails.

## Test results

- Final run: **22/22 passed** on OpenRouter deepseek with the rotated QA user token: https://github.com/geminixiang/mikan/actions/runs/29657070721
- Diagnostic history: runs 29655040584 (20/22, DM investigation start) → 29655368247 (gated, green) → 29655582239 (delivered-but-ignored evidence) → 29655894442 (bot_id attribution evidence) → 29656406651 (deepseek switch, human-token preflight passed) → 29656710804 (author-classification fix, DM context test green).
- Unit suite: 1286 passed; oxlint/oxfmt/knip clean.
