### PR TITLE
fix(slack): preserve mrkdwn links in Block Kit

### DIFF
--- a/e2e/slack/block-kit-markdown.e2e.ts
+++ b/e2e/slack/block-kit-markdown.e2e.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { renderSlackBlocks } from "../../src/adapters/slack/blocks.js";
+import { loadContextOrSkip } from "./helpers/client.js";
+import { fetchThreadMessages, postMessage } from "./helpers/slack.js";
+
+const ctx = loadContextOrSkip();
+
+function findMrkdwnText(
+  blocks: NonNullable<Awaited<ReturnType<typeof fetchThreadMessages>>[number]["blocks"]>,
+): string[] {
+  return blocks.flatMap((block) => {
+    if (block.type !== "section" || !("text" in block) || block.text?.type !== "mrkdwn") return [];
+    return [block.text.text];
+  });
+}
+
+describe.skipIf(!ctx)("Slack Block Kit markdown", () => {
+  if (!ctx) return;
+  const { client, env } = ctx;
+
+  it("S-024 preserves Slack mrkdwn links in canonical Block Kit messages", async () => {
+    const token = `QA_MRKDWN_LINK_${Date.now()}`;
+    const link = "<https://github.com/livingbio/designers/issues/523|#523>";
+    const source = `${token} ${link}`;
+    let rootTs: string | undefined;
+    let messageTs: string | undefined;
+
+    try {
+      rootTs = await postMessage(client, env.channel, `Slack Block Kit e2e root ${token}`);
+      const response = await client.chat.postMessage({
+        channel: env.channel,
+        thread_ts: rootTs,
+        ...renderSlackBlocks(source),
+      });
+      expect(response.ok, `chat.postMessage failed: ${response.error ?? "unknown"}`).toBe(true);
+      messageTs = response.ts;
+      expect(messageTs, "chat.postMessage missing ts").toBeTruthy();
+
+      const canonicalMessages = await fetchThreadMessages(client, env.channel, rootTs);
+      const canonicalMessage = canonicalMessages.find(
+        (message) => String(message.ts) === String(messageTs),
+      );
+      expect(
+        canonicalMessage,
+        "rendered message missing from canonical Slack thread",
+      ).toBeDefined();
+
+      const mrkdwnText = findMrkdwnText(canonicalMessage?.blocks ?? []).join("\n");
+      expect(mrkdwnText).toContain(source);
+      expect(mrkdwnText).not.toContain("issues/523%7C#523");
+      expect(mrkdwnText).not.toContain(`${link.slice(1, -1)}|https://`);
+    } finally {
+      if (messageTs) {
+        await client.chat.delete({ channel: env.channel, ts: messageTs }).catch(() => undefined);
+      }
+      if (rootTs) {
+        await client.chat.delete({ channel: env.channel, ts: rootTs }).catch(() => undefined);
+      }
+    }
+  });
+});

--- a/e2e/slack/helpers/slack.ts
+++ b/e2e/slack/helpers/slack.ts
@@ -1,3 +1,4 @@
+import type { KnownBlock } from "@slack/types";
 import type { WebClient } from "@slack/web-api";
 
 export interface SlackMessage {
@@ -6,6 +7,7 @@ export interface SlackMessage {
   user?: string;
   bot_id?: string;
   thread_ts?: string;
+  blocks?: KnownBlock[];
 }
 
 export function nowSeconds(): number {

--- a/src/adapters/slack/blocks.ts
+++ b/src/adapters/slack/blocks.ts
@@ -26,8 +26,20 @@ function pushSection(blocks: KnownBlock[], text: string): void {
 function renderInline(tokens: Token[] | null | undefined): string {
   if (!tokens) return "";
   let text = "";
-  for (const token of tokens) {
-    if (token.type === "text" || token.type === "code_inline") text += token.content;
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const linkText = tokens[i + 1];
+    const linkClose = tokens[i + 2];
+    if (
+      token.type === "link_open" &&
+      token.markup === "autolink" &&
+      linkText?.type === "text" &&
+      linkText.content.includes("|") &&
+      linkClose?.type === "link_close"
+    ) {
+      text += `<${linkText.content}>`;
+      i += 2;
+    } else if (token.type === "text" || token.type === "code_inline") text += token.content;
     else if (token.type === "softbreak" || token.type === "hardbreak") text += "\n";
     else if (token.type === "strong_open") text += "*";
     else if (token.type === "strong_close") text += "*";

--- a/test/slack-blocks.test.ts
+++ b/test/slack-blocks.test.ts
@@ -117,6 +117,22 @@ describe("renderSlackBlocks", () => {
     ]);
   });
 
+  test("preserves Slack mrkdwn links from agent responses", () => {
+    const rendered = renderSlackBlocks(
+      "• [電商 / Virtual Try-on] 夢展望 <https://github.com/livingbio/designers/issues/523|#523> / <https://example.com/video|video>",
+    );
+
+    expect(rendered.blocks).toEqual([
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "• [電商 / Virtual Try-on] 夢展望 <https://github.com/livingbio/designers/issues/523|#523> / <https://example.com/video|video>",
+        },
+      },
+    ]);
+  });
+
   test("keeps bullets as Slack mrkdwn sections", () => {
     const rendered = renderSlackBlocks("- one\n- two");
     expect(rendered.blocks).toEqual([


### PR DESCRIPTION
## Summary

- preserve existing Slack `<url|label>` links when Markdown is converted to Block Kit
- add a unit regression test using the malformed GitHub issue-link case observed in Production
- add a real Slack API e2e that posts rendered blocks and verifies canonical message blocks

## Root cause

`markdown-it` treats Slack mrkdwn links as Markdown autolinks and folds `|label` into the href. `renderInline()` then wraps the corrupted href again, producing malformed visible link text.

## Verification

- `npm test -- test/slack-blocks.test.ts`
- `npm run lint -- src/adapters/slack/blocks.ts test/slack-blocks.test.ts e2e/slack/helpers/slack.ts e2e/slack/block-kit-markdown.e2e.ts`
- `npm run fmt:check -- src/adapters/slack/blocks.ts test/slack-blocks.test.ts e2e/slack/helpers/slack.ts e2e/slack/block-kit-markdown.e2e.ts`
- `npm run build`
- `npx vitest --config vitest.e2e.config.ts --run e2e/slack/block-kit-markdown.e2e.ts`
