### PR TITLE
fix(office): verify id formats when claiming legacy directories

### DIFF
--- a/docs/adr/0005-office-address-identity.md
+++ b/docs/adr/0005-office-address-identity.md
@@ -22,6 +22,12 @@ Admin scope is a full office address: the token pins the invoking platform, requ
 Sandbox resource keys (container names, gondolin instances, cloudflare scopes) stay raw-conversation-derived until the resource-naming migration — a collision there costs a container recreate, never credential access.
 
 Platform adapters continue to use raw IDs at their external I/O boundaries.
-The registry never infers a platform from an ID prefix: one enabled platform may
-claim an unowned legacy directory, while multiple enabled platforms require an
-explicit owner.
+Legacy-directory claiming verifies rather than guesses: a directory is
+auto-claimed only when exactly one enabled platform's id format could have
+produced its name (GitHub's mikan-derived `GH_<owner>_<repo>_<n>` slug parses
+back; Telegram allows negative numeric ids; Discord snowflakes are positive
+digits; Slack ids are uppercase alphanumerics with a letter prefix). An id
+matching several enabled formats — bare digits while both Telegram and
+Discord are enabled — or none of them stays `needs-owner` and fails boot
+until `mikan office claim` names an owner. In particular, a single-platform
+deployment can never claim another platform's verifiable format.

--- a/src/office-migration.ts
+++ b/src/office-migration.ts
@@ -196,6 +196,13 @@ function recordMigratedOffice(registry: OfficeRegistry, record: OfficeMigrationR
  * infrastructure, not hidden, and not already office-key named. A symlink in
  * office position is refused outright — following it could move data from
  * outside the workspace root.
+ *
+ * A candidate must also look like a conversation office: every office that
+ * ever saw a message has a `log.jsonl`, and every office that ran the agent
+ * has `sessions/`. Trusted workspace roots legitimately accumulate other
+ * directories — repos the agent cloned, build output — which are not offices
+ * and must be neither renamed nor reported as unowned; they stay where they
+ * are (an operator can still claim one explicitly via `mikan office claim`).
  */
 function listLegacyOfficeDirs(workspaceRoot: string): string[] {
   const candidates: string[] = [];
@@ -207,9 +214,19 @@ function listLegacyOfficeDirs(workspaceRoot: string): string[] {
       throw new Error(`Workspace entry must not be a symlink: ${join(workspaceRoot, entry.name)}`);
     }
     if (!entry.isDirectory()) continue;
+    if (!looksLikeConversationOffice(join(workspaceRoot, entry.name))) {
+      log.logInfo(
+        `[office] Skipping non-office workspace directory (no log.jsonl or sessions/): ${entry.name}`,
+      );
+      continue;
+    }
     candidates.push(entry.name);
   }
   return candidates.toSorted();
+}
+
+function looksLikeConversationOffice(dir: string): boolean {
+  return existsSync(join(dir, "log.jsonl")) || existsSync(join(dir, "sessions"));
 }
 
 function pathExists(path: string): boolean {

--- a/src/office-registry.ts
+++ b/src/office-registry.ts
@@ -18,6 +18,7 @@ import {
   conversationOfficeDir,
   validateOfficeAddress,
 } from "./office-address.js";
+import { parseGithubConversationId } from "./adapters/github/ids.js";
 import { effectiveStateDir } from "./cli/arg-grammar.js";
 import { isRecord, readTextFileIfExists } from "./utils/file-guards.js";
 import { atomicWritePrivateFile } from "./utils/fs-atomic.js";
@@ -151,7 +152,7 @@ export class OfficeRegistry {
       }
 
       assertRegularDirectory(sourceDir, "Legacy office source");
-      const ownerPlatform = this.resolveOwner(options.ownerPlatform);
+      const ownerPlatform = this.resolveOwner(options.ownerPlatform, rawConversationId);
       if (!ownerPlatform) {
         const record = makeRecord({
           rawConversationId,
@@ -250,7 +251,10 @@ export class OfficeRegistry {
     });
   }
 
-  private resolveOwner(ownerPlatform: PlatformName | undefined): PlatformName | undefined {
+  private resolveOwner(
+    ownerPlatform: PlatformName | undefined,
+    rawConversationId: string,
+  ): PlatformName | undefined {
     if (ownerPlatform !== undefined) {
       const validPlatform = assertPlatformName(ownerPlatform);
       if (!this.state.enabledPlatforms.includes(validPlatform)) {
@@ -258,7 +262,11 @@ export class OfficeRegistry {
       }
       return validPlatform;
     }
-    return this.state.enabledPlatforms.length === 1 ? this.state.enabledPlatforms[0] : undefined;
+    const candidates = platformsMatchingConversationIdFormat(
+      rawConversationId,
+      this.state.enabledPlatforms,
+    );
+    return candidates.length === 1 ? candidates[0] : undefined;
   }
 
   private requireMigration(rawConversationId: string): OfficeMigrationRecord {
@@ -789,6 +797,43 @@ function ensureRegularOfficeDirectory(dir: string): void {
   }
   if (stats.isSymbolicLink() || !stats.isDirectory()) {
     throw new Error(`Office directory must be a regular non-symlink directory: ${dir}`);
+  }
+}
+
+/**
+ * Enabled platforms whose id format could have produced this raw
+ * conversation id. Auto-claiming uses this as verification, not guessing:
+ * every format below is one mikan itself writes (GitHub ids are mikan-derived
+ * slugs; Slack/Telegram/Discord ids are the platforms' own grammars), and a
+ * directory is only claimed when exactly one enabled platform's format
+ * matches. Bare digits stay ambiguous while both Telegram and Discord are
+ * enabled (negative ids are Telegram-only); anything matching no enabled
+ * format fails closed to needs-owner.
+ */
+function platformsMatchingConversationIdFormat(
+  rawConversationId: string,
+  enabledPlatforms: readonly PlatformName[],
+): PlatformName[] {
+  return enabledPlatforms.filter((platform) => {
+    switch (platform) {
+      case "github":
+        return isGithubConversationId(rawConversationId);
+      case "telegram":
+        return /^-?\d+$/.test(rawConversationId);
+      case "discord":
+        return /^\d+$/.test(rawConversationId);
+      case "slack":
+        return /^[A-Z][A-Z0-9]*$/.test(rawConversationId);
+    }
+  });
+}
+
+function isGithubConversationId(rawConversationId: string): boolean {
+  try {
+    parseGithubConversationId(rawConversationId);
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/test/office-migration.test.ts
+++ b/test/office-migration.test.ts
@@ -339,6 +339,85 @@ describe("migrateLegacyOffices", () => {
     expect(formatUnmigratedOfficesError(summary)).toContain("<state-dir>/conversations");
   });
 
+  test("multi-platform: verifiable formats claim automatically, prod-style", () => {
+    const { stateDir, workspaceRoot } = makeFixture();
+    makeLegacyOffice(workspaceRoot, "C0AB12CD3");
+    makeLegacyOffice(workspaceRoot, "D0EF45GH6");
+    makeLegacyOffice(workspaceRoot, "GH_livingbio_genv-queue_1652");
+
+    const summary = migrateLegacyOffices({
+      workspaceRoot,
+      stateDir,
+      enabledPlatforms: ["slack", "github"],
+    });
+
+    expect(summary.unowned).toEqual([]);
+    expect(summary.migrated.toSorted()).toEqual([
+      "C0AB12CD3",
+      "D0EF45GH6",
+      "GH_livingbio_genv-queue_1652",
+    ]);
+    expect(existsSync(officeDir(workspaceRoot, createOfficeAddress("slack", "C0AB12CD3")))).toBe(
+      true,
+    );
+    expect(
+      existsSync(
+        officeDir(workspaceRoot, createOfficeAddress("github", "GH_livingbio_genv-queue_1652")),
+      ),
+    ).toBe(true);
+  });
+
+  test("a github-format dir is never claimed by a slack-only deployment", () => {
+    const { stateDir, workspaceRoot } = makeFixture();
+    makeLegacyOffice(workspaceRoot, "GH_octo_widgets_5");
+
+    const summary = migrateLegacyOffices({
+      workspaceRoot,
+      stateDir,
+      enabledPlatforms: ["slack"],
+    });
+
+    expect(summary.unowned).toEqual(["GH_octo_widgets_5"]);
+    expect(existsSync(join(workspaceRoot, "GH_octo_widgets_5"))).toBe(true);
+  });
+
+  test("bare digits stay ambiguous under telegram+discord; negative ids are telegram's", () => {
+    const { stateDir, workspaceRoot } = makeFixture();
+    makeLegacyOffice(workspaceRoot, "900100");
+    makeLegacyOffice(workspaceRoot, "-1001234567890");
+
+    const summary = migrateLegacyOffices({
+      workspaceRoot,
+      stateDir,
+      enabledPlatforms: ["discord", "telegram"],
+    });
+
+    expect(summary.unowned).toEqual(["900100"]);
+    expect(summary.migrated).toEqual(["-1001234567890"]);
+    expect(
+      existsSync(officeDir(workspaceRoot, createOfficeAddress("telegram", "-1001234567890"))),
+    ).toBe(true);
+  });
+
+  test("workspace directories without office markers are skipped, not claimed", () => {
+    const { stateDir, workspaceRoot } = makeFixture();
+    makeLegacyOffice(workspaceRoot, "C123");
+    // A repo the agent cloned into a trusted workspace root: no log.jsonl,
+    // no sessions/ — not an office, must stay put and not block boot.
+    mkdirSync(join(workspaceRoot, "pi-mono"), { recursive: true });
+    writeFileSync(join(workspaceRoot, "pi-mono", "README.md"), "repo\n");
+
+    const summary = migrateLegacyOffices({
+      workspaceRoot,
+      stateDir,
+      enabledPlatforms: ["slack"],
+    });
+
+    expect(summary.migrated).toEqual(["C123"]);
+    expect(summary.unowned).toEqual([]);
+    expect(existsSync(join(workspaceRoot, "pi-mono", "README.md"))).toBe(true);
+  });
+
   test("already office-key-shaped directories are left alone", () => {
     const { stateDir, workspaceRoot } = makeFixture();
     const canonical = officeDir(workspaceRoot, createOfficeAddress("slack", "C123"));

--- a/test/office-registry.test.ts
+++ b/test/office-registry.test.ts
@@ -74,18 +74,37 @@ describe("OfficeRegistry", () => {
     expect(existsSync(record.targetDir!)).toBe(false);
   });
 
-  test("multiple enabled platforms leave an unowned directory ambiguous", () => {
+  test("a uniquely matching id format claims even with several platforms enabled", () => {
     const fixture = makeFixture();
     const registry = new OfficeRegistry(fixture.stateDir);
     registry.enablePlatform("slack");
     registry.enablePlatform("discord");
 
+    // "C123" is Slack's grammar and cannot be a Discord snowflake.
     const record = registry.prepareLegacyMigration(fixture);
+
+    expect(record.status).toBe("prepared");
+    expect(record.ownerPlatform).toBe("slack");
+  });
+
+  test("an id matching several enabled formats stays unowned", () => {
+    const fixture = makeFixture();
+    const digitsDir = join(fixture.workspaceRoot, "900100");
+    mkdirSync(digitsDir, { recursive: true });
+    const registry = new OfficeRegistry(fixture.stateDir);
+    registry.enablePlatform("discord");
+    registry.enablePlatform("telegram");
+
+    const record = registry.prepareLegacyMigration({
+      rawConversationId: "900100",
+      sourceDir: digitsDir,
+      workspaceRoot: fixture.workspaceRoot,
+    });
 
     expect(record.status).toBe("needs-owner");
     expect(record.ownerPlatform).toBeUndefined();
     expect(record.targetDir).toBeUndefined();
-    expect(() => registry.markMoving("C123")).toThrow(/needs an owner/);
+    expect(() => registry.markMoving("900100")).toThrow(/needs an owner/);
   });
 
   test("an explicit owner resolves ambiguity without guessing from the raw id", () => {


### PR DESCRIPTION
Found by rehearsing the boot migration against a copy of production data (327 workspace entries, 292GB, Slack+GitHub enabled; structure pulled in full, contents sampled, vault names only).

## Three launch blockers the rehearsal surfaced

1. **295 manual claims**: with two platforms enabled, every legacy directory became `needs-owner` — the operator would have had to run `mikan office claim` 295 times.
2. **Silent mis-claim**: booting with only the Slack token set auto-claimed `GH_livingbio_genv-queue_1652` as `v1-slack-gh-…` — GitHub's conversations would have gone invisible once that platform came up. Reproduced, then fixed.
3. **Repos reported as offices**: trusted workspace roots accumulate agent-cloned repos (`pi-mono`, `gstudio`, `repos/`, `scratch/`…) — these were reported as unowned offices, telling the operator to claim a git checkout.

## Fix

- **Format-verified claiming** (ADR 0005 updated): auto-claim only when exactly one enabled platform's id format could have produced the name — GitHub's `GH_<owner>_<repo>_<n>` slug must parse back, Telegram allows negative numeric ids, Discord snowflakes are positive digits, Slack ids are uppercase alphanumerics with a letter prefix. Bare digits under Telegram+Discord stay ambiguous; unknown formats stay needs-owner; a single-platform deployment can never claim another platform's verifiable format.
- **Office-marker gate**: a candidate must contain `log.jsonl` or `sessions/`; anything else is skipped in place with a log line (still claimable explicitly).

## Rehearsal results (prod-shape data)

| run | migrated | unowned | time |
|---|---|---|---|
| before fix (slack+github) | 0 | **295** | boot fails |
| before fix (slack only) | 295 | 0 | **GH dirs mis-claimed** |
| after fix (slack+github) | **285** | **0** | 2.4s, repos untouched |

Content integrity: 293 sampled files checksum-identical through the rename, absolute symlinks in a real `.venv` survive, loose workspace files (`.env`, media) untouched, second run is a 13ms no-op.

1595 tests green; lint/fmt/knip/build/docs; Docker isolation gate green.