### PR TITLE
fix(subagent): raise limits and surface budget exhaustion

### DIFF
--- a/src/harness/subagent-runner.ts
+++ b/src/harness/subagent-runner.ts
@@ -20,10 +20,10 @@ import { unboundedSlotPool, type SubagentSlotPool } from "../tools/subagent-slot
 const subagentRunDepth = new AsyncLocalStorage<number>();
 const DEFAULT_SYSTEM_PROMPT =
   "You are a focused subagent. Complete only the assigned task and return the result directly.";
-const DEFAULT_SUBAGENT_BUDGET = {
-  maxTurns: 8,
-  maxCostUsd: 0.5,
-  maxDurationMs: 2 * 60 * 1000,
+export const DEFAULT_SUBAGENT_BUDGET = {
+  maxTurns: 100,
+  maxCostUsd: 10,
+  maxDurationMs: 10 * 60 * 1000,
 } as const;
 
 const SCHEMA_STRUCTURAL_KEYS = new Set([
@@ -404,7 +404,15 @@ async function executeSubagentRun<TOutputSchema extends TSchema | undefined = un
       ...(text ? { text } : {}),
     };
 
-    if (terminalSignal) return { ...base, status: terminalSignal };
+    if (terminalSignal) {
+      return {
+        ...base,
+        status: terminalSignal,
+        ...(terminalSignal === "timeout"
+          ? { error: `Subagent exceeded its ${budget.maxDurationMs}ms duration limit` }
+          : {}),
+      };
+    }
     if (stats.budgetExceededReason) {
       return {
         ...base,

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -187,6 +187,9 @@ function formatOutcome(outcome: {
   output?: unknown;
   error?: string;
 }): string {
+  if (outcome.status === "budget_exceeded") {
+    return `Subagent stopped: budget limit exceeded${outcome.error ? ` (${outcome.error})` : ""}`;
+  }
   if (outcome.status !== "completed") {
     return `Subagent ${outcome.status}${outcome.error ? `: ${outcome.error}` : ""}`;
   }

--- a/test/subagent-runner.test.ts
+++ b/test/subagent-runner.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { Type, type TSchema } from "@sinclair/typebox";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { runSubagent } from "../src/harness/subagent-runner.js";
+import { DEFAULT_SUBAGENT_BUDGET, runSubagent } from "../src/harness/subagent-runner.js";
 import { MikanAgentSession, MikanModels, SessionStore } from "../src/harness/index.js";
 import { createSubagentTool } from "../src/tools/subagent.js";
 import { SubagentSlotPool } from "../src/tools/subagent-slots.js";
@@ -53,6 +53,14 @@ const echoTool: AgentTool = {
 };
 
 describe("runSubagent", () => {
+  test("uses the expanded default limits", () => {
+    expect(DEFAULT_SUBAGENT_BUDGET).toEqual({
+      maxTurns: 100,
+      maxCostUsd: 10,
+      maxDurationMs: 10 * 60 * 1000,
+    });
+  });
+
   test("backs the normal agent's subagent tool", async () => {
     const { models, faux, model } = createFauxSetup();
     faux.setResponses([

--- a/test/subagent-tool.test.ts
+++ b/test/subagent-tool.test.ts
@@ -398,6 +398,30 @@ describe("subagent tool", () => {
     });
   });
 
+  test("reports budget exhaustion and its concrete reason to the main agent", async () => {
+    const runSubagent = (async () => ({
+      runId: "subagent-budget",
+      status: "budget_exceeded",
+      model: { provider: "test", id: "model" },
+      turns: 100,
+      tokens: 1_000,
+      costUsd: 1.25,
+      durationMs: 1_000,
+      error: "LLM calls 100 >= 100 limit",
+    })) as RunSubagent;
+    const tool = createSubagentTool(runSubagent);
+
+    const result = await tool.execute("call-budget", { task: "Keep working" });
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "Subagent stopped: budget limit exceeded (LLM calls 100 >= 100 limit)",
+      },
+    ]);
+    expect(result.details).toMatchObject({ status: "budget_exceeded" });
+  });
+
   test("forwards cancellation and reports incomplete status", async () => {
     const controller = new AbortController();
     const runSubagent = (async (request: SubagentRunRequest) => {


### PR DESCRIPTION
## Summary

- raise default subagent limits to 100 turns, $10, and 10 minutes
- return concrete budget and duration limit reasons to the parent agent
- cover the new defaults and user-visible budget exhaustion output

## Verification

- `npm test -- test/subagent-runner.test.ts test/subagent-tool.test.ts`
- `npm run fmt:check -- src/harness/subagent-runner.ts src/tools/subagent.ts test/subagent-runner.test.ts test/subagent-tool.test.ts`
- `npm run lint -- src/harness/subagent-runner.ts src/tools/subagent.ts test/subagent-runner.test.ts test/subagent-tool.test.ts`
- `npm run build`
- `git diff --check`