### PR TITLE
refactor(admin): office-address scope and address-typed runner cache control

### DIFF
--- a/docs/adr/0005-office-address-identity.md
+++ b/docs/adr/0005-office-address-identity.md
@@ -17,7 +17,9 @@ Conversation-scoped credential vaults are keyed by office key — the same strin
 
 Per-conversation host state (`<state-dir>/conversations/<officeKey>` — settings.json, extensions, extension-data, git checkouts) is office-keyed: the settings scope and the extension/package APIs carry the `OfficeAddress`, and the boot migration moves each office's whole legacy tree in one rename, failing closed on conflicts. The event tool's conversation scope matches platform as well as raw ID (platform-less legacy files stay visible); the events directory itself remains the workspace-wide scheduling bus by design.
 
-Sandbox resource keys (container names, gondolin instances, cloudflare scopes) stay raw-conversation-derived until the resource-naming migration — a collision there costs a container recreate, never credential access. Admin scope is still raw-ID keyed; its surfaces resolve offices through the registry (`resolveOwnedOfficeAddress`), which refuses ambiguous IDs shared by several platforms until Admin carries full addresses.
+Admin scope is a full office address: the token pins the invoking platform, requested conversation IDs default to that platform, and cross-platform targets name theirs explicitly (`platform` query/body parameter, `platform:id` scope keys in the UI). The runner cache-control surface (`switchConversationModel`, `refreshConversationEnvironment`, the busy list) and runner generations are address-typed, and the raw-ID bridge functions are gone; `resolveOwnedOfficeAddress` remains only for CLI operators who name offices by raw ID.
+
+Sandbox resource keys (container names, gondolin instances, cloudflare scopes) stay raw-conversation-derived until the resource-naming migration — a collision there costs a container recreate, never credential access.
 
 Platform adapters continue to use raw IDs at their external I/O boundaries.
 The registry never infers a platform from an ID prefix: one enabled platform may

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -59,8 +59,11 @@ async function refreshCopiedVaultRuntime(
 ): Promise<string | undefined> {
   if (context.services.sandbox.type !== "image") return undefined;
 
-  const targetConversationId = context.vaultConversationId ?? context.conversationId;
-  const cleared = context.services.runtime?.refreshConversationEnvironment(targetConversationId);
+  const targetAddress = createOfficeAddress(
+    context.address.platform,
+    context.vaultConversationId ?? context.conversationId,
+  );
+  const cleared = context.services.runtime?.refreshConversationEnvironment(targetAddress);
   if (cleared === false) {
     return "A session is currently running, so the sandbox was not restarted. The copied credentials will be applied after the run finishes and the sandbox is recreated.";
   }

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import type { MessagingBot, ConversationContext, PlatformName } from "../adapter.js";
+import type { MessagingBot, ConversationContext, OfficeAddress, PlatformName } from "../adapter.js";
 import type { DockerContainerManager } from "../provisioner.js";
 import type { SandboxConfig } from "../sandbox/index.js";
 import type { SandboxResourceController } from "../types.js";
@@ -89,8 +89,8 @@ interface CommandRuntimeBridge {
     responder: ConversationContext["responder"],
     platform: ConversationContext["platform"],
   ): Promise<void>;
-  switchConversationModel(conversationId: string, provider: string, model: string): boolean;
-  refreshConversationEnvironment(conversationId: string): boolean;
+  switchConversationModel(address: OfficeAddress, provider: string, model: string): boolean;
+  refreshConversationEnvironment(address: OfficeAddress): boolean;
 }
 
 export interface CommandServices {

--- a/src/office-registry.ts
+++ b/src/office-registry.ts
@@ -777,11 +777,6 @@ export function listRegisteredOffices(): readonly OfficeRecord[] {
   return registry.getOffices();
 }
 
-/** Office working directory for a raw-id-scoped caller (see resolveOwnedOfficeAddress). */
-export function resolveLegacyOfficeDir(workspaceRoot: string, rawConversationId: string): string {
-  return conversationOfficeDir(workspaceRoot, resolveOwnedOfficeAddress(rawConversationId));
-}
-
 /** mkdir-if-missing with the same fail-closed type guard as projection roots. */
 function ensureRegularOfficeDirectory(dir: string): void {
   let stats;

--- a/src/runtime/conversation-runtime.ts
+++ b/src/runtime/conversation-runtime.ts
@@ -7,7 +7,7 @@ import type {
   PlatformName,
   RunningSession,
 } from "../adapter.js";
-import { conversationOfficeDir, officeDirName } from "../office-address.js";
+import { conversationOfficeDir, officeDirName, officeKey } from "../office-address.js";
 import { createRunner } from "../agent.js";
 import type { PiAgentWrapper } from "../agent.js";
 import { MikanModels } from "../harness/index.js";
@@ -661,42 +661,26 @@ class ConversationRuntimeImpl implements ConversationRuntime {
     );
   }
 
-  switchConversationModel(conversationId: string, _provider: string, _model: string): boolean {
-    this.bumpConversationRunnerGeneration(conversationId);
-    return this.clearConversationsById(conversationId, "Model switched");
+  switchConversationModel(address: OfficeAddress, _provider: string, _model: string): boolean {
+    this.bumpConversationRunnerGeneration(address);
+    return this.clearOffice(address, "Model switched");
   }
 
-  refreshConversationEnvironment(conversationId: string): boolean {
-    this.bumpConversationRunnerGeneration(conversationId);
-    return this.clearConversationsById(conversationId, "Environment refreshed");
+  refreshConversationEnvironment(address: OfficeAddress): boolean {
+    this.bumpConversationRunnerGeneration(address);
+    return this.clearOffice(address, "Environment refreshed");
   }
 
-  refreshAllConversations(): { busy: string[] } {
+  refreshAllConversations(): { busy: OfficeAddress[] } {
     this.globalRunnerGeneration++;
-    // Deduplicated raw ids: offices on different platforms may share one, and
-    // callers report the busy list in raw-id terms (ADR 0005).
-    const busy = new Set<string>();
+    const busy: OfficeAddress[] = [];
     for (const address of this.sessions.offices()) {
       if (!this.clearOffice(address, "Global settings changed")) {
         this.sessions.deferConversationClear(address);
-        busy.add(address.conversationId);
+        busy.push(address);
       }
     }
-    return { busy: Array.from(busy) };
-  }
-
-  /**
-   * Settings and Admin scope still name an office by its raw id (ADR 0005), so
-   * every office behind that id is cleared. Returns false when any of them is
-   * busy, matching the clear-or-refuse contract these callers rely on.
-   */
-  private clearConversationsById(conversationId: string, reason: string): boolean {
-    const offices = this.sessions.officesForConversationId(conversationId);
-    let cleared = true;
-    for (const address of offices) {
-      if (!this.clearOffice(address, reason)) cleared = false;
-    }
-    return cleared;
+    return { busy };
   }
 
   private clearOffice(address: OfficeAddress, reason: string): boolean {
@@ -707,21 +691,16 @@ class ConversationRuntimeImpl implements ConversationRuntime {
     return cleared;
   }
 
-  /**
-   * Runner generations stay keyed by raw conversation id: they are bumped from
-   * the same raw-id settings/Admin surfaces that read them, and two platforms
-   * sharing a raw id only cost each other a redundant runner rebuild, never a
-   * wrong one. They migrate with Admin scope (ADR 0005).
-   */
-  private bumpConversationRunnerGeneration(conversationId: string): void {
+  private bumpConversationRunnerGeneration(address: OfficeAddress): void {
+    const key = officeKey(address);
     this.conversationRunnerGenerations.set(
-      conversationId,
-      (this.conversationRunnerGenerations.get(conversationId) ?? 0) + 1,
+      key,
+      (this.conversationRunnerGenerations.get(key) ?? 0) + 1,
     );
   }
 
-  private runnerGeneration(conversationId: string): string {
-    return `${this.globalRunnerGeneration}:${this.conversationRunnerGenerations.get(conversationId) ?? 0}`;
+  private runnerGeneration(address: OfficeAddress): string {
+    return `${this.globalRunnerGeneration}:${this.conversationRunnerGenerations.get(officeKey(address)) ?? 0}`;
   }
 
   private async createCurrentRunner(
@@ -730,7 +709,7 @@ class ConversationRuntimeImpl implements ConversationRuntime {
     sessionScope: Awaited<ReturnType<ChatHistorySync["resolveSessionScope"]>>,
   ): Promise<PiAgentWrapper> {
     while (true) {
-      const generation = this.runnerGeneration(options.conversationId);
+      const generation = this.runnerGeneration(options.address);
       const runner = await createRunner({
         sandboxConfig: this.options.sandbox,
         sessionKey: options.sessionKey,
@@ -755,7 +734,7 @@ class ConversationRuntimeImpl implements ConversationRuntime {
         platformToolPackFactories: this.options.platformToolPackFactories,
         models: this.resolvedModels,
       });
-      if (generation === this.runnerGeneration(options.conversationId)) return runner;
+      if (generation === this.runnerGeneration(options.address)) return runner;
       await runner.dispose();
     }
   }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -103,9 +103,9 @@ export interface ConversationRuntimeOptions extends Omit<
 
 export interface ConversationRuntime extends MessagingEventHandler {
   runSession(options: RunSessionOptions): Promise<void>;
-  switchConversationModel(conversationId: string, provider: string, model: string): boolean;
-  refreshConversationEnvironment(conversationId: string): boolean;
+  switchConversationModel(address: OfficeAddress, provider: string, model: string): boolean;
+  refreshConversationEnvironment(address: OfficeAddress): boolean;
   /** Clear idle runners; defer busy conversation invalidation until settlement. */
-  refreshAllConversations(): { busy: string[] };
+  refreshAllConversations(): { busy: OfficeAddress[] };
   shutdown(timeoutMs?: number): Promise<void>;
 }

--- a/src/settings-mutation.ts
+++ b/src/settings-mutation.ts
@@ -42,12 +42,11 @@ export function applyConversationSettings(
   address: OfficeAddress,
   patch: Partial<AgentConfig>,
 ): SettingsApplyResult {
-  const conversationId = address.conversationId;
   let runtimeSwitched: boolean | null = null;
   if (affectsCachedRunner(patch) && runtime) {
     // Clear-or-refuse before writing. The clear and the write happen in the
     // same synchronous tick, so no runner can be created in between.
-    if (!runtime.switchConversationModel(conversationId, patch.provider ?? "", patch.model ?? "")) {
+    if (!runtime.switchConversationModel(address, patch.provider ?? "", patch.model ?? "")) {
       return { ok: false, reason: "busy" };
     }
     runtimeSwitched = true;
@@ -82,7 +81,7 @@ export function applyConversationSettingsByRawId(
 export function applyGlobalSettings(
   runtime: GlobalRunnerCacheControl | undefined,
   patch: Partial<AgentConfig>,
-): { ok: true; staleConversations: string[] } {
+): { ok: true; staleConversations: OfficeAddress[] } {
   updateGlobalSettings(patch);
   const staleConversations =
     affectsCachedRunner(patch) && runtime ? runtime.refreshAllConversations().busy : [];

--- a/src/settings-mutation.ts
+++ b/src/settings-mutation.ts
@@ -18,7 +18,6 @@
  */
 import { updateConversationSettings, updateGlobalSettings } from "./config.js";
 import { conversationOfficeDir } from "./office-address.js";
-import { resolveOwnedOfficeAddress } from "./office-registry.js";
 import type {
   AgentConfig,
   GlobalRunnerCacheControl,
@@ -56,26 +55,6 @@ export function applyConversationSettings(
     patch,
   );
   return { ok: true, runtimeSwitched };
-}
-
-/**
- * Raw-id adapter for Admin surfaces that predate OfficeAddress: the office
- * registry supplies the owning platform. Migrates away with ADR 0005's Admin
- * commit; chat commands must use applyConversationSettings with their
- * address.
- */
-export function applyConversationSettingsByRawId(
-  runtime: RunnerCacheControl | undefined,
-  workingDir: string,
-  conversationId: string,
-  patch: Partial<AgentConfig>,
-): SettingsApplyResult {
-  return applyConversationSettings(
-    runtime,
-    workingDir,
-    resolveOwnedOfficeAddress(conversationId),
-    patch,
-  );
 }
 
 export function applyGlobalSettings(

--- a/src/types.ts
+++ b/src/types.ts
@@ -649,11 +649,11 @@ export interface EnvGroup {
 }
 
 export interface RunnerCacheControl {
-  switchConversationModel(conversationId: string, provider: string, model: string): boolean;
+  switchConversationModel(address: OfficeAddress, provider: string, model: string): boolean;
 }
 
 export interface GlobalRunnerCacheControl {
-  refreshAllConversations(): { busy: string[] };
+  refreshAllConversations(): { busy: OfficeAddress[] };
 }
 
 export type SettingsApplyResult =

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -12,7 +12,7 @@ import {
   type AgentConfig,
   type SandboxSettings,
 } from "../../config.js";
-import { applyConversationSettingsByRawId, applyGlobalSettings } from "../../settings-mutation.js";
+import { applyConversationSettings, applyGlobalSettings } from "../../settings-mutation.js";
 import { effectiveStateDir } from "../../cli/arg-grammar.js";
 import {
   addPackage,
@@ -26,19 +26,21 @@ import { renderPortalShell } from "../portal-shell.js";
 import { resolveExistingSessionFile } from "../session-view/service.js";
 import { PRODUCT_NAME } from "../../platform-messages.js";
 import { credentialAuthorizationKey } from "../../sandbox/identity.js";
-import { legacyResolveWorkspaceProjection } from "../../workspace-projection/index.js";
+import { resolveWorkspaceProjection } from "../../workspace-projection/index.js";
 import { sharedVaultKey } from "../../vault/index.js";
 import { modelKey, resolveAdminModelAccessStatuses } from "./provider-models.js";
 import type { AdminToken } from "./store.js";
 
 export type { AdminRuntimeBridge, AdminServices, EventSummary } from "./types.js";
 import type { AdminServices, EventSummary } from "./types.js";
-import { conversationOfficeDir } from "../../office-address.js";
+import type { OfficeAddress } from "../../adapter.js";
+import { sameOffice } from "../../office-address.js";
 import {
-  listRegisteredOffices,
-  resolveLegacyOfficeDir,
-  resolveOwnedOfficeAddress,
-} from "../../office-registry.js";
+  assertPlatformName,
+  conversationOfficeDir,
+  createOfficeAddress,
+} from "../../office-address.js";
+import { listRegisteredOffices } from "../../office-registry.js";
 
 // ── Handler ────────────────────────────────────────────────────────────────────
 
@@ -219,24 +221,45 @@ async function routeApiRequest(
 
 // ── Scope helpers ──────────────────────────────────────────────────────────────
 
-function resolveConversationId(
-  requested: string,
+interface AdminConversationScope {
+  address: OfficeAddress;
+  conversationId: string;
+  error?: string;
+}
+
+/**
+ * Admin scope is a full office address. The platform defaults to the token's
+ * (an admin invoked from Slack browses Slack offices); cross-platform targets
+ * name theirs explicitly. Identity validation is the address factory's.
+ */
+export function resolveConversationScope(
+  requestedId: string,
+  requestedPlatform: string,
   token: AdminToken,
-): { conversationId: string; error?: string } {
-  if (!requested) return { conversationId: token.conversationId };
-  if (requested === token.conversationId) return { conversationId: requested };
-  if (requested.includes("/") || requested.includes("..")) {
-    return { conversationId: requested, error: "Invalid conversationId." };
+): AdminConversationScope {
+  const fallback = createOfficeAddress(token.platform, token.conversationId);
+  try {
+    const address = createOfficeAddress(
+      requestedPlatform ? assertPlatformName(requestedPlatform) : token.platform,
+      requestedId || token.conversationId,
+    );
+    return { address, conversationId: address.conversationId };
+  } catch {
+    return {
+      address: fallback,
+      conversationId: fallback.conversationId,
+      error: "Invalid conversation scope.",
+    };
   }
-  return { conversationId: requested };
 }
 
 function resolveTargetConversation(
   body: Record<string, unknown>,
   token: AdminToken,
-): { conversationId: string; error?: string } {
+): AdminConversationScope {
   const requested = typeof body.conversationId === "string" ? body.conversationId.trim() : "";
-  return resolveConversationId(requested, token);
+  const platform = typeof body.platform === "string" ? body.platform.trim() : "";
+  return resolveConversationScope(requested, platform, token);
 }
 
 function requireAdminWorkingDir(res: ServerResponse, services: AdminServices): string | null {
@@ -260,23 +283,23 @@ function serveMe(res: ServerResponse, token: AdminToken): void {
 }
 
 /**
- * Admin scope is still raw-conversation-id keyed. Office directories are
- * office-key named and not reversible to raw ids, so enumeration reads the
- * office registry — the durable raw-id ↔ office mapping — instead of
- * scanning the workspace. Offices whose directory disappeared are filtered
- * out; ids shared by several platforms stay listed once (their per-office
- * detail pages come with the Admin address migration, ADR 0005).
+ * Office directories are office-key named and not reversible to raw ids, so
+ * enumeration reads the office registry — the durable raw-id ↔ office
+ * mapping — instead of scanning the workspace. Offices whose directory
+ * disappeared are filtered out.
  */
-function listConversationDirs(workingDir: string): string[] {
-  const ids = new Set<string>();
-  for (const office of listRegisteredOffices()) {
-    if (existsSync(conversationOfficeDir(workingDir, office))) ids.add(office.conversationId);
-  }
-  return Array.from(ids).toSorted((a, b) => a.localeCompare(b));
+function listAdminOffices(workingDir: string): OfficeAddress[] {
+  return listRegisteredOffices()
+    .filter((office) => existsSync(conversationOfficeDir(workingDir, office)))
+    .map((office) => createOfficeAddress(office.platform, office.conversationId))
+    .toSorted(
+      (a, b) =>
+        a.platform.localeCompare(b.platform) || a.conversationId.localeCompare(b.conversationId),
+    );
 }
 
-function conversationLastActivity(workingDir: string, conversationId: string): number | null {
-  const dir = resolveLegacyOfficeDir(workingDir, conversationId);
+function conversationLastActivity(workingDir: string, office: OfficeAddress): number | null {
+  const dir = conversationOfficeDir(workingDir, office);
   if (!existsSync(dir)) return null;
   let latest = 0;
   const visit = (path: string, depth: number): void => {
@@ -305,36 +328,26 @@ function conversationLastActivity(workingDir: string, conversationId: string): n
   return latest > 0 ? latest : null;
 }
 
-function conversationDisplayLabel(services: AdminServices, conversationId: string): string {
-  for (const [platform, bot] of Object.entries(services.botsByPlatform ?? {})) {
-    const channel = bot?.getMessagingInfo().channels.find((c) => c.id === conversationId);
-    if (channel) return `${platform}:#${channel.name}:${conversationId}`;
-  }
-  return conversationId;
+function conversationDisplayLabel(services: AdminServices, office: OfficeAddress): string {
+  const bot = services.botsByPlatform?.[office.platform];
+  const channel = bot?.getMessagingInfo().channels.find((c) => c.id === office.conversationId);
+  if (channel) return `${office.platform}:#${channel.name}:${office.conversationId}`;
+  return `${office.platform}:${office.conversationId}`;
 }
 
 function serveConversationsList(res: ServerResponse, services: AdminServices): void {
   const workingDir = requireAdminWorkingDir(res, services);
   if (!workingDir) return;
 
-  const ids = listConversationDirs(workingDir);
+  const running = services.runtime?.getRunningSessions() ?? [];
 
-  const runningKeys = new Set<string>(
-    services.runtime?.getRunningSessions().map((s) => s.sessionKey) ?? [],
-  );
-
-  const conversations = ids.map((conversationId) => {
-    const lastActivity = conversationLastActivity(workingDir, conversationId);
-    const running = Array.from(runningKeys).some(
-      (key) => key === conversationId || key.startsWith(`${conversationId}:`),
-    );
-    return {
-      conversationId,
-      label: conversationDisplayLabel(services, conversationId),
-      running,
-      lastActivityAt: lastActivity,
-    };
-  });
+  const conversations = listAdminOffices(workingDir).map((office) => ({
+    platform: office.platform,
+    conversationId: office.conversationId,
+    label: conversationDisplayLabel(services, office),
+    running: running.some((session) => sameOffice(session.address, office)),
+    lastActivityAt: conversationLastActivity(workingDir, office),
+  }));
 
   jsonRes(res, 200, { conversations });
 }
@@ -357,13 +370,9 @@ function serveSessionUsage(res: ServerResponse, services: AdminServices): void {
   const workingDir = requireAdminWorkingDir(res, services);
   if (!workingDir) return;
 
-  const rows = listConversationDirs(workingDir)
-    .flatMap((conversationId) =>
-      listConversationSessionUsage(
-        workingDir,
-        conversationId,
-        conversationDisplayLabel(services, conversationId),
-      ),
+  const rows = listAdminOffices(workingDir)
+    .flatMap((office) =>
+      listConversationSessionUsage(workingDir, office, conversationDisplayLabel(services, office)),
     )
     .toSorted((a, b) => b.total - a.total)
     .slice(0, 20);
@@ -373,14 +382,16 @@ function serveSessionUsage(res: ServerResponse, services: AdminServices): void {
 
 function listConversationSessionUsage(
   workingDir: string,
-  conversationId: string,
+  office: OfficeAddress,
   label: string,
 ): SessionUsageRow[] {
-  const sessionDir = join(resolveLegacyOfficeDir(workingDir, conversationId), "sessions");
+  const sessionDir = join(conversationOfficeDir(workingDir, office), "sessions");
   try {
     return readdirSync(sessionDir, { withFileTypes: true })
       .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
-      .flatMap((entry) => readSessionUsage(join(sessionDir, entry.name), conversationId, label));
+      .flatMap((entry) =>
+        readSessionUsage(join(sessionDir, entry.name), office.conversationId, label),
+      );
   } catch {
     return [];
   }
@@ -471,8 +482,14 @@ function serveConversationUsage(res: ServerResponse, url: URL, services: AdminSe
   const workingDir = requireAdminWorkingDir(res, services);
   if (!workingDir) return;
 
-  const conversationId = url.searchParams.get("conversationId") ?? "";
-  if (!conversationId || !listConversationDirs(workingDir).includes(conversationId)) {
+  const conversationId = (url.searchParams.get("conversationId") ?? "").trim();
+  const platformParam = (url.searchParams.get("platform") ?? "").trim();
+  const office = listAdminOffices(workingDir).find(
+    (candidate) =>
+      candidate.conversationId === conversationId &&
+      (!platformParam || candidate.platform === platformParam),
+  );
+  if (!office) {
     jsonRes(res, 400, { error: "Unknown conversationId" });
     return;
   }
@@ -494,7 +511,7 @@ function serveConversationUsage(res: ServerResponse, url: URL, services: AdminSe
   cutoff.setDate(today.getDate() - (days - 1));
 
   const flags = { hasOlder: false };
-  const sessionDir = join(resolveLegacyOfficeDir(workingDir, conversationId), "sessions");
+  const sessionDir = join(conversationOfficeDir(workingDir, office), "sessions");
   try {
     for (const entry of readdirSync(sessionDir, { withFileTypes: true })) {
       if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
@@ -516,8 +533,9 @@ function serveConversationUsage(res: ServerResponse, url: URL, services: AdminSe
   }, emptyBucket(""));
 
   jsonRes(res, 200, {
+    platform: office.platform,
     conversationId,
-    label: conversationDisplayLabel(services, conversationId),
+    label: conversationDisplayLabel(services, office),
     days,
     hasOlder: flags.hasOlder,
     buckets: series,
@@ -582,20 +600,20 @@ function serveConversationState(
   const workingDir = requireAdminWorkingDir(res, services);
   if (!workingDir) return;
 
-  const requested = url.searchParams.get("conversationId")?.trim() ?? "";
-  const conversationId = requested || token.conversationId;
-  if (conversationId.includes("/") || conversationId.includes("..")) {
-    jsonRes(res, 400, { error: "Invalid conversationId" });
+  const scope = resolveConversationFromQuery(url, token);
+  if (scope.error) {
+    jsonRes(res, 400, { error: scope.error });
     return;
   }
+  const conversationId = scope.conversationId;
 
-  const dir = resolveLegacyOfficeDir(workingDir, conversationId);
+  const dir = conversationOfficeDir(workingDir, scope.address);
   const globalConfig = loadGlobalSettings();
   const conversationConfig = resolveConversationSettings({
-    address: resolveOwnedOfficeAddress(conversationId),
+    address: scope.address,
     conversationDir: dir,
   });
-  const conversationWorkspace = legacyResolveWorkspaceProjection(workingDir, conversationId);
+  const conversationWorkspace = resolveWorkspaceProjection(workingDir, scope.address);
   const globalWorkspaceSettings = globalConfig.sandbox?.workspace;
   const autoReply = loadConversationAutoReplyConfig(dir);
 
@@ -693,16 +711,11 @@ function serveConversationModelUpdate(
   if (!workingDir) return;
 
   try {
-    const result = applyConversationSettingsByRawId(
-      services.runtime,
-      workingDir,
-      scope.conversationId,
-      {
-        provider,
-        model,
-        ...(thinkingLevel ? { thinkingLevel } : {}),
-      },
-    );
+    const result = applyConversationSettings(services.runtime, workingDir, scope.address, {
+      provider,
+      model,
+      ...(thinkingLevel ? { thinkingLevel } : {}),
+    });
     if (!result.ok) {
       jsonRes(res, 409, {
         error: "Conversation has a running job; retry after it finishes (or /stop it).",
@@ -745,7 +758,7 @@ function serveConversationSlackUpdate(
   const workingDir = requireAdminWorkingDir(res, services);
   if (!workingDir) return;
   try {
-    applyConversationSettingsByRawId(services.runtime, workingDir, scope.conversationId, {
+    applyConversationSettings(services.runtime, workingDir, scope.address, {
       slack: { replyMode },
     });
     jsonRes(res, 200, { ok: true });
@@ -776,7 +789,7 @@ function serveConversationAutoReplyUpdate(
   }
   const workingDir = requireAdminWorkingDir(res, services);
   if (!workingDir) return;
-  const dir = resolveLegacyOfficeDir(workingDir, scope.conversationId);
+  const dir = conversationOfficeDir(workingDir, scope.address);
   try {
     const existing = loadConversationAutoReplyConfig(dir);
     saveConversationAutoReplyConfig(dir, {
@@ -814,7 +827,7 @@ function serveConversationSessionLink(
   }
 
   const sessionFile = resolveExistingSessionFile(
-    resolveLegacyOfficeDir(workingDir, scope.conversationId),
+    conversationOfficeDir(workingDir, scope.address),
     scope.conversationId,
   );
   if (!sessionFile) {
@@ -870,7 +883,7 @@ function serveConversationLoginLink(
     try {
       vaultId = credentialAuthorizationKey(services.sandbox, {
         userId: token.platformUserId,
-        address: resolveOwnedOfficeAddress(scope.conversationId),
+        address: scope.address,
       });
     } catch (err) {
       jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
@@ -1004,12 +1017,10 @@ function isWorkspacePathAllowed(rel: string): boolean {
   return WORKSPACE_TOP_DIRS.has(first);
 }
 
-function resolveConversationFromQuery(
-  url: URL,
-  token: AdminToken,
-): { conversationId: string; error?: string } {
+function resolveConversationFromQuery(url: URL, token: AdminToken): AdminConversationScope {
   const requested = (url.searchParams.get("conversationId") ?? "").trim();
-  return resolveConversationId(requested, token);
+  const platform = (url.searchParams.get("platform") ?? "").trim();
+  return resolveConversationScope(requested, platform, token);
 }
 
 interface SafePathResult {
@@ -1113,7 +1124,7 @@ function serveWorkspaceTree(
   }
   const workingDir = requireAdminWorkingDir(res, services);
   if (!workingDir) return;
-  const convDir = resolveLegacyOfficeDir(workingDir, scope.conversationId);
+  const convDir = conversationOfficeDir(workingDir, scope.address);
   if (!existsSync(convDir)) {
     jsonRes(res, 200, { conversationId: scope.conversationId, tree: null });
     return;
@@ -1223,7 +1234,7 @@ function serveWorkspaceFile(
     jsonRes(res, 403, { error: "Workspace path is not exposed" });
     return;
   }
-  const convDir = resolveLegacyOfficeDir(workingDir, scope.conversationId);
+  const convDir = conversationOfficeDir(workingDir, scope.address);
   const safe = safeJoinUnderRoot(convDir, requestedPath);
   if (safe.error) {
     jsonRes(res, 400, { error: safe.error });
@@ -1305,9 +1316,9 @@ async function servePackagesList(
   if (!workingDir) return;
   try {
     const inventory = await inspectConversationPackages({
-      address: resolveOwnedOfficeAddress(scope.conversationId),
+      address: scope.address,
       stateDir: effectiveStateDir(),
-      conversationDir: resolveLegacyOfficeDir(workingDir, scope.conversationId),
+      conversationDir: conversationOfficeDir(workingDir, scope.address),
     });
     jsonRes(res, 200, { conversationId: scope.conversationId, ...inventory });
   } catch (err) {
@@ -1346,9 +1357,9 @@ function servePackageMutation(
   if (!workingDir) return;
 
   const context = {
-    address: resolveOwnedOfficeAddress(scope.conversationId),
+    address: scope.address,
     stateDir: effectiveStateDir(),
-    conversationDir: resolveLegacyOfficeDir(workingDir, scope.conversationId),
+    conversationDir: conversationOfficeDir(workingDir, scope.address),
     workingDir,
     runtime: services.runtime,
   };
@@ -1388,7 +1399,7 @@ function serveSkillsList(
   if (!workingDir) return;
   const global = readSkillsFromDir(join(workingDir, "skills"), "global");
   const conversation = readSkillsFromDir(
-    join(resolveLegacyOfficeDir(workingDir, scope.conversationId), "skills"),
+    join(conversationOfficeDir(workingDir, scope.address), "skills"),
     "conversation",
   );
   jsonRes(res, 200, {
@@ -1430,7 +1441,7 @@ function serveSkillFile(
   const skillsRoot =
     source === "global"
       ? join(workingDir, "skills")
-      : join(resolveLegacyOfficeDir(workingDir, scope.conversationId), "skills");
+      : join(conversationOfficeDir(workingDir, scope.address), "skills");
   const safe = safeJoinUnderRoot(skillsRoot, join(directory, "SKILL.md"));
   if (safe.error) {
     jsonRes(res, 400, { error: safe.error });
@@ -1791,8 +1802,23 @@ function renderAdminPage(token: AdminToken): string {
 
   const script = `
     const adminToken = ${JSON.stringify(token.token)};
-    const defaultConversationId = ${JSON.stringify(token.conversationId)};
-    let activeConversationId = defaultConversationId;
+    // Conversation ids never contain ":" (session-key grammar), so
+    // "platform:id" is a safe composite scope key for the UI.
+    const defaultConversationKey = ${JSON.stringify(`${token.platform}:${token.conversationId}`)};
+    let activeConversationKey = defaultConversationKey;
+    function scopeOf(key) {
+      const sep = key.indexOf(':');
+      return { platform: key.slice(0, sep), conversationId: key.slice(sep + 1) };
+    }
+    function scopeQuery() {
+      const scope = scopeOf(activeConversationKey);
+      return 'conversationId=' + encodeURIComponent(scope.conversationId) +
+        '&platform=' + encodeURIComponent(scope.platform);
+    }
+    function scopeBody() {
+      const scope = scopeOf(activeConversationKey);
+      return { conversationId: scope.conversationId, platform: scope.platform };
+    }
     let availableModels = [];
     let modelsLoaded = false;
 
@@ -1900,9 +1926,10 @@ function renderAdminPage(token: AdminToken): string {
       try {
         const data = await apiGet('/admin/api/conversations');
         sel.innerHTML = data.conversations.map((c) => {
+          const key = c.platform + ':' + c.conversationId;
           const label = (c.label || c.conversationId) + (c.running ? ' (running)' : '');
-          const selected = c.conversationId === defaultConversationId ? ' selected' : '';
-          return '<option value="' + escAttr(c.conversationId) + '"' + selected + '>' + escHtml(label) + '</option>';
+          const selected = key === defaultConversationKey ? ' selected' : '';
+          return '<option value="' + escAttr(key) + '"' + selected + '>' + escHtml(label) + '</option>';
         }).join('');
         sel.addEventListener('change', () => setActiveConversation(sel.value));
       } catch (err) {
@@ -1910,10 +1937,10 @@ function renderAdminPage(token: AdminToken): string {
       }
     }
 
-    function setActiveConversation(id) {
-      activeConversationId = id;
+    function setActiveConversation(key) {
+      activeConversationKey = key;
       const sel = document.getElementById('conv-switcher');
-      if (sel && sel.value !== id) sel.value = id;
+      if (sel && sel.value !== key) sel.value = key;
       // Reset all conversation sections.
       loadSettings();
       loadWorkspace();
@@ -1931,7 +1958,7 @@ function renderAdminPage(token: AdminToken): string {
       container.innerHTML = '<div class="loading-msg">Loading…</div>';
       if (!modelsLoaded) await loadModels();
       try {
-        const data = await apiGet('/admin/api/conversation-state?conversationId=' + encodeURIComponent(activeConversationId));
+        const data = await apiGet('/admin/api/conversation-state?' + scopeQuery());
         container.innerHTML = renderSettings(data);
       } catch (err) {
         container.innerHTML = '<div class="err-msg">' + escHtml(err.message) + '</div>';
@@ -1998,7 +2025,7 @@ function renderAdminPage(token: AdminToken): string {
       btn.disabled = true; btn.textContent = 'Saving…'; result.style.display = 'none';
       try {
         const data = await apiPost('/admin/api/conversations/model', {
-          conversationId: activeConversationId, provider, model, thinkingLevel,
+          ...scopeBody(), provider, model, thinkingLevel,
         });
         result.style.display = 'block'; result.className = 'inline-result ok';
         result.textContent = 'Saved ✓';
@@ -2017,7 +2044,7 @@ function renderAdminPage(token: AdminToken): string {
       btn.disabled = true; btn.textContent = 'Saving…'; result.style.display = 'none';
       try {
         await apiPost('/admin/api/conversations/auto-reply', {
-          conversationId: activeConversationId, enabled, rules,
+          ...scopeBody(), enabled, rules,
         });
         result.style.display = 'block'; result.className = 'inline-result ok'; result.textContent = 'Saved ✓';
       } catch (err) {
@@ -2033,7 +2060,7 @@ function renderAdminPage(token: AdminToken): string {
       btn.disabled = true; btn.textContent = 'Saving…'; result.style.display = 'none';
       try {
         await apiPost('/admin/api/conversations/slack', {
-          conversationId: activeConversationId, replyMode,
+          ...scopeBody(), replyMode,
         });
         result.style.display = 'block'; result.className = 'inline-result ok'; result.textContent = 'Saved ✓';
       } catch (err) {
@@ -2051,7 +2078,7 @@ function renderAdminPage(token: AdminToken): string {
       treeEl.innerHTML = '<div class="loading-msg">Loading…</div>';
       previewEl.innerHTML = '<div class="placeholder-msg">Click a file to preview</div>';
       try {
-        const data = await apiGet('/admin/api/workspace/tree?conversationId=' + encodeURIComponent(activeConversationId));
+        const data = await apiGet('/admin/api/workspace/tree?' + scopeQuery());
         if (!data.tree) {
           treeEl.innerHTML = '<div class="empty-state">No files</div>';
           return;
@@ -2091,7 +2118,7 @@ function renderAdminPage(token: AdminToken): string {
       const previewEl = document.getElementById('workspace-preview');
       previewEl.innerHTML = '<div class="loading-msg">Loading ' + escHtml(path) + '…</div>';
       try {
-        const data = await apiGet('/admin/api/workspace/file?conversationId=' + encodeURIComponent(activeConversationId) + '&path=' + encodeURIComponent(path));
+        const data = await apiGet('/admin/api/workspace/file?' + scopeQuery() + '&path=' + encodeURIComponent(path));
         renderPreviewFileResult(previewEl, path, data);
       } catch (err) {
         previewEl.innerHTML = '<div class="err-msg">' + escHtml(err.message) + '</div>';
@@ -2143,7 +2170,7 @@ function renderAdminPage(token: AdminToken): string {
       if (convEl) convEl.innerHTML = '<div class="loading-msg">Loading…</div>';
       if (globalEl) globalEl.innerHTML = '<div class="loading-msg">Loading…</div>';
       try {
-        const data = await apiGet('/admin/api/packages?conversationId=' + encodeURIComponent(activeConversationId));
+        const data = await apiGet('/admin/api/packages?' + scopeQuery());
         if (convEl) renderPackageList(convEl, data.conversation, 'conversation');
         if (globalEl) renderPackageList(globalEl, data.global, 'global');
       } catch (err) {
@@ -2159,7 +2186,7 @@ function renderAdminPage(token: AdminToken): string {
           action: action,
           scope: scope,
           source: source,
-          conversationId: activeConversationId,
+          ...scopeBody(),
         });
         packageMessage(
           scope,
@@ -2201,7 +2228,7 @@ function renderAdminPage(token: AdminToken): string {
       container.innerHTML = '<div class="loading-msg">Loading…</div>';
       if (previewEl) previewEl.innerHTML = '<div class="placeholder-msg">Click a skill to preview SKILL.md</div>';
       try {
-        const data = await apiGet('/admin/api/skills?conversationId=' + encodeURIComponent(activeConversationId));
+        const data = await apiGet('/admin/api/skills?' + scopeQuery());
         if (data.skills.length === 0) {
           container.innerHTML = '<div class="empty-state">No skills available</div>';
           return;
@@ -2227,7 +2254,7 @@ function renderAdminPage(token: AdminToken): string {
       }
       previewEl.innerHTML = '<div class="loading-msg">Loading ' + escHtml(name || directory) + '…</div>';
       try {
-        const data = await apiGet('/admin/api/skills/file?conversationId=' + encodeURIComponent(activeConversationId) + '&source=' + encodeURIComponent(source) + '&directory=' + encodeURIComponent(directory));
+        const data = await apiGet('/admin/api/skills/file?' + scopeQuery() + '&source=' + encodeURIComponent(source) + '&directory=' + encodeURIComponent(directory));
         renderPreviewFileResult(previewEl, source + '/' + directory + '/SKILL.md', data);
       } catch (err) {
         previewEl.innerHTML = '<div class="err-msg">' + escHtml(err.message) + '</div>';
@@ -2248,7 +2275,7 @@ function renderAdminPage(token: AdminToken): string {
       if (silent) { frame.removeAttribute('src'); frame.style.display = 'none'; result.style.display = 'none'; return; }
       result.style.display = 'block'; result.className = 'link-result loading'; result.textContent = 'Generating link…';
       try {
-        const data = await apiPost('/admin/api/conversations/login-link', { conversationId: activeConversationId });
+        const data = await apiPost('/admin/api/conversations/login-link', scopeBody());
         result.className = 'link-result ok';
         result.innerHTML =
           '<span class="link-vault">vault: <code>' + escHtml(data.vaultId) + '</code></span>' +
@@ -2269,7 +2296,7 @@ function renderAdminPage(token: AdminToken): string {
       if (silent) { frame.removeAttribute('src'); frame.style.display = 'none'; result.style.display = 'none'; return; }
       result.style.display = 'block'; result.className = 'link-result loading'; result.textContent = 'Generating link…';
       try {
-        const data = await apiPost('/admin/api/conversations/session-link', { conversationId: activeConversationId });
+        const data = await apiPost('/admin/api/conversations/session-link', scopeBody());
         result.className = 'link-result ok';
         result.innerHTML =
           '<a href="' + escAttr(data.url) + '" target="_blank" rel="noopener">' + escHtml(data.url) + '</a>' +
@@ -2288,7 +2315,7 @@ function renderAdminPage(token: AdminToken): string {
       if (!container) return;
       container.innerHTML = '<div class="loading-msg">Loading…</div>';
       try {
-        const data = await apiGet('/admin/api/conversations/events?conversationId=' + encodeURIComponent(activeConversationId));
+        const data = await apiGet('/admin/api/conversations/events?' + scopeQuery());
         if (data.events.length === 0) {
           container.innerHTML = '<div class="empty-state">沒有關聯此對話的 event</div>';
           return;
@@ -2339,7 +2366,7 @@ function renderAdminPage(token: AdminToken): string {
       btn.disabled = true; btn.textContent = 'Deleting…';
       try {
         await apiPost('/admin/api/conversations/events/delete', {
-          conversationId: activeConversationId, name,
+          ...scopeBody(), name,
         });
         await loadConversationEvents();
       } catch (err) {
@@ -2427,12 +2454,13 @@ function renderAdminPage(token: AdminToken): string {
         timelineConvLoaded = true;
         return;
       }
-      const want = prev || defaultConversationId;
-      sel.innerHTML = data.conversations.map((c) =>
-        '<option value="' + escAttr(c.conversationId) + '"' +
-        (c.conversationId === want ? ' selected' : '') + '>' +
-        escHtml(c.label || c.conversationId) + '</option>'
-      ).join('');
+      const want = prev || defaultConversationKey;
+      sel.innerHTML = data.conversations.map((c) => {
+        const key = c.platform + ':' + c.conversationId;
+        return '<option value="' + escAttr(key) + '"' +
+          (key === want ? ' selected' : '') + '>' +
+          escHtml(c.label || c.conversationId) + '</option>';
+      }).join('');
       timelineConvLoaded = true;
     }
 
@@ -2455,8 +2483,10 @@ function renderAdminPage(token: AdminToken): string {
           return;
         }
         container.innerHTML = '<div class="loading-msg">Loading…</div>';
+        const convScope = scopeOf(conv);
         const data = await apiGet('/admin/api/conversation-usage?conversationId=' +
-          encodeURIComponent(conv));
+          encodeURIComponent(convScope.conversationId) +
+          '&platform=' + encodeURIComponent(convScope.platform));
         timelineData = data;
         container.innerHTML = renderUsageTimeline(data);
       } catch (err) {
@@ -2655,7 +2685,7 @@ function renderAdminPage(token: AdminToken): string {
       container.innerHTML = '<div class="loading-msg">Loading…</div>';
       try {
         // Reuse skills endpoint scoped to a conversation that doesn't have any of its own; the global half is what we want.
-        const data = await apiGet('/admin/api/skills?conversationId=' + encodeURIComponent(activeConversationId));
+        const data = await apiGet('/admin/api/skills?' + scopeQuery());
         const globals = data.skills.filter((s) => s.source === 'global');
         if (globals.length === 0) {
           container.innerHTML = '<div class="empty-state">No global skills</div>';

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -915,7 +915,12 @@ function serveGlobalModelUpdate(
       model,
       ...(thinkingLevel ? { thinkingLevel } : {}),
     });
-    jsonRes(res, 200, { ok: true, staleConversations: result.staleConversations });
+    jsonRes(res, 200, {
+      ok: true,
+      staleConversations: result.staleConversations.map(
+        (office) => `${office.platform}:${office.conversationId}`,
+      ),
+    });
   } catch (err) {
     jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
   }

--- a/src/web/admin/types.ts
+++ b/src/web/admin/types.ts
@@ -1,4 +1,4 @@
-import type { MessagingBot, PlatformName, RunningSession } from "../../adapter.js";
+import type { MessagingBot, OfficeAddress, PlatformName, RunningSession } from "../../adapter.js";
 import type { LinkTokenStoreLike } from "../../commands/types.js";
 import type { SandboxConfig } from "../../sandbox/index.js";
 import type { EventStore } from "../../tools/types.js";
@@ -9,8 +9,8 @@ import type { InMemoryAdminTokenStore } from "./store.js";
 
 export interface AdminRuntimeBridge {
   getRunningSessions(): RunningSession[];
-  switchConversationModel(conversationId: string, provider: string, model: string): boolean;
-  refreshAllConversations(): { busy: string[] };
+  switchConversationModel(address: OfficeAddress, provider: string, model: string): boolean;
+  refreshAllConversations(): { busy: OfficeAddress[] };
 }
 
 export interface AdminServices {

--- a/src/workspace-projection/index.ts
+++ b/src/workspace-projection/index.ts
@@ -2,7 +2,7 @@ import { dirname, join } from "node:path";
 import { lstatSync, mkdirSync, writeFileSync } from "node:fs";
 import { ensureDirExists } from "../utils/file-guards.js";
 import { resolveConversationSettings } from "../config.js";
-import { ensureOfficeDir, resolveOwnedOfficeAddress } from "../office-registry.js";
+import { ensureOfficeDir } from "../office-registry.js";
 import * as log from "../log.js";
 import { conversationOfficeDir, officeDirName, validateOfficeAddress } from "../office-address.js";
 import type {
@@ -95,20 +95,6 @@ export function readWorkspaceProjectionMode(
   address: OfficeAddress,
 ): ImageWorkspaceMountMode {
   return resolveWorkspaceProjection(hostWorkspaceRoot, address).mode;
-}
-
-/**
- * Legacy bridge for surfaces that name an office by raw id alone (Admin
- * scope): the office registry resolves the owning platform.
- */
-export function legacyResolveWorkspaceProjection(
-  hostWorkspaceRoot: string | undefined,
-  rawConversationId: string,
-): WorkspaceProjection {
-  return resolveWorkspaceProjection(
-    hostWorkspaceRoot,
-    resolveOwnedOfficeAddress(rawConversationId),
-  );
 }
 
 function resolveEffectiveWorkspace(

--- a/test/admin-portal.test.ts
+++ b/test/admin-portal.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { HostEventStore } from "../src/tools/event.js";
-import { listAllEvents, readSkillsFromDir } from "../src/web/admin/portal.js";
+import {
+  listAllEvents,
+  readSkillsFromDir,
+  resolveConversationScope,
+} from "../src/web/admin/portal.js";
+import { createOfficeAddress } from "../src/office-address.js";
+import type { AdminToken } from "../src/web/admin/store.js";
 
 const tempDirs: string[] = [];
 
@@ -160,5 +166,35 @@ describe("admin portal skills listing", () => {
   test("returns empty list for a missing skills directory", () => {
     const workspaceDir = makeWorkspace();
     expect(readSkillsFromDir(join(workspaceDir, "skills"), "global")).toEqual([]);
+  });
+});
+
+describe("admin conversation scope", () => {
+  const token = {
+    token: "t",
+    platform: "slack",
+    platformUserId: "U1",
+    conversationId: "C123",
+    expiresAt: Date.now() + 60_000,
+  } as AdminToken;
+
+  test("defaults to the token's office", () => {
+    expect(resolveConversationScope("", "", token).address).toEqual(
+      createOfficeAddress("slack", "C123"),
+    );
+  });
+
+  test("a requested id stays on the token's platform unless one is named", () => {
+    expect(resolveConversationScope("900100", "", token).address).toEqual(
+      createOfficeAddress("slack", "900100"),
+    );
+    expect(resolveConversationScope("900100", "discord", token).address).toEqual(
+      createOfficeAddress("discord", "900100"),
+    );
+  });
+
+  test("rejects invalid ids and platforms without leaking a scope", () => {
+    expect(resolveConversationScope("../escape", "", token).error).toBeTruthy();
+    expect(resolveConversationScope("C1", "matrix", token).error).toBeTruthy();
   });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -254,7 +254,7 @@ describe("ModelCommandHandler", () => {
       expect(ctx.responder.responses[0]).toContain("Switched: `provider/model:2026-01`");
       expect(ctx.responder.responses[0]).not.toContain("未知的 thinking level");
       expect(ctx.services.runtime?.switchConversationModel).toHaveBeenCalledWith(
-        "C123",
+        createOfficeAddress("slack", "C123"),
         "provider",
         "model:2026-01",
       );
@@ -541,7 +541,9 @@ describe("LoginCommandHandler", () => {
       "gliaclaw",
       officeKey(createOfficeAddress("slack", "C123")),
     );
-    expect(ctx.services.runtime?.refreshConversationEnvironment).toHaveBeenCalledWith("C123");
+    expect(ctx.services.runtime?.refreshConversationEnvironment).toHaveBeenCalledWith(
+      createOfficeAddress("slack", "C123"),
+    );
     expect(remove).toHaveBeenCalledWith(officeKey(createOfficeAddress("slack", "C123")));
     expect(ctx.responder.responses[0]).toContain("Copied shared login profile `gliaclaw`");
     expect(ctx.responder.responses[0]).toContain("will be recreated with the copied env");
@@ -575,7 +577,9 @@ describe("LoginCommandHandler", () => {
 
     expect(await handler.tryHandle(ctx)).toBe(true);
     expect(remove).not.toHaveBeenCalled();
-    expect(ctx.services.runtime?.refreshConversationEnvironment).toHaveBeenCalledWith("C123");
+    expect(ctx.services.runtime?.refreshConversationEnvironment).toHaveBeenCalledWith(
+      createOfficeAddress("slack", "C123"),
+    );
     expect(ctx.responder.responses[0]).toContain("currently running");
   });
 

--- a/test/session-runtime.test.ts
+++ b/test/session-runtime.test.ts
@@ -295,8 +295,8 @@ describe("ConversationRuntime lifecycle", () => {
     const oldRunner = oldState!.runner;
     const dispose = vi.spyOn(oldRunner, "dispose");
 
-    expect(runtime.refreshAllConversations()).toEqual({ busy: ["C123"] });
-    expect(runtime.refreshAllConversations()).toEqual({ busy: ["C123"] });
+    expect(runtime.refreshAllConversations()).toEqual({ busy: [testAddress] });
+    expect(runtime.refreshAllConversations()).toEqual({ busy: [testAddress] });
     expect(dispose).not.toHaveBeenCalled();
 
     release();
@@ -588,7 +588,7 @@ describe("ConversationRuntime lifecycle", () => {
     const oldRunner = oldState!.runner;
     const oldDispose = vi.spyOn(oldRunner, "dispose");
 
-    expect(runtime.refreshAllConversations()).toEqual({ busy: ["C123"] });
+    expect(runtime.refreshAllConversations()).toEqual({ busy: [testAddress] });
     expect(oldDispose).not.toHaveBeenCalled();
 
     releaseDream();

--- a/test/settings-mutation.test.ts
+++ b/test/settings-mutation.test.ts
@@ -3,12 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { createOfficeAddress, officeStateDir } from "../src/office-address.js";
-import {
-  applyConversationSettings,
-  applyConversationSettingsByRawId,
-  applyGlobalSettings,
-} from "../src/settings-mutation.js";
-import { OfficeRegistry } from "../src/office-registry.js";
+import { applyConversationSettings, applyGlobalSettings } from "../src/settings-mutation.js";
 
 const C1 = createOfficeAddress("slack", "C1");
 
@@ -81,27 +76,6 @@ describe("applyConversationSettings", () => {
     });
     expect(result).toEqual({ ok: true, runtimeSwitched: null });
     expect(existsSync(conversationSettingsFile("C1"))).toBe(true);
-  });
-});
-
-describe("applyConversationSettingsByRawId", () => {
-  test("resolves the office through the registry before writing", () => {
-    new OfficeRegistry(stateDir).recordOffice(C1);
-
-    const result = applyConversationSettingsByRawId(undefined, workingDir, "C1", {
-      slack: { replyMode: "thread" },
-    });
-
-    expect(result).toEqual({ ok: true, runtimeSwitched: null });
-    expect(existsSync(conversationSettingsFile("C1"))).toBe(true);
-  });
-
-  test("fails loudly for an unknown raw id instead of guessing a directory", () => {
-    expect(() =>
-      applyConversationSettingsByRawId(undefined, workingDir, "C-unknown", {
-        slack: { replyMode: "thread" },
-      }),
-    ).toThrow(/No office is registered/);
   });
 });
 

--- a/test/settings-mutation.test.ts
+++ b/test/settings-mutation.test.ts
@@ -45,7 +45,7 @@ describe("applyConversationSettings", () => {
     });
     expect(result).toEqual({ ok: true, runtimeSwitched: true });
     expect(runtime.switchConversationModel).toHaveBeenCalledWith(
-      "C1",
+      C1,
       "anthropic",
       "claude-sonnet-4-6",
     );
@@ -107,12 +107,13 @@ describe("applyConversationSettingsByRawId", () => {
 
 describe("applyGlobalSettings", () => {
   test("llm change writes, refreshes all, reports busy conversations as stale", () => {
-    const runtime = { refreshAllConversations: vi.fn().mockReturnValue({ busy: ["C9"] }) };
+    const busyOffice = createOfficeAddress("slack", "C9");
+    const runtime = { refreshAllConversations: vi.fn().mockReturnValue({ busy: [busyOffice] }) };
     const result = applyGlobalSettings(runtime, {
       provider: "anthropic",
       model: "claude-sonnet-4-6",
     });
-    expect(result).toEqual({ ok: true, staleConversations: ["C9"] });
+    expect(result).toEqual({ ok: true, staleConversations: [busyOffice] });
     expect(runtime.refreshAllConversations).toHaveBeenCalledOnce();
     const written = JSON.parse(readFileSync(join(stateDir, "settings.json"), "utf-8"));
     expect(written.llm.model).toBe("claude-sonnet-4-6");


### PR DESCRIPTION
Final Phase 4 slice (ADR 0005): Admin was the last surface naming offices by raw id alone.

## Commits

1. **refactor(runtime): address-typed runner cache control** — `switchConversationModel`, `refreshConversationEnvironment`, and `refreshAllConversations().busy` speak `OfficeAddress`; runner generations are office-keyed. `/login`'s vault-target refresh builds the same-platform address.

2. **refactor(admin): scope the portal by office address** — the admin token pins the invoking platform; requested conversation ids default to it; cross-platform targets pass `platform` explicitly (query/body; `platform:id` scope keys in the UI, safe because conversation ids never contain `:`). The conversation list enumerates registry offices with platforms; all handlers resolve paths/settings/projections/vault keys from the scope address. Deletes the raw-id bridges (`resolveLegacyOfficeDir`, `legacyResolveWorkspaceProjection`, `applyConversationSettingsByRawId`); `resolveOwnedOfficeAddress` survives only for `mikan ext`/CLI raw-id input.

## Verification

- 1590 tests green (new: scope-resolution defaults/explicit-platform/invalid-input)
- lint, fmt, knip, build, docs build
- Docker office isolation gate green

With this, every ADR 0005 surface except sandbox resource keys (documented trade-off: collision costs a container recreate, never credential access) speaks `OfficeAddress`.