### PR TITLE
fix(test): detach git fixtures from an ambient GIT_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-node_modules/
+# No trailing slash: a `node_modules` symlink (worktrees sometimes get one)
+# is not a directory and would otherwise be committable.
+node_modules
 dist/
 site-dist/
 .astro/
@@ -21,4 +23,6 @@ vaults/*/
 .pi/subagent-schedules/
 .pi/subagents.json
 
-ecosystem.config.cjs
+# Anchored: the deployment template at deploy/pm2/ecosystem.config.cjs is
+# tracked, and an unanchored pattern matches it at every depth.
+/ecosystem.config.cjs

--- a/knip.json
+++ b/knip.json
@@ -1,4 +1,4 @@
 {
-  "ignore": ["examples/**", "scripts/**"],
+  "ignore": ["examples/**", "scripts/**", "deploy/**"],
   "ignoreBinaries": ["taskkill"]
 }

--- a/test/setup/git-env.ts
+++ b/test/setup/git-env.ts
@@ -1,0 +1,30 @@
+/**
+ * Detach the test process from any ambient git repository.
+ *
+ * Git resolves its target repository from the environment before it looks at
+ * the working directory. When the suite runs inside a git hook — husky's
+ * pre-commit runs `npm test` — git exports `GIT_DIR` and friends to the hook,
+ * and every `git` a test spawns for a fixture repo under /tmp inherits them.
+ * The fixture then operates on *this* repository instead of its own `cwd`:
+ * its `git commit` re-enters this repo's pre-commit hook in a directory with
+ * no package.json (so the commit fails), and its staging can drop real entries
+ * out of this repo's index. That is not hypothetical — it silently untracked
+ * `deploy/pm2/ecosystem.config.cjs`, which `.gitignore` then refused to
+ * re-add.
+ *
+ * Eight test files spawn git, so this belongs here rather than in each one.
+ */
+const AMBIENT_GIT_VARS = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_PREFIX",
+  "GIT_CONFIG_PARAMETERS",
+] as const;
+
+for (const key of AMBIENT_GIT_VARS) {
+  delete process.env[key];
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     },
   },
   test: {
+    // Git fixtures must resolve their repo from cwd, never from an ambient
+    // GIT_DIR inherited when the suite runs inside a git hook.
+    setupFiles: ["./test/setup/git-env.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],


### PR DESCRIPTION
The pre-commit hook has been unusable and quietly destructive. Both causes are here.

## What was happening

Git resolves its repository from the environment before it looks at the working directory. Husky's pre-commit runs `npm test`, and git exports `GIT_DIR` to hooks — so every `git` a test fixture spawns inherits it. With `GIT_DIR` set and no `GIT_WORK_TREE`, git treats the fixture's **cwd** as the work tree. So `git add -A` inside a throwaway `/tmp` repo stages the deletion of every file tracked in *this* repository.

Not hypothetical:

- It is why `deploy/pm2/ecosystem.config.cjs` silently left the index during the gondolin work. `.gitignore`'s unanchored `ecosystem.config.cjs` pattern then refused to let `git add -A` put it back, so the file looked deliberately deleted and shipped that way in #103 until it was caught.
- It is why recent commits needed `--no-verify`: the fixture's own `git commit` re-enters this repo's pre-commit in a directory with no `package.json`, so the fixture fails and takes the hook down with it.

## The fix

Eight test files spawn git, so this is one setup file that strips the ambient pointers (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, …) rather than eight separate patches. A spawned git then always resolves its repo from `cwd`, which is what these fixtures assume.

Two `.gitignore` patterns made the damage stick, and are anchored here:

| before | after | why |
| --- | --- | --- |
| `ecosystem.config.cjs` | `/ecosystem.config.cjs` | unanchored, so it matched the tracked `deploy/pm2/` template at every depth |
| `node_modules/` | `node_modules` | the trailing slash matches directories only, so a `node_modules` **symlink** was committable — one was nearly committed during #103 |

Un-ignoring the deploy template exposes it to knip, which has no reason to resolve a pm2 config, so `deploy/**` joins the knip ignore list.

## Verification

Two independent ways:

1. Pointing `GIT_DIR` at a decoy repo: **before** — 3 failures and a wrecked index; **after** — 23 passes and the decoy's index untouched.
2. This commit passes the **real pre-commit hook** end to end — lint, fmt:check, knip, build, 1390/1390 — and leaves a clean index. That is the first commit in this stretch of work that did not need `--no-verify`.