### PR TITLE
docs: extend landing page with themed sections and animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1949,7 +1949,7 @@
     },
     "node_modules/@geminixiang/mikan-starlight-theme": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/geminixiang/mikan-starlight-theme.git#b737aff608caef28f6e471d1b1ad7353e147f0ae",
+      "resolved": "git+ssh://git@github.com/geminixiang/mikan-starlight-theme.git#b35f0a618a9de68d877e61be120a7a78e10338be",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -5,13 +5,121 @@ template: splash
 ---
 
 import Hero from "@geminixiang/mikan-starlight-theme/components/Hero.astro";
+import PlatformStrip from "@geminixiang/mikan-starlight-theme/components/PlatformStrip.astro";
+import Features from "@geminixiang/mikan-starlight-theme/components/Features.astro";
+import ArchBand from "@geminixiang/mikan-starlight-theme/components/ArchBand.astro";
+import CodeDemo from "@geminixiang/mikan-starlight-theme/components/CodeDemo.astro";
+import CTA from "@geminixiang/mikan-starlight-theme/components/CTA.astro";
 
 <Hero
-  eyebrow="AI coding agent"
-  title="mikan"
-  tagline="A multi-platform AI coding agent for Slack, Telegram, Discord, and GitHub. It separates platform history, agent sessions, credentials, and sandbox execution."
+  eyebrow="AI coding agent · pre-1.0"
+  title="One agent, every chat."
+  tagline="mikan is an AI coding agent that lives in Slack, Telegram, Discord, and GitHub — and keeps the chat record, its own session, the sandbox it runs in, and your credentials each in their own place."
   actions={[
     { text: "Get started", href: "/quickstart/", variant: "primary" },
     { text: "View on GitHub", href: "https://github.com/geminixiang/mikan", variant: "secondary" },
+  ]}
+/>
+
+<PlatformStrip
+  label="Runs where your team already talks"
+  items={["Slack", "Telegram", "Discord", "GitHub"]}
+/>
+
+<Features
+  items={[
+    {
+      icon: "comment",
+      title: "Multi-platform",
+      body: "One agent across Slack, Telegram, Discord, and GitHub. Mention it in a channel or DM it directly.",
+    },
+    {
+      icon: "random",
+      title: "Concurrent sessions",
+      body: "Slack threads, Discord replies, and Telegram reply chains each run as an independent session.",
+    },
+    {
+      icon: "rocket",
+      title: "Sandbox execution",
+      body: "Run tool commands on the host, in a shared or per-user container, or a Firecracker microVM.",
+    },
+    {
+      icon: "lock",
+      title: "Credential vaults",
+      body: "Store keys with /login. mikan injects them as env and mounted files only at run time.",
+    },
+    {
+      icon: "document",
+      title: "Persistent memory",
+      body: "Workspace- and channel-level MEMORY.md the agent reads and writes as it works.",
+    },
+    {
+      icon: "puzzle",
+      title: "Skills & events",
+      body: "Drop CLI tools into skills/, and schedule one-shot or recurring work with JSON events.",
+    },
+  ]}
+/>
+
+<ArchBand
+  eyebrow="Separation of concerns"
+  title="Four layers on one path — kept apart on purpose."
+  tagline="Most agents fuse the transcript, the model loop, and the shell into a single process. mikan keeps them on one path but separate, so each can be inspected, swapped, or locked down on its own."
+  lanes={[
+    {
+      name: "Chat record",
+      verb: "feeds",
+      body: "The platform-facing history — log.jsonl, attachments, and conversation files.",
+    },
+    {
+      name: "Agent session",
+      verb: "drives",
+      body: "Structured turns with compaction and retry, persisted under sessions/.",
+    },
+    {
+      name: "Sandbox",
+      verb: "unlocks",
+      body: "Where tool commands actually run: host, container, image, or microVM.",
+    },
+    {
+      name: "Vault",
+      body: "Runtime credentials as env vars and mounted secret files — never at rest in the repo.",
+    },
+  ]}
+/>
+
+<CodeDemo
+  eyebrow="How it works"
+  title="Install it. Point it at a chat. Go."
+  steps={[
+    {
+      title: "Install",
+      body: "One npm install, supervised by PM2 so it restarts on failure and starts on boot.",
+    },
+    {
+      title: "Connect",
+      body: "Set a bot token per platform in mikan.env — run as many platforms at once as you like.",
+    },
+    {
+      title: "Talk to it",
+      body: "@mention it in a channel or send a DM. Each thread becomes its own agent session.",
+    },
+  ]}
+  terminalTitle="~/.mikan"
+  lines={[
+    "$ npm i -g @geminixiang/mikan pm2",
+    "$ mikan --onboard --state-dir=~/.mikan",
+    "# add SLACK_BOT_TOKEN + friends to ~/.mikan/mikan.env",
+    "$ pm2 start ecosystem.config.cjs",
+    "  mikan online — Slack, Telegram, Discord, GitHub",
+  ]}
+/>
+
+<CTA
+  title="Put an agent in your team's chat."
+  body="Free and MIT-licensed. Bring your own model provider and deploy in minutes."
+  actions={[
+    { text: "Get started", href: "/quickstart/", variant: "primary" },
+    { text: "Read the architecture", href: "/architecture/", variant: "secondary" },
   ]}
 />


### PR DESCRIPTION
## What

Extends the mikan docs landing page (`src/content/docs/index.mdx`) from a bare `<Hero>` into a full product landing page, composed from new theme components in the xAI-inspired `--mk-*` system:

- **Hero** — one-shot page-load entrance choreography (eyebrow → title → tagline → actions).
- **PlatformStrip** — hairline-ruled row of the surfaces mikan connects to.
- **Features** — the real feature set (multi-platform, sessions, sandbox, vaults, memory, skills).
- **ArchBand** *(signature)* — an animated separation-of-concerns pipeline (chat record → agent session → sandbox → vault) with a scroll-triggered stagger reveal and a sunset pulse along the spine.
- **CodeDemo** — steps beside a static terminal frame showing the install/run flow.
- **CTA** — closing call to action.

## Dependency

Bumps the `@geminixiang/mikan-starlight-theme` lock to the commit that ships these components (theme PR #2, merged to the theme's `main`).

## Motion

All animation is opt-in via a `[data-anim]` hook set only when it will play, so no-JS, `prefers-reduced-motion`, and crawlers get the fully-visible static layout.

## Scope

English (`root`) locale only. zh-tw / zh-cn / ja still use the simple hero; they can be ported in a follow-up.

## Verification

- `astro build` green (153 pages) against the freshly-installed theme dependency.
- Full pre-commit gate passed: lint, fmt:check, knip, build, and test (1286 tests).