### PR TITLE
refactor(state): key per-conversation host state by office

### DIFF
--- a/docs/adr/0005-office-address-identity.md
+++ b/docs/adr/0005-office-address-identity.md
@@ -15,7 +15,9 @@ Workspace office directories use the office-key layout: `officeDirName` names th
 
 Conversation-scoped credential vaults are keyed by office key — the same string that names the office in the workspace and the registry — so platforms sharing a raw conversation ID can never resolve each other's credentials. The boot migration renames legacy raw-ID vault directories using the registry inventory and fails closed on conflicts. Host-mode vaults stay user-keyed (the host has no execution isolation to scope to) and container mode stays container-keyed.
 
-Settings, package, and event ownership keep raw-ID keys under the state dir, and sandbox resource keys (container names, gondolin instances, cloudflare scopes) stay raw-conversation-derived until the resource-naming migration — a collision there costs a container recreate, never credential access. Admin scope is still raw-ID keyed; its surfaces resolve offices through the registry (`resolveOwnedOfficeAddress`), which refuses ambiguous IDs shared by several platforms until Admin carries full addresses.
+Per-conversation host state (`<state-dir>/conversations/<officeKey>` — settings.json, extensions, extension-data, git checkouts) is office-keyed: the settings scope and the extension/package APIs carry the `OfficeAddress`, and the boot migration moves each office's whole legacy tree in one rename, failing closed on conflicts. The event tool's conversation scope matches platform as well as raw ID (platform-less legacy files stay visible); the events directory itself remains the workspace-wide scheduling bus by design.
+
+Sandbox resource keys (container names, gondolin instances, cloudflare scopes) stay raw-conversation-derived until the resource-naming migration — a collision there costs a container recreate, never credential access. Admin scope is still raw-ID keyed; its surfaces resolve offices through the registry (`resolveOwnedOfficeAddress`), which refuses ambiguous IDs shared by several platforms until Admin carries full addresses.
 
 Platform adapters continue to use raw IDs at their external I/O boundaries.
 The registry never infers a platform from an ID prefix: one enabled platform may

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -156,10 +156,7 @@ export class SlackMessagingBot implements MessagingBot {
   private resolveReplyMode(
     address: import("../../adapter.js").OfficeAddress,
   ): "top-level" | "thread" {
-    const scope = {
-      conversationId: address.conversationId,
-      conversationDir: this.conversationDir(address.conversationId),
-    };
+    const scope = { address, conversationDir: this.conversationDir(address.conversationId) };
     return resolveConversationSettings(scope).slack?.replyMode ?? "top-level";
   }
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -314,7 +314,7 @@ function isRegularFile(path: string): boolean {
 }
 
 function loadMikanSkills(
-  conversationId: string,
+  address: OfficeAddress,
   conversationDir: string,
   workspacePath: string,
   projection: WorkspaceProjection,
@@ -345,7 +345,7 @@ function loadMikanSkills(
   // skill ships alongside its SKILL.md, which inlining could never carry.
   const mounted = workspacePath !== hostWorkspacePath;
   for (const { slug, dir } of resolveConversationPackages({
-    conversationId,
+    address,
     stateDir: effectiveStateDir(),
     conversationDir,
   }).skillDirs) {
@@ -1349,6 +1349,7 @@ function buildExtensionHostServices(params: {
 }
 
 async function createConfiguredAgentSession(params: {
+  address: OfficeAddress;
   conversationId: string;
   conversationDir: string;
   workspaceDir: string;
@@ -1365,6 +1366,7 @@ async function createConfiguredAgentSession(params: {
   platformBlockKit?: PlatformBlockKit;
 }): Promise<ConfiguredAgentSession> {
   const {
+    address,
     conversationId,
     conversationDir,
     workspaceDir,
@@ -1400,7 +1402,7 @@ async function createConfiguredAgentSession(params: {
   // they always agree on which profiles are launchable.
   let runnableSubagentProfiles = loadedProfiles.profiles;
   const resolvedPackages = resolveConversationPackages({
-    conversationId,
+    address,
     stateDir: effectiveStateDir(),
     conversationDir,
   });
@@ -1410,7 +1412,7 @@ async function createConfiguredAgentSession(params: {
   const extensionsResult = await loadExtensions({
     dirs: resolvedPackages.extensionDirs,
     roots: resolvedPackages.extensionRoots,
-    context: { conversationId, workspaceDir, model, thinkingLevel },
+    context: { address, conversationId, workspaceDir, model, thinkingLevel },
     services: buildExtensionHostServices({
       workspaceDir,
       vaultManager,
@@ -1567,7 +1569,7 @@ async function prepareRunContext(params: {
   const projection = resolveWorkspaceProjection(join(conversationDir, ".."), message.address);
   const memory = await getMemory(projection);
   const skills = mergeExtensionSkills(
-    loadMikanSkills(conversationId, conversationDir, pathContext.runtimeWorkspaceRoot, projection),
+    loadMikanSkills(message.address, conversationDir, pathContext.runtimeWorkspaceRoot, projection),
     params.extensionSkills ?? [],
   );
   const triggerAttribution = resolveTriggerAttribution(message);
@@ -2091,7 +2093,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
     platformBlockKit,
     platformToolPackFactories,
   } = options;
-  const agentConfig = resolveConversationSettings({ conversationId, conversationDir });
+  const agentConfig = resolveConversationSettings({ address: options.address, conversationDir });
 
   const workspaceBase = join(conversationDir, "..");
   const projection = resolveWorkspaceProjection(workspaceBase, options.address);
@@ -2134,7 +2136,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
   // Initial system prompt (will be updated each run with fresh memory/channels/users/skills)
   const memory = await getMemory(projection);
   const skills = loadMikanSkills(
-    conversationId,
+    options.address,
     conversationDir,
     pathContext.runtimeWorkspaceRoot,
     projection,
@@ -2173,6 +2175,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
   const chatSessionManager = new ChatHistorySync();
   const { session, extensionSkills, extensionRegistry, disposeExtensions } =
     await createConfiguredAgentSession({
+      address: options.address,
       conversationId,
       conversationDir,
       workspaceDir,

--- a/src/cli/ext-dev.ts
+++ b/src/cli/ext-dev.ts
@@ -101,14 +101,9 @@ export async function runExtDevCommand(argv: string[]): Promise<number> {
   // Declaring the working copy as this conversation's package is what makes
   // the dev loop use the real resolution path rather than a bespoke one.
   process.env.MIKAN_STATE_DIR = stateDir;
+  const devAddress = createOfficeAddress("slack", conversationId);
   updateConversationSettings(
-    {
-      conversationId,
-      conversationDir: conversationOfficeDir(
-        workingDir,
-        createOfficeAddress("slack", conversationId),
-      ),
-    },
+    { address: devAddress, conversationDir: conversationOfficeDir(workingDir, devAddress) },
     { packages: [source] },
   );
 

--- a/src/cli/ext.ts
+++ b/src/cli/ext.ts
@@ -21,6 +21,8 @@ import {
 import { resolveStateDir, takeValueFlag } from "./arg-grammar.js";
 import { runExtDevCommand } from "./ext-dev.js";
 import { parseGitSource, resolveGitSource } from "./ext-git.js";
+import { officeStateDir } from "../office-address.js";
+import { resolveOwnedOfficeAddress } from "../office-registry.js";
 
 interface ExtArgs {
   action?: string;
@@ -58,7 +60,10 @@ function scopeExtensionsDir(args: ExtArgs): string {
   if (args.scope === "global") return join(args.stateDir, "global", "extensions");
   if (args.scope === "conversation" && args.conversationId) {
     // defaultExtensionDirs returns [global, conversation]; take the conversation one.
-    return defaultExtensionDirs(args.conversationId, args.stateDir)[1];
+    return defaultExtensionDirs(
+      resolveOwnedOfficeAddress(args.conversationId, args.stateDir),
+      args.stateDir,
+    )[1];
   }
   throw new Error("Specify a scope: --global or --conversation <id>");
 }
@@ -169,7 +174,14 @@ async function installResolved(args: ExtArgs, source: string, destDir: string): 
   const dataDir =
     args.scope === "global"
       ? join(args.stateDir, "global", "extension-data", result.slug)
-      : join(args.stateDir, "conversations", args.conversationId!, "extension-data", result.slug);
+      : join(
+          officeStateDir(
+            args.stateDir,
+            resolveOwnedOfficeAddress(args.conversationId!, args.stateDir),
+          ),
+          "extension-data",
+          result.slug,
+        );
   const verb = replaced ? "Reinstalled" : "Installed";
   console.log(`\n${verb} ${result.name} (slug: ${result.slug}) for ${scopeLabel}.`);
   console.log(`  code: ${dest}`);
@@ -181,7 +193,10 @@ async function installResolved(args: ExtArgs, source: string, destDir: string): 
 function listAction(args: ExtArgs): number {
   // List the requested scope, or both when no conversation is given.
   const dirs = args.conversationId
-    ? defaultExtensionDirs(args.conversationId, args.stateDir)
+    ? defaultExtensionDirs(
+        resolveOwnedOfficeAddress(args.conversationId, args.stateDir),
+        args.stateDir,
+      )
     : [join(args.stateDir, "global", "extensions")];
   const installed = listInstalledExtensions(dirs);
   if (installed.length === 0) {

--- a/src/commands/extensions.ts
+++ b/src/commands/extensions.ts
@@ -23,7 +23,7 @@ export class ExtensionsCommandHandler implements CommandHandler {
     const matched = matchCommand(context.commandText, EXTENSIONS_COMMANDS, { stripMention: true });
     if (!matched) return false;
 
-    const dirs = defaultExtensionDirs(context.conversationId, effectiveStateDir());
+    const dirs = defaultExtensionDirs(context.address, effectiveStateDir());
     const installed = listInstalledExtensions(dirs);
 
     // A root-level index file means an extension's contents were copied into

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -101,7 +101,7 @@ export class ModelCommandHandler implements CommandHandler {
     }
 
     const settingsScope = {
-      conversationId: context.address.conversationId,
+      address: context.address,
       conversationDir: conversationOfficeDir(context.services.workingDir, context.address),
     };
     if (!parsed.provider || !parsed.model) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,8 @@ export class MissingGlobalSettingsError extends Error {
 
 export type { AgentConfig, AutoReplyConfig, JudgeModelConfig, SandboxSettings } from "./types.js";
 import type { AgentConfig, AutoReplyConfig, JudgeModelConfig, SandboxSettings } from "./types.js";
+import { officeStateDir } from "./office-address.js";
+import type { OfficeAddress } from "./types.js";
 
 const ONBOARD_SETTINGS: SettingsFileConfig = {
   llm: {
@@ -283,29 +285,14 @@ export function loadGlobalSettings(): AgentConfig {
 }
 
 /**
- * Explicit identity for conversation-settings access. The state-dir key is the
- * raw conversation id (its migration is tracked by ADR 0005); the workspace
- * directory is only the legacy pre-host-migration settings location. Callers
- * name both — the key is never inferred from the directory basename, which
- * the storage migration will rename to the office key.
+ * Explicit identity for conversation-settings access. The state-dir key is
+ * the office key derived from the address; the workspace directory is only
+ * the legacy pre-host-migration settings location. Callers name both — the
+ * key is never inferred from the directory basename.
  */
 export interface ConversationSettingsScope {
-  conversationId: string;
+  address: OfficeAddress;
   conversationDir: string;
-}
-
-function assertSettingsConversationId(conversationId: string): string {
-  if (
-    conversationId.length === 0 ||
-    conversationId === "." ||
-    conversationId === ".." ||
-    conversationId.includes("/") ||
-    conversationId.includes("\\") ||
-    conversationId.includes("\0")
-  ) {
-    throw new Error("Conversation settings id must be a safe path segment");
-  }
-  return conversationId;
 }
 
 /**
@@ -326,8 +313,7 @@ function assertSettingsConversationId(conversationId: string): string {
  * inside the sandbox, is never read again.
  */
 export function conversationSettingsPath(scope: ConversationSettingsScope): string {
-  const conversationId = assertSettingsConversationId(scope.conversationId);
-  const hostPath = join(getStateDir(), "conversations", conversationId, "settings.json");
+  const hostPath = join(officeStateDir(getStateDir(), scope.address), "settings.json");
   if (existsSync(hostPath)) {
     assertSettingsFile(hostPath, "Host conversation settings");
     return hostPath;

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -185,7 +185,7 @@ export class ActorExecutionResolver {
     // which are administrator-chosen targets and could be aimed anywhere.
     const packageMounts = this.workspaceDir
       ? conversationPackageSkillMounts({
-          conversationId: address.conversationId,
+          address,
           stateDir: effectiveStateDir(),
           conversationDir: conversationOfficeDir(this.workspaceDir, address),
         })

--- a/src/harness/extensions/loader.ts
+++ b/src/harness/extensions/loader.ts
@@ -33,6 +33,8 @@ import { loadSkillsFromDir } from "../skills.js";
 import type { MikanSkill } from "../types.js";
 import { namespaceActionIds } from "./blockkit.js";
 import { ExtensionRegistry } from "./registry.js";
+import { officeStateDir } from "../../office-address.js";
+import type { OfficeAddress } from "../../types.js";
 import type {
   ExtensionCommand,
   ExtensionDisposer,
@@ -82,12 +84,12 @@ async function importExtensionModule(entrypoint: string): Promise<unknown> {
  * `LAYOUT.md`. Conversation ids are used verbatim (see LAYOUT.md § Casing).
  */
 export function defaultExtensionDirs(
-  conversationId: string,
+  address: OfficeAddress,
   stateDir: string = join(homedir(), ".mikan"),
 ): string[] {
   return [
     join(stateDir, "global", "extensions"),
-    join(stateDir, "conversations", conversationId, "extensions"),
+    join(officeStateDir(stateDir, address), "extensions"),
   ];
 }
 
@@ -375,6 +377,7 @@ function buildExtensionApi(params: {
   const { name, slug, registry, context, services } = params;
   const stateDir = services.stateDir ?? join(homedir(), ".mikan");
   const conversationId = context.conversationId;
+  const conversationStateDir = officeStateDir(stateDir, context.address);
 
   const requireScheduleStore = () => {
     if (!services.scheduleStore) {
@@ -394,7 +397,7 @@ function buildExtensionApi(params: {
       get dataDir(): string {
         // This conversation's own data, co-located with the conversation's
         // other host-only assets; removed when the conversation is deleted.
-        const dir = join(stateDir, "conversations", conversationId, "extension-data", slug);
+        const dir = join(conversationStateDir, "extension-data", slug);
         mkdirSync(dir, { recursive: true });
         return dir;
       },

--- a/src/harness/extensions/types.ts
+++ b/src/harness/extensions/types.ts
@@ -551,6 +551,9 @@ export interface LoadExtensionsOptions {
    */
   roots?: string[];
   context: {
+    /** Office identity; host-only state keys derive from it. */
+    address: import("../../types.js").OfficeAddress;
+    /** Raw platform id — what extension code sees and platform APIs accept. */
     conversationId: string;
     workspaceDir: string;
     model: Model<Api>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,7 +281,8 @@ const officeMigration = (() => {
 if (
   officeMigration.unowned.length > 0 ||
   officeMigration.failed.length > 0 ||
-  officeMigration.vaultConflicts.length > 0
+  officeMigration.vaultConflicts.length > 0 ||
+  officeMigration.stateDirConflicts.length > 0
 ) {
   console.error(formatUnmigratedOfficesError(officeMigration));
   process.exit(1);
@@ -294,6 +295,11 @@ if (officeMigration.migrated.length > 0 || officeMigration.recovered.length > 0)
 }
 if (officeMigration.vaultKeysMigrated.length > 0) {
   console.log(`  Vault keys migrated to office keys: ${officeMigration.vaultKeysMigrated.length}.`);
+}
+if (officeMigration.stateDirsMigrated.length > 0) {
+  console.log(
+    `  Host state dirs migrated to office keys: ${officeMigration.stateDirsMigrated.length}.`,
+  );
 }
 
 try {

--- a/src/office-migration.ts
+++ b/src/office-migration.ts
@@ -1,7 +1,7 @@
-import { lstatSync, readdirSync, renameSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import * as log from "./log.js";
-import { isOfficeKey } from "./office-address.js";
+import { isOfficeKey, officeStateDir } from "./office-address.js";
 import { OfficeRegistry } from "./office-registry.js";
 import { migrateConversationVaultKeys } from "./vault/index.js";
 import type { OfficeMigrationRecord, PlatformName } from "./types.js";
@@ -25,6 +25,10 @@ export interface OfficeMigrationRunSummary {
   vaultKeysMigrated: string[];
   /** Raw ids whose legacy and office-key vault dirs both exist (manual merge). */
   vaultConflicts: string[];
+  /** Raw ids whose host state dirs (settings, extensions, data) moved. */
+  stateDirsMigrated: string[];
+  /** Raw ids whose legacy and office-key state dirs both exist (manual merge). */
+  stateDirConflicts: string[];
 }
 
 /**
@@ -53,6 +57,8 @@ export function migrateLegacyOffices(options: {
     failed: [],
     vaultKeysMigrated: [],
     vaultConflicts: [],
+    stateDirsMigrated: [],
+    stateDirConflicts: [],
   };
 
   recoverInterruptedMoves(registry, summary);
@@ -69,6 +75,8 @@ export function migrateLegacyOffices(options: {
   for (const rawConversationId of vaults.migrated) {
     log.logInfo(`[office] Migrated vault key to office key: ${rawConversationId}`);
   }
+
+  migrateConversationStateDirs(registry, options.stateDir, summary);
 
   for (const record of registry.getState().migrations) {
     if (record.status === "needs-owner") summary.unowned.push(record.rawConversationId);
@@ -149,6 +157,31 @@ function claimAndMoveLegacyDirs(
   }
 }
 
+/**
+ * Move each registered office's host state tree — settings.json, extensions,
+ * extension-data, git checkouts — from `conversations/<rawId>` to
+ * `conversations/<officeKey>` in one rename. Conflicts are reported for
+ * manual merge, never clobbered.
+ */
+function migrateConversationStateDirs(
+  registry: OfficeRegistry,
+  stateDir: string,
+  summary: OfficeMigrationRunSummary,
+): void {
+  for (const office of registry.getOffices()) {
+    const legacyDir = join(stateDir, "conversations", office.conversationId);
+    if (!existsSync(legacyDir)) continue;
+    const targetDir = officeStateDir(stateDir, office);
+    if (existsSync(targetDir)) {
+      summary.stateDirConflicts.push(office.conversationId);
+      continue;
+    }
+    renameSync(legacyDir, targetDir);
+    summary.stateDirsMigrated.push(office.conversationId);
+    log.logInfo(`[office] Migrated host state dir to office key: ${office.conversationId}`);
+  }
+}
+
 /** A migrated office is an existing office; keep the directory enumerable. */
 function recordMigratedOffice(registry: OfficeRegistry, record: OfficeMigrationRecord): void {
   if (!record.ownerPlatform) return;
@@ -217,6 +250,14 @@ export function formatUnmigratedOfficesError(summary: OfficeMigrationRunSummary)
       "These conversations have credentials under both the legacy and the",
       "office-key vault directory; merge them manually under <state-dir>/vaults:",
       ...summary.vaultConflicts.map((id) => `  - ${id}`),
+    );
+  }
+  if (summary.stateDirConflicts.length > 0) {
+    lines.push(
+      "",
+      "These conversations have host state under both the legacy and the",
+      "office-key directory; merge them manually under <state-dir>/conversations:",
+      ...summary.stateDirConflicts.map((id) => `  - ${id}`),
     );
   }
   return lines.join("\n");

--- a/src/office-registry.ts
+++ b/src/office-registry.ts
@@ -731,9 +731,12 @@ export function ensureOfficeDir(workspaceRoot: string, address: OfficeAddress): 
  * genuinely ambiguous, and an unknown id has no office to resolve — both
  * fail loudly rather than guessing a directory.
  */
-export function resolveOwnedOfficeAddress(rawConversationId: string): OfficeAddress {
+export function resolveOwnedOfficeAddress(
+  rawConversationId: string,
+  stateDir: string = effectiveStateDir(),
+): OfficeAddress {
   assertConversationId(rawConversationId);
-  const registry = registryFor(effectiveStateDir());
+  const registry = registryFor(stateDir);
 
   const owners = () =>
     registry.getState().offices.filter((record) => record.conversationId === rawConversationId);

--- a/src/packages/admin.ts
+++ b/src/packages/admin.ts
@@ -11,7 +11,7 @@
  * Activation stays where it was: the next harness instance (`/pi-new`) picks
  * up what is on disk. Only the failure reporting moves earlier.
  */
-import { applyConversationSettingsByRawId, applyGlobalSettings } from "../settings-mutation.js";
+import { applyConversationSettings, applyGlobalSettings } from "../settings-mutation.js";
 import { formatSource, parseSource, sourceIdentity } from "./source.js";
 import { materializeSource } from "./materialize.js";
 import { declaredSources } from "./inspect.js";
@@ -32,7 +32,7 @@ export function addPackage(
   const source = formatSource(parseSource(rawSource));
   const materialized = materializeSource(source, {
     scope,
-    conversationId: context.conversationId,
+    address: context.address,
     stateDir: context.stateDir,
     mode: "fetch",
   });
@@ -73,7 +73,7 @@ export function refreshPackage(
   }
   const materialized = materializeSource(rawSource, {
     scope,
-    conversationId: context.conversationId,
+    address: context.address,
     stateDir: context.stateDir,
     mode: "refresh",
   });
@@ -113,11 +113,8 @@ function writePackages(
     applyGlobalSettings(context.runtime, { packages });
     return;
   }
-  const result = applyConversationSettingsByRawId(
-    context.runtime,
-    context.workingDir,
-    context.conversationId,
-    { packages },
-  );
+  const result = applyConversationSettings(context.runtime, context.workingDir, context.address, {
+    packages,
+  });
   if (!result.ok) throw new Error("Conversation is busy; try again when the current run ends");
 }

--- a/src/packages/inspect.ts
+++ b/src/packages/inspect.ts
@@ -55,7 +55,7 @@ export function declaredSources(scope: PackageScope, options: ResolvePackagesOpt
       scope === "global"
         ? loadGlobalSettings()
         : resolveConversationSettings({
-            conversationId: options.conversationId,
+            address: options.address,
             conversationDir: options.conversationDir,
           });
     return settings.packages ?? [];
@@ -91,7 +91,7 @@ async function describe(
   try {
     dir = materializeSource(source, {
       scope,
-      conversationId: options.conversationId,
+      address: options.address,
       stateDir: options.stateDir,
       mode: "offline",
     }).dir;

--- a/src/packages/materialize.ts
+++ b/src/packages/materialize.ts
@@ -18,6 +18,8 @@ import { dirname, join } from "node:path";
 import { ensureDirExists, readTextFileIfExists } from "../utils/file-guards.js";
 import * as log from "../log.js";
 import { gitRepoPath, parseSource, sourceIdentity } from "./source.js";
+import { officeStateDir } from "../office-address.js";
+import type { OfficeAddress } from "../types.js";
 import type {
   MaterializeMode,
   MaterializeOptions,
@@ -57,13 +59,12 @@ const MATERIALIZED_REF_FILE = "mikan-ref";
  */
 export function packageScopeDir(
   scope: PackageScope,
-  conversationId: string | undefined,
+  address: OfficeAddress | undefined,
   stateDir: string,
 ): string {
   if (scope === "global") return join(stateDir, "global");
-  if (!conversationId) throw new Error("A conversation-scoped package needs a conversation id");
-  assertSafePathSegment(conversationId);
-  return join(stateDir, "conversations", conversationId);
+  if (!address) throw new Error("A conversation-scoped package needs an office address");
+  return officeStateDir(stateDir, address);
 }
 
 /**
@@ -94,7 +95,7 @@ export function materializeSource(
   options: MaterializeOptions,
 ): MaterializedPackage {
   const parsed = parseSource(source);
-  const scopeDir = packageScopeDir(options.scope, options.conversationId, options.stateDir);
+  const scopeDir = packageScopeDir(options.scope, options.address, options.stateDir);
   const dir =
     parsed.type === "local"
       ? materializeLocal(parsed)
@@ -320,17 +321,4 @@ function gitErrorText(err: unknown): string {
     if (text) return text.split("\n").slice(-3).join(" ");
   }
   return err instanceof Error ? err.message : String(err);
-}
-
-function assertSafePathSegment(value: string): void {
-  if (
-    value.length === 0 ||
-    value === "." ||
-    value === ".." ||
-    value.includes("/") ||
-    value.includes("\\") ||
-    value.includes("\0")
-  ) {
-    throw new Error("Conversation id must be a safe path segment");
-  }
 }

--- a/src/packages/resolve.ts
+++ b/src/packages/resolve.ts
@@ -89,10 +89,7 @@ export function conversationPackageSkillMounts(
  * dedups, and reports the directories to load from.
  */
 export function resolveConversationPackages(options: ResolvePackagesOptions): ResolvedPackages {
-  const declarations = [
-    ...readScope("global", undefined, options),
-    ...readScope("conversation", options.conversationId, options),
-  ];
+  const declarations = [...readScope("global", options), ...readScope("conversation", options)];
 
   const errors: PackageError[] = [];
   const byIdentity = new Map<string, MaterializedPackage>();
@@ -132,17 +129,13 @@ interface Declaration {
   scope: PackageScope;
 }
 
-function readScope(
-  scope: PackageScope,
-  conversationId: string | undefined,
-  options: ResolvePackagesOptions,
-): Declaration[] {
+function readScope(scope: PackageScope, options: ResolvePackagesOptions): Declaration[] {
   try {
     const sources =
       scope === "global"
         ? loadGlobalSettings().packages
         : resolveConversationSettings({
-            conversationId: options.conversationId,
+            address: options.address,
             conversationDir: options.conversationDir,
           }).packages;
     return (sources ?? []).map((source) => ({ source, scope }));
@@ -150,7 +143,6 @@ function readScope(
     // Unreadable settings must not take the conversation down; the other
     // scope, and the convention directories, still load.
     log.logWarning(`Could not read ${scope} package list`, messageOf(err));
-    void conversationId;
     return [];
   }
 }
@@ -163,7 +155,7 @@ function materialize(
   try {
     return materializeSource(declaration.source, {
       scope: declaration.scope,
-      conversationId: options.conversationId,
+      address: options.address,
       stateDir: options.stateDir,
       mode: options.fetchMissing ? "fetch" : "offline",
     });
@@ -183,10 +175,7 @@ function materialize(
 function scopeConventionDirs(options: ResolvePackagesOptions): string[] {
   return [
     join(packageScopeDir("global", undefined, options.stateDir), EXTENSIONS_SUBDIR),
-    join(
-      packageScopeDir("conversation", options.conversationId, options.stateDir),
-      EXTENSIONS_SUBDIR,
-    ),
+    join(packageScopeDir("conversation", options.address, options.stateDir), EXTENSIONS_SUBDIR),
   ];
 }
 

--- a/src/packages/types.ts
+++ b/src/packages/types.ts
@@ -76,7 +76,8 @@ export interface PackageSkillDir {
 }
 
 export interface ResolvePackagesOptions {
-  conversationId: string;
+  /** Office whose packages resolve; state-dir keys derive from it. */
+  address: import("../types.js").OfficeAddress;
   stateDir: string;
   conversationDir: string;
   fetchMissing?: boolean;
@@ -86,7 +87,7 @@ export type MaterializeMode = "offline" | "fetch" | "refresh";
 
 export interface MaterializeOptions {
   scope: PackageScope;
-  conversationId?: string;
+  address?: import("../types.js").OfficeAddress;
   stateDir: string;
   mode?: MaterializeMode;
 }

--- a/src/settings-mutation.ts
+++ b/src/settings-mutation.ts
@@ -53,7 +53,7 @@ export function applyConversationSettings(
     runtimeSwitched = true;
   }
   updateConversationSettings(
-    { conversationId, conversationDir: conversationOfficeDir(workingDir, address) },
+    { address, conversationDir: conversationOfficeDir(workingDir, address) },
     patch,
   );
   return { ok: true, runtimeSwitched };

--- a/src/tools/event.ts
+++ b/src/tools/event.ts
@@ -202,11 +202,17 @@ export function createEventTool(eventStore: EventStore): {
 
       if (action === "list") {
         const events = await eventStore.list();
-        const conversationId = eventContext.conversationId;
+        const { conversationId, platform } = eventContext;
         const scopedEvents =
           params.scope === "all"
             ? events
-            : events.filter((event) => event.payload?.conversationId === conversationId);
+            : events.filter(
+                (event) =>
+                  event.payload?.conversationId === conversationId &&
+                  // Same raw id on another platform is another office. Files
+                  // written before payloads carried a platform stay visible.
+                  (event.payload.platform === undefined || event.payload.platform === platform),
+              );
         return {
           content: [
             {

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -90,7 +90,7 @@ async function judgeAutoReplyWithLlm(input: {
   conversationDir: string;
 }): Promise<boolean> {
   const judgeConfig = loadAutoReplyJudgeModel({
-    conversationId: input.event.address.conversationId,
+    address: input.event.address,
     conversationDir: input.conversationDir,
   });
   const models = MikanModels.create();

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -591,7 +591,10 @@ function serveConversationState(
 
   const dir = resolveLegacyOfficeDir(workingDir, conversationId);
   const globalConfig = loadGlobalSettings();
-  const conversationConfig = resolveConversationSettings({ conversationId, conversationDir: dir });
+  const conversationConfig = resolveConversationSettings({
+    address: resolveOwnedOfficeAddress(conversationId),
+    conversationDir: dir,
+  });
   const conversationWorkspace = legacyResolveWorkspaceProjection(workingDir, conversationId);
   const globalWorkspaceSettings = globalConfig.sandbox?.workspace;
   const autoReply = loadConversationAutoReplyConfig(dir);
@@ -1297,7 +1300,7 @@ async function servePackagesList(
   if (!workingDir) return;
   try {
     const inventory = await inspectConversationPackages({
-      conversationId: scope.conversationId,
+      address: resolveOwnedOfficeAddress(scope.conversationId),
       stateDir: effectiveStateDir(),
       conversationDir: resolveLegacyOfficeDir(workingDir, scope.conversationId),
     });
@@ -1338,7 +1341,7 @@ function servePackageMutation(
   if (!workingDir) return;
 
   const context = {
-    conversationId: scope.conversationId,
+    address: resolveOwnedOfficeAddress(scope.conversationId),
     stateDir: effectiveStateDir(),
     conversationDir: resolveLegacyOfficeDir(workingDir, scope.conversationId),
     workingDir,

--- a/src/workspace-projection/index.ts
+++ b/src/workspace-projection/index.ts
@@ -120,10 +120,7 @@ function resolveEffectiveWorkspace(
   if (!hostWorkspaceRoot) return fallback;
 
   try {
-    const settings = resolveConversationSettings({
-      conversationId: address.conversationId,
-      conversationDir,
-    }).sandbox;
+    const settings = resolveConversationSettings({ address, conversationDir }).sandbox;
     if (settings?.workspace) {
       return normalizeWorkspace(settings.workspace.doorPolicy, settings.workspace.layout);
     }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -653,7 +653,12 @@ describe("ExtensionsCommandHandler", () => {
   });
 
   test("warns about an index file at the scope root instead of listing it wrongly", async () => {
-    const convDir = join(stateDir, "conversations", "C123", "extensions");
+    const convDir = join(
+      stateDir,
+      "conversations",
+      officeKey(createOfficeAddress("slack", "C123")),
+      "extensions",
+    );
     mkdirSync(convDir, { recursive: true });
     // Mis-install: extension contents copied into the scope dir itself.
     writeFileSync(join(convDir, "index.mjs"), "export default function activate() {}\n");
@@ -679,7 +684,12 @@ describe("ExtensionsCommandHandler", () => {
       "---\nname: triage\ndescription: d\n---\nbody\n",
     );
     // conversation-scoped: bare file form
-    const convDir = join(stateDir, "conversations", "C123", "extensions");
+    const convDir = join(
+      stateDir,
+      "conversations",
+      officeKey(createOfficeAddress("slack", "C123")),
+      "extensions",
+    );
     mkdirSync(convDir, { recursive: true });
     writeFileSync(join(convDir, "audit.mjs"), "export default function activate() {}\n");
     // side-effect canary: activation must NOT run during listing
@@ -763,7 +773,7 @@ describe("SandboxCommandHandler", () => {
     expect(
       existsSync(
         conversationSettingsPath({
-          conversationId: "C123",
+          address: createOfficeAddress("slack", "C123"),
           conversationDir: join(workingDir, "C123"),
         }),
       ),
@@ -772,7 +782,7 @@ describe("SandboxCommandHandler", () => {
       JSON.parse(
         readFileSync(
           conversationSettingsPath({
-            conversationId: "C123",
+            address: createOfficeAddress("slack", "C123"),
             conversationDir: join(workingDir, "C123"),
           }),
           "utf-8",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { createOfficeAddress } from "../src/office-address.js";
 import {
   assertStateDirOutsideWorkspace,
   conversationSettingsPath,
@@ -184,16 +185,19 @@ describe("loadGlobalSettings", () => {
       "utf-8",
     );
 
-    expect(() => resolveConversationSettings({ conversationId: "C123", conversationDir })).toThrow(
-      /Malformed settings file.*workspaceMount/,
-    );
+    expect(() =>
+      resolveConversationSettings({
+        address: createOfficeAddress("slack", "C123"),
+        conversationDir,
+      }),
+    ).toThrow(/Malformed settings file.*workspaceMount/);
   });
 
   test("conversation model config overrides global provider and model only", () => {
     updateGlobalSettings({ provider: "anthropic", model: "claude-sonnet-4-6" });
     const conversationDir = join(stateDir, "workspace", "C123");
     updateConversationSettings(
-      { conversationId: "C123", conversationDir },
+      { address: createOfficeAddress("slack", "C123"), conversationDir },
       {
         provider: "openai",
         model: "gpt-4o",
@@ -201,7 +205,10 @@ describe("loadGlobalSettings", () => {
       },
     );
 
-    const config = resolveConversationSettings({ conversationId: "C123", conversationDir });
+    const config = resolveConversationSettings({
+      address: createOfficeAddress("slack", "C123"),
+      conversationDir,
+    });
     expect(config.provider).toBe("openai");
     expect(config.model).toBe("gpt-4o");
     expect(config.thinkingLevel).toBe("low");
@@ -211,7 +218,10 @@ describe("loadGlobalSettings", () => {
     expect(
       JSON.parse(
         readFileSync(
-          conversationSettingsPath({ conversationId: "C123", conversationDir }),
+          conversationSettingsPath({
+            address: createOfficeAddress("slack", "C123"),
+            conversationDir,
+          }),
           "utf-8",
         ),
       ),
@@ -224,16 +234,22 @@ describe("loadGlobalSettings", () => {
     createGlobalSettingsFile(stateDir);
     const conversationDir = join(stateDir, "workspace", "C123");
     updateConversationSettings(
-      { conversationId: "C123", conversationDir },
+      { address: createOfficeAddress("slack", "C123"), conversationDir },
       { sandbox: { image: { workspaceMount: "full" } } },
     );
 
-    const config = resolveConversationSettings({ conversationId: "C123", conversationDir });
+    const config = resolveConversationSettings({
+      address: createOfficeAddress("slack", "C123"),
+      conversationDir,
+    });
     expect(config.sandbox?.image?.workspaceMount).toBe("full");
     expect(
       JSON.parse(
         readFileSync(
-          conversationSettingsPath({ conversationId: "C123", conversationDir }),
+          conversationSettingsPath({
+            address: createOfficeAddress("slack", "C123"),
+            conversationDir,
+          }),
           "utf-8",
         ),
       ),
@@ -247,13 +263,16 @@ describe("loadGlobalSettings", () => {
     updateGlobalSettings({ sandbox: { cpus: "1", boost: { cpus: "4" } } });
     const conversationDir = join(stateDir, "workspace", "C123");
     updateConversationSettings(
-      { conversationId: "C123", conversationDir },
+      { address: createOfficeAddress("slack", "C123"), conversationDir },
       {
         sandbox: { memory: "2g", boost: { memory: "8g" } },
       },
     );
 
-    const config = resolveConversationSettings({ conversationId: "C123", conversationDir });
+    const config = resolveConversationSettings({
+      address: createOfficeAddress("slack", "C123"),
+      conversationDir,
+    });
     // Global sandbox.cpus survives a conversation that only sets sandbox.memory.
     expect(config.sandbox?.cpus).toBe("1");
     expect(config.sandbox?.memory).toBe("2g");
@@ -266,16 +285,22 @@ describe("loadGlobalSettings", () => {
     updateGlobalSettings({ slack: { replyMode: "top-level" } });
     const conversationDir = join(stateDir, "workspace", "C123");
     updateConversationSettings(
-      { conversationId: "C123", conversationDir },
+      { address: createOfficeAddress("slack", "C123"), conversationDir },
       { slack: { replyMode: "thread" } },
     );
 
-    const config = resolveConversationSettings({ conversationId: "C123", conversationDir });
+    const config = resolveConversationSettings({
+      address: createOfficeAddress("slack", "C123"),
+      conversationDir,
+    });
     expect(config.slack?.replyMode).toBe("thread");
     expect(
       JSON.parse(
         readFileSync(
-          conversationSettingsPath({ conversationId: "C123", conversationDir }),
+          conversationSettingsPath({
+            address: createOfficeAddress("slack", "C123"),
+            conversationDir,
+          }),
           "utf-8",
         ),
       ),
@@ -291,13 +316,21 @@ describe("loadGlobalSettings", () => {
     const legacyPath = join(conversationDir, "settings.json");
     writeFileSync(legacyPath, JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }));
 
-    const config = resolveConversationSettings({ conversationId: "C123", conversationDir });
+    const config = resolveConversationSettings({
+      address: createOfficeAddress("slack", "C123"),
+      conversationDir,
+    });
     expect(config.sandbox?.image?.workspaceMount).toBe("full");
     // Legacy file was moved out of the (sandbox-mounted) conversation dir.
     expect(existsSync(legacyPath)).toBe(false);
-    expect(existsSync(conversationSettingsPath({ conversationId: "C123", conversationDir }))).toBe(
-      true,
-    );
+    expect(
+      existsSync(
+        conversationSettingsPath({
+          address: createOfficeAddress("slack", "C123"),
+          conversationDir,
+        }),
+      ),
+    ).toBe(true);
   });
 
   test("a legacy settings.json appearing after migration is never read (sandbox plant)", () => {
@@ -308,7 +341,10 @@ describe("loadGlobalSettings", () => {
     // First access with no legacy file writes the migration marker.
     // Global onboarding now defaults to an isolated office.
     expect(
-      resolveConversationSettings({ conversationId: "C123", conversationDir }).sandbox?.workspace,
+      resolveConversationSettings({
+        address: createOfficeAddress("slack", "C123"),
+        conversationDir,
+      }).sandbox?.workspace,
     ).toEqual({
       doorPolicy: "isolated",
     });
@@ -320,7 +356,10 @@ describe("loadGlobalSettings", () => {
       JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }),
     );
     expect(
-      resolveConversationSettings({ conversationId: "C123", conversationDir }).sandbox?.workspace,
+      resolveConversationSettings({
+        address: createOfficeAddress("slack", "C123"),
+        conversationDir,
+      }).sandbox?.workspace,
     ).toEqual({
       doorPolicy: "isolated",
     });

--- a/test/event-tool.test.ts
+++ b/test/event-tool.test.ts
@@ -190,6 +190,36 @@ describe("createEventTool", () => {
     expect(allResult.content[0]?.text).toContain("Visible only globally");
   });
 
+  test("conversation scope excludes another platform's identically named office", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1700000000003);
+    const workspaceDir = makeWorkspace();
+    const { tool, setEventContext } = createWorkspaceEventTool(workspaceDir);
+    setEventContext({
+      platform: "discord",
+      conversationId: "900100",
+      conversationKind: "shared",
+      userId: "U123",
+    });
+    await tool.execute("call-1", {
+      type: "immediate",
+      text: "Discord office schedule",
+      filenamePrefix: "discord-office",
+    });
+
+    setEventContext({
+      platform: "telegram",
+      conversationId: "900100",
+      conversationKind: "shared",
+      userId: "U123",
+    });
+    const scoped = await tool.execute("call-2", { action: "list" });
+    expect(scoped.content[0]?.text).not.toContain("Discord office schedule");
+
+    // The workspace scheduling bus stays fully visible on request.
+    const all = await tool.execute("call-3", { action: "list", scope: "all" });
+    expect(all.content[0]?.text).toContain("Discord office schedule");
+  });
+
   test("supports list, read, update, and delete", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1700000000003);
     const workspaceDir = makeWorkspace();

--- a/test/ext-cli.test.ts
+++ b/test/ext-cli.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { runExtCommand } from "../src/cli/ext.js";
+import { createOfficeAddress, officeKey } from "../src/office-address.js";
+import { OfficeRegistry } from "../src/office-registry.js";
 
 let stateDir: string;
 let srcDir: string;
@@ -37,6 +39,13 @@ function captureOut(): { log: string[]; err: string[]; restore: () => void } {
 }
 
 describe("mikan ext CLI", () => {
+  // The CLI resolves raw conversation ids through the office registry.
+  beforeEach(() => {
+    const registry = new OfficeRegistry(stateDir);
+    registry.recordOffice(createOfficeAddress("slack", "D0AKS5AHX89"));
+    registry.recordOffice(createOfficeAddress("slack", "C1"));
+  });
+
   test("install places code under the conversation scope and reports data path", async () => {
     const source = writeExtension("agent-pm");
     const out = captureOut();
@@ -53,7 +62,14 @@ describe("mikan ext CLI", () => {
     expect(code).toBe(0);
     expect(
       existsSync(
-        join(stateDir, "conversations", "D0AKS5AHX89", "extensions", "agent-pm", "index.mjs"),
+        join(
+          stateDir,
+          "conversations",
+          officeKey(createOfficeAddress("slack", "D0AKS5AHX89")),
+          "extensions",
+          "agent-pm",
+          "index.mjs",
+        ),
       ),
     ).toBe(true);
     expect(out.log.join("\n")).toMatch(/slug: agent-pm/);
@@ -101,9 +117,21 @@ describe("mikan ext CLI", () => {
   test("remove deletes code and leaves data", async () => {
     const source = writeExtension("agent-pm");
     await runExtCommand(["install", source, "--conversation", "C1", "--state-dir", stateDir]);
-    const codeDir = join(stateDir, "conversations", "C1", "extensions", "agent-pm");
+    const codeDir = join(
+      stateDir,
+      "conversations",
+      officeKey(createOfficeAddress("slack", "C1")),
+      "extensions",
+      "agent-pm",
+    );
     // Simulate data written on first use.
-    const dataDir = join(stateDir, "conversations", "C1", "extension-data", "agent-pm");
+    const dataDir = join(
+      stateDir,
+      "conversations",
+      officeKey(createOfficeAddress("slack", "C1")),
+      "extension-data",
+      "agent-pm",
+    );
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "db"), "x");
 

--- a/test/extension-blockkit.test.ts
+++ b/test/extension-blockkit.test.ts
@@ -7,11 +7,13 @@ import { namespaceActionIds, parseExtActionId } from "../src/harness/extensions/
 import { ExtensionRegistry } from "../src/harness/extensions/registry.js";
 import { loadExtensions } from "../src/harness/extensions/loader.js";
 import type { ExtensionBlockAction } from "../src/harness/extensions/types.js";
+import { createOfficeAddress } from "../src/office-address.js";
 
 let dir: string;
 
 const testModel = { id: "test", name: "Test" } as Model<Api>;
 const context = {
+  address: createOfficeAddress("slack", "C123"),
   conversationId: "C123",
   workspaceDir: "/work",
   model: testModel,

--- a/test/harness-extensions.test.ts
+++ b/test/harness-extensions.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../src/harness/index.js";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Api, Model, Usage } from "@earendil-works/pi-ai";
+import { createOfficeAddress, officeKey } from "../src/office-address.js";
 
 let dir: string;
 
@@ -30,6 +31,7 @@ const testModel = {
 } as Model<Api>;
 
 const context = {
+  address: createOfficeAddress("slack", "C123"),
   conversationId: "C123",
   workspaceDir: "/work",
   model: testModel,
@@ -45,20 +47,25 @@ afterEach(() => {
 });
 
 describe("defaultExtensionDirs", () => {
-  test("returns host-only global then per-conversation code dirs under the state dir", () => {
-    expect(defaultExtensionDirs("C123", "/state")).toEqual([
+  test("returns host-only global then per-office code dirs under the state dir", () => {
+    const address = createOfficeAddress("slack", "C123");
+    expect(defaultExtensionDirs(address, "/state")).toEqual([
       join("/state", "global", "extensions"),
-      join("/state", "conversations", "C123", "extensions"),
+      join("/state", "conversations", officeKey(address), "extensions"),
     ]);
   });
 
-  test("uses the conversation id verbatim (no lowercasing)", () => {
-    const [, convDir] = defaultExtensionDirs("C0AbC123", "/state");
-    expect(convDir).toBe(join("/state", "conversations", "C0AbC123", "extensions"));
+  test("separates platforms sharing a raw conversation id", () => {
+    const [, discordDir] = defaultExtensionDirs(createOfficeAddress("discord", "900100"), "/state");
+    const [, telegramDir] = defaultExtensionDirs(
+      createOfficeAddress("telegram", "900100"),
+      "/state",
+    );
+    expect(discordDir).not.toBe(telegramDir);
   });
 
   test("defaults the state dir to ~/.mikan", () => {
-    const [globalDir] = defaultExtensionDirs("C123");
+    const [globalDir] = defaultExtensionDirs(createOfficeAddress("slack", "C123"));
     expect(globalDir.endsWith(join(".mikan", "global", "extensions"))).toBe(true);
   });
 });
@@ -340,7 +347,16 @@ describe("loadExtensions v2 api", () => {
     expect(errors).toHaveLength(0);
     const { dataDir, sharedDataDir } = probe.read() as { dataDir: string; sharedDataDir: string };
     // Per-conversation data lives under the conversation; shared under global.
-    expect(dataDir).toBe(join(dir, "state", "conversations", "C123", "extension-data", "probe"));
+    expect(dataDir).toBe(
+      join(
+        dir,
+        "state",
+        "conversations",
+        officeKey(createOfficeAddress("slack", "C123")),
+        "extension-data",
+        "probe",
+      ),
+    );
     expect(sharedDataDir).toBe(join(dir, "state", "global", "extension-data", "probe"));
     expect(existsSync(dataDir)).toBe(true);
     expect(existsSync(sharedDataDir)).toBe(true);

--- a/test/office-migration.test.ts
+++ b/test/office-migration.test.ts
@@ -57,6 +57,8 @@ describe("migrateLegacyOffices", () => {
       failed: [],
       vaultKeysMigrated: [],
       vaultConflicts: [],
+      stateDirsMigrated: [],
+      stateDirConflicts: [],
     });
     expect(new OfficeRegistry(stateDir).getState().enabledPlatforms).toEqual(["slack"]);
   });
@@ -107,6 +109,8 @@ describe("migrateLegacyOffices", () => {
       failed: [],
       vaultKeysMigrated: [],
       vaultConflicts: [],
+      stateDirsMigrated: [],
+      stateDirConflicts: [],
     });
   });
 
@@ -295,6 +299,44 @@ describe("migrateLegacyOffices", () => {
     for (const name of ["shared/claw", "u1-ancient", "d0ar8t4q61e"]) {
       expect(existsSync(join(stateDir, "vaults", name))).toBe(true);
     }
+  });
+
+  test("moves the host state tree (settings, extensions, data) in one rename", () => {
+    const { stateDir, workspaceRoot } = makeFixture();
+    makeLegacyOffice(workspaceRoot, "C123");
+    const legacyState = join(stateDir, "conversations", "C123");
+    mkdirSync(join(legacyState, "extension-data", "probe"), { recursive: true });
+    writeFileSync(join(legacyState, "settings.json"), "{}\n");
+
+    const summary = migrateLegacyOffices({
+      workspaceRoot,
+      stateDir,
+      enabledPlatforms: ["slack"],
+    });
+
+    expect(summary.stateDirsMigrated).toEqual(["C123"]);
+    const target = join(stateDir, "conversations", officeKey(createOfficeAddress("slack", "C123")));
+    expect(existsSync(join(target, "settings.json"))).toBe(true);
+    expect(existsSync(join(target, "extension-data", "probe"))).toBe(true);
+    expect(existsSync(legacyState)).toBe(false);
+  });
+
+  test("reports a state-dir conflict instead of clobbering either side", () => {
+    const { stateDir, workspaceRoot } = makeFixture();
+    makeLegacyOffice(workspaceRoot, "C123");
+    mkdirSync(join(stateDir, "conversations", "C123"), { recursive: true });
+    mkdirSync(join(stateDir, "conversations", officeKey(createOfficeAddress("slack", "C123"))), {
+      recursive: true,
+    });
+
+    const summary = migrateLegacyOffices({
+      workspaceRoot,
+      stateDir,
+      enabledPlatforms: ["slack"],
+    });
+
+    expect(summary.stateDirConflicts).toEqual(["C123"]);
+    expect(formatUnmigratedOfficesError(summary)).toContain("<state-dir>/conversations");
   });
 
   test("already office-key-shaped directories are left alone", () => {

--- a/test/packages-admin.test.ts
+++ b/test/packages-admin.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { createOfficeAddress, officeDirName } from "../src/office-address.js";
+import { createOfficeAddress, officeDirName, officeKey } from "../src/office-address.js";
 import { OfficeRegistry } from "../src/office-registry.js";
 import {
   addPackage,
@@ -26,7 +26,7 @@ function globalSettingsFile(): string {
 }
 
 function conversationSettingsFile(): string {
-  return join(stateDir, "conversations", CONVERSATION_ID, "settings.json");
+  return join(stateDir, "conversations", officeKey(CONVERSATION_ADDRESS), "settings.json");
 }
 
 function readPackages(path: string): string[] {
@@ -39,7 +39,7 @@ function readPackages(path: string): string[] {
 
 function context() {
   return {
-    conversationId: CONVERSATION_ID,
+    address: CONVERSATION_ADDRESS,
     stateDir,
     conversationDir: join(workingDir, officeDirName(CONVERSATION_ADDRESS)),
     workingDir,

--- a/test/packages-materialize.test.ts
+++ b/test/packages-materialize.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { gitCloneDir, materializeSource, packageScopeDir } from "../src/packages/index.js";
+import { createOfficeAddress, officeKey } from "../src/office-address.js";
 
 function run(cwd: string, args: string[]): string {
   return execFileSync("git", args, {
@@ -57,10 +58,19 @@ describe("materializeSource", () => {
   test("clones into the conversation scope's git dir", () => {
     const result = materializeSource(source, {
       scope: "conversation",
-      conversationId: "C03045VJJAY",
+      address: createOfficeAddress("slack", "C03045VJJAY"),
       stateDir,
     });
-    expect(result.dir.startsWith(join(stateDir, "conversations", "C03045VJJAY", "git"))).toBe(true);
+    expect(
+      result.dir.startsWith(
+        join(
+          stateDir,
+          "conversations",
+          officeKey(createOfficeAddress("slack", "C03045VJJAY")),
+          "git",
+        ),
+      ),
+    ).toBe(true);
   });
 
   test("checkout keys share a ref across subpaths and isolate other refs", () => {
@@ -234,14 +244,19 @@ describe("materializeSource", () => {
 describe("packageScopeDir", () => {
   test("global and conversation scopes are siblings under the state dir", () => {
     expect(packageScopeDir("global", undefined, "/s")).toBe("/s/global");
-    expect(packageScopeDir("conversation", "C1", "/s")).toBe("/s/conversations/C1");
+    expect(packageScopeDir("conversation", createOfficeAddress("slack", "C1"), "/s")).toBe(
+      `/s/conversations/${officeKey(createOfficeAddress("slack", "C1"))}`,
+    );
   });
 
-  test("a conversation scope needs an id", () => {
-    expect(() => packageScopeDir("conversation", undefined, "/s")).toThrow(/conversation id/);
+  test("a conversation scope needs an office address", () => {
+    expect(() => packageScopeDir("conversation", undefined, "/s")).toThrow(/office address/);
   });
 
-  test("a conversation id that is not a safe path segment is rejected", () => {
-    expect(() => packageScopeDir("conversation", "../escape", "/s")).toThrow(/safe path segment/);
+  test("path-dangerous identities cannot reach the scope dir", () => {
+    // The address factory rejects them before any path is built.
+    expect(() =>
+      packageScopeDir("conversation", createOfficeAddress("slack", "../escape"), "/s"),
+    ).toThrow(/Conversation id/);
   });
 });

--- a/test/packages-mounts.test.ts
+++ b/test/packages-mounts.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { createOfficeAddress } from "../src/office-address.js";
 import {
   conversationPackageSkillMounts,
   packageSkillRuntimeDir,
@@ -47,7 +48,7 @@ function makeSkillPackage(): string {
 
 function options() {
   return {
-    conversationId: CONVERSATION_ID,
+    address: createOfficeAddress("slack", CONVERSATION_ID),
     stateDir,
     conversationDir: join(workingDir, CONVERSATION_ID),
   };

--- a/test/packages-resolve.test.ts
+++ b/test/packages-resolve.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { resolveConversationPackages } from "../src/packages/resolve.js";
+import { createOfficeAddress, officeKey } from "../src/office-address.js";
 
 const CONVERSATION_ID = "C03045VJJAY";
 
@@ -24,7 +25,15 @@ function globalSettings(packages: string[]): void {
 }
 
 function conversationSettings(packages: string[]): void {
-  writeSettings(join(stateDir, "conversations", CONVERSATION_ID, "settings.json"), { packages });
+  writeSettings(
+    join(
+      stateDir,
+      "conversations",
+      officeKey(createOfficeAddress("slack", CONVERSATION_ID)),
+      "settings.json",
+    ),
+    { packages },
+  );
 }
 
 /** A package repo whose extensions live in the `extensions/` collection dir. */
@@ -81,7 +90,7 @@ function makeTwoRefRepo(): string {
 
 function resolve(options?: { fetchMissing?: boolean }) {
   return resolveConversationPackages({
-    conversationId: CONVERSATION_ID,
+    address: createOfficeAddress("slack", CONVERSATION_ID),
     stateDir,
     conversationDir: join(workingDir, CONVERSATION_ID),
     ...options,
@@ -108,7 +117,12 @@ describe("scope convention directories", () => {
     const result = resolve();
     expect(result.extensionDirs).toEqual([
       join(stateDir, "global", "extensions"),
-      join(stateDir, "conversations", CONVERSATION_ID, "extensions"),
+      join(
+        stateDir,
+        "conversations",
+        officeKey(createOfficeAddress("slack", CONVERSATION_ID)),
+        "extensions",
+      ),
     ]);
     expect(result.errors).toEqual([]);
   });
@@ -116,7 +130,14 @@ describe("scope convention directories", () => {
   test("the global convention dir is scanned before the conversation's", () => {
     const dirs = resolve().extensionDirs;
     expect(dirs.indexOf(join(stateDir, "global", "extensions"))).toBeLessThan(
-      dirs.indexOf(join(stateDir, "conversations", CONVERSATION_ID, "extensions")),
+      dirs.indexOf(
+        join(
+          stateDir,
+          "conversations",
+          officeKey(createOfficeAddress("slack", CONVERSATION_ID)),
+          "extensions",
+        ),
+      ),
     );
   });
 });

--- a/test/settings-mutation.test.ts
+++ b/test/settings-mutation.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { createOfficeAddress } from "../src/office-address.js";
+import { createOfficeAddress, officeStateDir } from "../src/office-address.js";
 import {
   applyConversationSettings,
   applyConversationSettingsByRawId,
@@ -30,7 +30,10 @@ afterEach(() => {
 });
 
 function conversationSettingsFile(conversationId: string): string {
-  return join(stateDir, "conversations", conversationId, "settings.json");
+  return join(
+    officeStateDir(stateDir, createOfficeAddress("slack", conversationId)),
+    "settings.json",
+  );
 }
 
 describe("applyConversationSettings", () => {

--- a/test/workspace-projection.test.ts
+++ b/test/workspace-projection.test.ts
@@ -89,7 +89,7 @@ describe("workspace office projection", () => {
 
   test("maps legacy full conversation override above canonical global defaults", () => {
     const settingsPath = conversationSettingsPath({
-      conversationId,
+      address,
       conversationDir: join(workspaceDir, officeSegment),
     });
     writeFileSync(settingsPath, JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }));
@@ -106,7 +106,7 @@ describe("workspace office projection", () => {
       sandbox: { workspace: { doorPolicy: "trusted", layout: "full" } },
     });
     updateConversationSettings(
-      { conversationId, conversationDir: join(workspaceDir, officeSegment) },
+      { address, conversationDir: join(workspaceDir, officeSegment) },
       {
         sandbox: { workspace: { doorPolicy: "isolated" } },
       },


### PR DESCRIPTION
Phase 4 continuation (ADR 0005): the `<state-dir>/conversations` tree — settings.json, extensions, extension-data, git checkouts — moves to office-key naming, ending config/extension-data bleed between platforms whose conversation ids collide.

## Changes

- `ConversationSettingsScope` carries the `OfficeAddress`; the state key derives via `officeStateDir`, never from a raw id or a directory basename.
- Package APIs (`ResolvePackagesOptions`, `MaterializeOptions`, `packageScopeDir`) and the extension loader (`defaultExtensionDirs`, per-extension `dataDir`) thread the address through. Extension code still sees the raw `conversationId` in its context — only host-side keying changed.
- Boot migration moves each registered office's **whole legacy state tree in one rename** (settings + extensions + data + git), reported in the boot summary; legacy+target conflicts fail boot with merge instructions.
- `mikan ext --conversation <id>` resolves the raw id through the office registry using its own `--state-dir` (fixed a latent mismatch where the registry would have been read from the env-derived state dir).
- Event tool: the default conversation scope now matches **platform and** raw id, so an office no longer lists another platform's schedules as its own. Platform-less legacy event files stay visible, and `scope: "all"` / the events directory remain the workspace-wide scheduling bus by design (unchanged, per the recorded decision).

## Verification

- 1589 tests green (new: state-tree migration move/conflict, cross-platform extension-dir separation, cross-platform event scope)
- lint, fmt, knip, build, docs build
- Docker office isolation gate green

Remaining raw-id per ADR 0005: sandbox resource keys (documented trade-off) and Admin scope UI.