### PR TITLE
fix(slack): keep long continuations in thread

### DIFF
--- a/e2e/slack/long-message-thread.e2e.ts
+++ b/e2e/slack/long-message-thread.e2e.ts
@@ -1,0 +1,94 @@
+import { WebClient } from "@slack/web-api";
+import { describe, expect, it } from "vitest";
+import { SlackMessagingBot } from "../../src/adapters/slack/bot.js";
+import { createSlackAdapters } from "../../src/adapters/slack/context.js";
+import { assertBotTokenShape } from "./helpers/env.js";
+import { loadContextOrSkip } from "./helpers/client.js";
+import { fetchThreadMessages, postMessage } from "./helpers/slack.js";
+
+const ctx = loadContextOrSkip();
+
+function createRealSlackResponderBot(botClient: WebClient): SlackMessagingBot {
+  let rejectNextPost = true;
+  return {
+    getUser: () => undefined,
+    getMessagingInfo: () => ({
+      name: "slack",
+      trustModel: "membership",
+      formattingGuide: "",
+      channels: [],
+      users: [],
+    }),
+    postInThread: (channel: string, threadTs: string, text: string) => {
+      if (rejectNextPost) {
+        rejectNextPost = false;
+        const error = new Error("An API error occurred: msg_too_long") as Error & {
+          data?: { error: string };
+        };
+        error.data = { error: "msg_too_long" };
+        return Promise.reject(error);
+      }
+      return Reflect.apply(SlackMessagingBot.prototype.postInThread, { webClient: botClient }, [
+        channel,
+        threadTs,
+        text,
+      ]) as Promise<string>;
+    },
+    logBotResponse: () => undefined,
+  } as unknown as SlackMessagingBot;
+}
+
+describe.skipIf(!ctx || !ctx.env.streamingBotToken)("Slack long-message continuation", () => {
+  if (!ctx || !ctx.env.streamingBotToken) return;
+  const { client, env } = ctx;
+  assertBotTokenShape(env.streamingBotToken);
+  const botClient = new WebClient(env.streamingBotToken);
+
+  it("S-024 keeps msg_too_long continuation messages in the existing thread", async () => {
+    const token = `LONG_THREAD_E2E_${Date.now()}`;
+    const longText = `${"x".repeat(6_000)}${token}`;
+    let rootTs: string | undefined;
+
+    try {
+      rootTs = await postMessage(client, env.channel, `Slack long-message E2E root ${token}`);
+      const userReplyTs = await postMessage(client, env.channel, "trigger", rootTs);
+      const slack = createRealSlackResponderBot(botClient);
+      const { responder } = createSlackAdapters(
+        {
+          type: "mention",
+          conversationId: env.channel,
+          conversationKind: "shared",
+          channel: env.channel,
+          ts: userReplyTs,
+          thread_ts: rootTs,
+          user: "slack-e2e",
+          text: "trigger",
+        },
+        slack,
+      );
+
+      await responder.replaceResponse(longText);
+
+      const messages = await fetchThreadMessages(client, env.channel, rootTs);
+      const fallback = messages.find((message) =>
+        message.text?.includes("message too long for Slack; continued in thread"),
+      );
+      const continuation = messages.find((message) => message.text?.includes(token));
+      expect(fallback, "missing msg_too_long fallback message").toBeDefined();
+      expect(continuation, "missing long-message continuation").toBeDefined();
+      expect(fallback!.thread_ts).toBe(rootTs);
+      expect(continuation!.thread_ts).toBe(rootTs);
+    } finally {
+      if (rootTs) {
+        const messages = await fetchThreadMessages(client, env.channel, rootTs).catch(() => []);
+        for (const message of messages.toReversed()) {
+          if (!message.ts || message.ts === rootTs) continue;
+          await botClient.chat
+            .delete({ channel: env.channel, ts: message.ts })
+            .catch(() => client.chat.delete({ channel: env.channel, ts: message.ts }));
+        }
+        await client.chat.delete({ channel: env.channel, ts: rootTs }).catch(() => undefined);
+      }
+    }
+  });
+});

--- a/src/adapters/slack/response-lifecycle.ts
+++ b/src/adapters/slack/response-lifecycle.ts
@@ -127,8 +127,9 @@ export function createSlackResponseContext({
   const postDiagnosticDirect = async (
     text: string,
     options?: { style?: "muted" | "error" },
+    anchorTs?: string,
   ): Promise<void> => {
-    const threadAnchor = messageTs ?? rootTs;
+    const threadAnchor = anchorTs ?? messageTs ?? rootTs;
     if (!threadAnchor) return;
 
     for (const part of splitText(text, MAX_THREAD_LENGTH, formatSlackContinuation)) {
@@ -390,7 +391,11 @@ export function createSlackResponseContext({
             accumulatedText = fallback.text;
             const continuation = text.slice(fallback.prefixLength).trimStart();
             if (continuation) {
-              await postDiagnosticDirect(`_(continued from truncated message)_\n\n${continuation}`);
+              await postDiagnosticDirect(
+                `_(continued from truncated message)_\n\n${continuation}`,
+                undefined,
+                replyInThread ? rootTs : (messageTs ?? rootTs),
+              );
             }
           }
         },

--- a/test/slack-context.test.ts
+++ b/test/slack-context.test.ts
@@ -483,6 +483,30 @@ describe("text accumulation", () => {
     expect(fallbackText).not.toContain("END");
   });
 
+  test("replaceResponse keeps long-message continuations in the existing thread", async () => {
+    const tooLongError = new Error("An API error occurred: msg_too_long") as Error & {
+      data?: { error: string };
+    };
+    tooLongError.data = { error: "msg_too_long" };
+    const bot = makeSlackMessagingBot({
+      postInThread: vi
+        .fn()
+        .mockRejectedValueOnce(tooLongError)
+        .mockResolvedValueOnce("BOT_MSG")
+        .mockResolvedValueOnce("CONTINUATION"),
+    });
+    const event = makeEvent({ thread_ts: "ROOT" });
+    const { responder } = createSlackAdapters(event, bot);
+
+    await responder.replaceResponse(`${"x".repeat(6000)}END`);
+
+    expect(bot.postInThread).toHaveBeenLastCalledWith(
+      "C001",
+      "ROOT",
+      expect.stringContaining("END"),
+    );
+  });
+
   test("respond falls back to short text when Slack says msg_too_long", async () => {
     const tooLongError = new Error("An API error occurred: msg_too_long") as Error & {
       data?: { error: string };


### PR DESCRIPTION
## Summary
- keep `msg_too_long` continuation messages anchored to the existing Slack thread root
- preserve bot-message anchoring for top-level long responses
- add unit and real-Slack regression coverage

## Verification
- `npm test` (1327 tests)
- `npm run build`
- `npm run fmt:check -- src/adapters/slack/response-lifecycle.ts test/slack-context.test.ts e2e/slack/long-message-thread.e2e.ts`
- `npm run lint -- src/adapters/slack/response-lifecycle.ts test/slack-context.test.ts e2e/slack/long-message-thread.e2e.ts`
- `npx vitest --run --config vitest.e2e.config.ts e2e/slack/long-message-thread.e2e.ts`