### PR TITLE
feat(office): make the door policy configurable from the portal and /pi-sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ any release.
 
 ## [Unreleased]
 
+### Added
+
+- Make the office door policy configurable: the Admin portal gains a per-office selector (global default / isolated / trusted shared-support / trusted full) plus a global-default selector, and the existing `/pi-sandbox` command gains `door <default|isolated|shared|full>` — both write the explicit `sandbox.workspace` settings and retire the legacy `image.workspaceMount` key on save.
+- Door-policy changes follow the same clear-or-refuse contract as model changes (the system prompt bakes the workspace projection), and the sandbox container is rebuilt with the new mounts on the office's next message.
+
 ## [1.0.0-beta.35]
 
 Completes the office storage migration introduced in 1.0.0-beta.34: sandbox containers now survive it with everything installed inside them intact. Upgrading directly from 1.0.0-beta.33 or earlier to this release keeps container contents; deployments that already booted 1.0.0-beta.34 had their containers recreated by that release.

--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -52,10 +52,11 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
   },
   {
     name: "sandbox",
-    description: "Show or temporarily boost this conversation's sandbox limits",
+    description: "Show sandbox status, boost limits, or set the office door policy",
     arg: {
       name: "action",
-      description: "Use 'boost' to temporarily apply the configured boost limits",
+      description:
+        "Use 'boost' to temporarily apply the configured boost limits, or 'door default|isolated|shared|full' to set this office's data door policy",
       required: false,
     },
     slackCommand: "/pi-sandbox",

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -1,9 +1,28 @@
+import type { WorkspacePolicyChoice } from "../config.js";
 import { resolveWorkspaceProjection } from "../workspace-projection/index.js";
 import { runtimeResourceKey } from "../sandbox/identity.js";
+import { applyConversationWorkspacePolicy } from "../settings-mutation.js";
 import { slashForms } from "./manifest.js";
 import { matchCommand } from "./parse.js";
 import type { CommandContext, CommandHandler, ParsedSandboxCommand } from "./types.js";
 import { formatCommandSummary, replyDiagnosticWithContext } from "./utils.js";
+
+/** Word → selection; null clears the override, undefined is an unknown word. */
+function doorChoiceFromWord(word: string): WorkspacePolicyChoice | null | undefined {
+  switch (word) {
+    case "default":
+      return null;
+    case "isolated":
+      return { doorPolicy: "isolated" };
+    case "shared":
+    case "shared-support":
+      return { doorPolicy: "trusted", layout: "shared-support" };
+    case "full":
+      return { doorPolicy: "trusted", layout: "full" };
+    default:
+      return undefined;
+  }
+}
 
 export type { ParsedSandboxCommand } from "./types.js";
 
@@ -13,9 +32,15 @@ export function parseSandboxCommand(text: string): ParsedSandboxCommand | null {
   const matched = matchCommand(text, SANDBOX_COMMANDS, { stripMention: true });
   if (!matched) return null;
 
-  const action = matched.args.length === 1 ? matched.args[0].toLowerCase() : undefined;
-  if (action === "boost") {
+  const action = matched.args.length > 0 ? matched.args[0].toLowerCase() : undefined;
+  if (action === "boost" && matched.args.length === 1) {
     return { action };
+  }
+  if (action === "door" && matched.args.length <= 2) {
+    return {
+      action,
+      ...(matched.args.length === 2 ? { doorPolicy: matched.args[1].toLowerCase() } : {}),
+    };
   }
   return {};
 }
@@ -65,6 +90,64 @@ export class SandboxCommandHandler implements CommandHandler {
           "已暫時提升此 conversation 的 sandbox 規格。",
           `Current: ${formatLimits(status.limits)}`,
           "boost 會在此 sandbox runtime 關閉後結束。",
+        ]),
+        { style: "muted" },
+      );
+      return true;
+    }
+
+    if (parsed.action === "door") {
+      const workspace = resolveWorkspaceProjection(context.services.workingDir, context.address);
+      if (parsed.doorPolicy === undefined) {
+        await replyDiagnosticWithContext(
+          context.responder,
+          formatCommandSummary("Sandbox Door", [
+            `Current: ${workspace.doorPolicy} / ${workspace.layout}`,
+            "",
+            "用法：`/pi-sandbox door <default|isolated|shared|full>`",
+            "- `default`：跟隨全域預設",
+            "- `isolated`：只掛載自己辦公室",
+            "- `shared`：辦公室 + 共用 MEMORY.md / skills / events",
+            "- `full`：掛載整個 workspace（全開）",
+          ]),
+          { style: "muted" },
+        );
+        return true;
+      }
+      const choice = doorChoiceFromWord(parsed.doorPolicy);
+      if (choice === undefined) {
+        await replyDiagnosticWithContext(
+          context.responder,
+          formatCommandSummary("Sandbox Door", [
+            `未知的 door policy：\`${parsed.doorPolicy}\``,
+            "可用值：`default`、`isolated`、`shared`、`full`",
+          ]),
+          { style: "muted" },
+        );
+        return true;
+      }
+      const result = applyConversationWorkspacePolicy(
+        context.services.runtime,
+        context.services.workingDir,
+        context.address,
+        choice,
+      );
+      if (!result.ok) {
+        await replyDiagnosticWithContext(
+          context.responder,
+          formatCommandSummary("Sandbox Door", [
+            "目前有工作正在執行，無法切換 door policy。等執行結束後再試一次。",
+          ]),
+          { style: "muted" },
+        );
+        return true;
+      }
+      const updated = resolveWorkspaceProjection(context.services.workingDir, context.address);
+      await replyDiagnosticWithContext(
+        context.responder,
+        formatCommandSummary("Sandbox Door", [
+          `Door policy 已更新。Effective: ${updated.doorPolicy} / ${updated.layout}`,
+          "下一則訊息時會以新的掛載重建 sandbox 容器；先前在容器內安裝的軟體會重置。",
         ]),
         { style: "muted" },
       );

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -145,7 +145,9 @@ export interface ParsedModelCommand {
 }
 
 export interface ParsedSandboxCommand {
-  action?: "boost";
+  action?: "boost" | "door";
+  /** Raw door-policy argument; the handler validates it so typos get a usage reply. */
+  doorPolicy?: string;
 }
 
 export type ParsedLoginCommand =

--- a/src/config.ts
+++ b/src/config.ts
@@ -563,24 +563,28 @@ function patchSettingsConfig(
   return compactSettingsConfig(patched);
 }
 
+function loadSettingsFileForUpdate(
+  settingsPath: string,
+  defaultSettings: SettingsFileConfig,
+): SettingsFileConfig {
+  if (!existsSync(settingsPath)) return defaultSettings;
+  try {
+    return loadSettingsFile(settingsPath) ?? {};
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const message = detail.startsWith("Malformed settings file")
+      ? detail.replace("Malformed settings file", "Refusing to overwrite malformed settings file")
+      : detail;
+    throw new Error(message, { cause: err });
+  }
+}
+
 function updateSettingsFile(
   settingsPath: string,
   patch: Partial<AgentConfig>,
   defaultSettings: SettingsFileConfig,
 ): void {
-  let existing = defaultSettings;
-  if (existsSync(settingsPath)) {
-    try {
-      existing = loadSettingsFile(settingsPath) ?? {};
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      const message = detail.startsWith("Malformed settings file")
-        ? detail.replace("Malformed settings file", "Refusing to overwrite malformed settings file")
-        : detail;
-      throw new Error(message, { cause: err });
-    }
-  }
-
+  const existing = loadSettingsFileForUpdate(settingsPath, defaultSettings);
   ensureDirExists(dirname(settingsPath));
   atomicWritePrivateFile(
     settingsPath,
@@ -597,4 +601,69 @@ export function updateConversationSettings(
   patch: Partial<AgentConfig>,
 ): void {
   updateSettingsFile(conversationSettingsPath(scope), patch, {});
+}
+
+/** An explicit office door-policy selection; `layout` only exists behind a trusted door. */
+export type WorkspacePolicyChoice =
+  | { doorPolicy: "isolated" }
+  | { doorPolicy: "trusted"; layout: "shared-support" | "full" };
+
+/**
+ * The conversation's own door-policy override (legacy `image.workspaceMount`
+ * included), or null when the office follows the global default.
+ */
+export function loadConversationWorkspaceOverride(
+  scope: ConversationSettingsScope,
+): WorkspacePolicyChoice | null {
+  const file = loadSettingsFile(conversationSettingsPath(scope));
+  const sandbox = file?.sandbox;
+  if (sandbox?.workspace?.doorPolicy === "isolated") return { doorPolicy: "isolated" };
+  if (sandbox?.workspace?.doorPolicy === "trusted") {
+    return {
+      doorPolicy: "trusted",
+      layout: sandbox.workspace.layout === "full" ? "full" : "shared-support",
+    };
+  }
+  if (sandbox?.image?.workspaceMount === "full") return { doorPolicy: "trusted", layout: "full" };
+  if (sandbox?.image?.workspaceMount === "private") {
+    return { doorPolicy: "trusted", layout: "shared-support" };
+  }
+  return null;
+}
+
+export function setConversationWorkspacePolicy(
+  scope: ConversationSettingsScope,
+  choice: WorkspacePolicyChoice | null,
+): void {
+  writeWorkspacePolicy(conversationSettingsPath(scope), choice, {});
+}
+
+export function setGlobalWorkspacePolicy(choice: WorkspacePolicyChoice | null): void {
+  writeWorkspacePolicy(join(getStateDir(), "settings.json"), choice, ONBOARD_SETTINGS);
+}
+
+/**
+ * The generic settings patch merges leaves and cannot remove keys, so the
+ * door-policy writer edits the file shape directly: it always drops the
+ * legacy `image.workspaceMount` (the explicit choice replaces it) and either
+ * sets or removes the `workspace` group.
+ */
+function writeWorkspacePolicy(
+  settingsPath: string,
+  choice: WorkspacePolicyChoice | null,
+  defaultSettings: SettingsFileConfig,
+): void {
+  const existing = loadSettingsFileForUpdate(settingsPath, defaultSettings);
+  const { workspaceMount: _legacy, ...image } = existing.sandbox?.image ?? {};
+  const { workspace: _previous, image: _image, ...sandboxRest } = existing.sandbox ?? {};
+  const sandbox: SandboxSettings = {
+    ...sandboxRest,
+    ...(hasDefinedValue(image) ? { image } : {}),
+    ...(choice ? { workspace: choice } : {}),
+  };
+  ensureDirExists(dirname(settingsPath));
+  atomicWritePrivateFile(
+    settingsPath,
+    JSON.stringify(compactSettingsConfig({ ...existing, sandbox }), null, 2),
+  );
 }

--- a/src/settings-mutation.ts
+++ b/src/settings-mutation.ts
@@ -16,7 +16,13 @@
  *   their old runner until it settles, are reported as stale, and are cleared
  *   automatically before their next turn.
  */
-import { updateConversationSettings, updateGlobalSettings } from "./config.js";
+import {
+  setConversationWorkspacePolicy,
+  setGlobalWorkspacePolicy,
+  updateConversationSettings,
+  updateGlobalSettings,
+  type WorkspacePolicyChoice,
+} from "./config.js";
 import { conversationOfficeDir } from "./office-address.js";
 import type {
   AgentConfig,
@@ -64,5 +70,37 @@ export function applyGlobalSettings(
   updateGlobalSettings(patch);
   const staleConversations =
     affectsCachedRunner(patch) && runtime ? runtime.refreshAllConversations().busy : [];
+  return { ok: true, staleConversations };
+}
+
+/**
+ * Door-policy changes follow the same clear-or-refuse contract as model
+ * changes: the system prompt bakes the workspace projection (layout line,
+ * memory and skill guidance), so the cached runner must clear before the
+ * write, and the container is re-provisioned on the next message when its
+ * mount signature no longer matches.
+ */
+export function applyConversationWorkspacePolicy(
+  runtime: RunnerCacheControl | undefined,
+  workingDir: string,
+  address: OfficeAddress,
+  choice: WorkspacePolicyChoice | null,
+): SettingsApplyResult {
+  if (runtime && !runtime.refreshConversationEnvironment(address)) {
+    return { ok: false, reason: "busy" };
+  }
+  setConversationWorkspacePolicy(
+    { address, conversationDir: conversationOfficeDir(workingDir, address) },
+    choice,
+  );
+  return { ok: true, runtimeSwitched: runtime ? true : null };
+}
+
+export function applyGlobalWorkspacePolicy(
+  runtime: GlobalRunnerCacheControl | undefined,
+  choice: WorkspacePolicyChoice | null,
+): { ok: true; staleConversations: OfficeAddress[] } {
+  setGlobalWorkspacePolicy(choice);
+  const staleConversations = runtime ? runtime.refreshAllConversations().busy : [];
   return { ok: true, staleConversations };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -650,6 +650,8 @@ export interface EnvGroup {
 
 export interface RunnerCacheControl {
   switchConversationModel(address: OfficeAddress, provider: string, model: string): boolean;
+  /** Clear the office's cached runner for a non-model settings change; false while busy. */
+  refreshConversationEnvironment(address: OfficeAddress): boolean;
 }
 
 export interface GlobalRunnerCacheControl {

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -6,13 +6,20 @@ import type { EventStore } from "../../tools/types.js";
 
 import {
   loadConversationAutoReplyConfig,
+  loadConversationWorkspaceOverride,
   loadGlobalSettings,
   resolveConversationSettings,
   saveConversationAutoReplyConfig,
   type AgentConfig,
   type SandboxSettings,
+  type WorkspacePolicyChoice,
 } from "../../config.js";
-import { applyConversationSettings, applyGlobalSettings } from "../../settings-mutation.js";
+import {
+  applyConversationSettings,
+  applyConversationWorkspacePolicy,
+  applyGlobalSettings,
+  applyGlobalWorkspacePolicy,
+} from "../../settings-mutation.js";
 import { effectiveStateDir } from "../../cli/arg-grammar.js";
 import {
   addPackage,
@@ -206,6 +213,10 @@ async function routeApiRequest(
   }
   if (url.pathname === "/admin/api/settings/model") {
     serveGlobalModelUpdate(res, body, services);
+    return;
+  }
+  if (url.pathname === "/admin/api/settings/workspace") {
+    serveGlobalWorkspaceUpdate(res, body, services);
     return;
   }
   if (url.pathname === "/admin/api/settings/sandbox") {
@@ -627,6 +638,9 @@ function serveConversationState(
     globalThinkingLevel: globalConfig.thinkingLevel,
     workspaceDoorPolicy: conversationWorkspace.doorPolicy,
     workspaceLayout: conversationWorkspace.layout,
+    workspaceOverride: doorPolicyChoiceKey(
+      loadConversationWorkspaceOverride({ address: scope.address, conversationDir: dir }),
+    ),
     globalWorkspaceDoorPolicy: globalWorkspaceSettings?.doorPolicy ?? "isolated",
     globalWorkspaceLayout: globalWorkspaceSettings?.layout ?? "conversation",
     autoReplyEnabled: autoReply.enabled,
@@ -728,15 +742,87 @@ function serveConversationModelUpdate(
   }
 }
 
+/** Wire values for a door-policy selection; "default" clears the office's override. */
+function parseDoorPolicyChoice(
+  value: unknown,
+): { choice: WorkspacePolicyChoice | null } | undefined {
+  switch (value) {
+    case "default":
+      return { choice: null };
+    case "isolated":
+      return { choice: { doorPolicy: "isolated" } };
+    case "trusted-shared-support":
+      return { choice: { doorPolicy: "trusted", layout: "shared-support" } };
+    case "trusted-full":
+      return { choice: { doorPolicy: "trusted", layout: "full" } };
+    default:
+      return undefined;
+  }
+}
+
+function doorPolicyChoiceKey(choice: WorkspacePolicyChoice | null): string {
+  if (!choice) return "default";
+  if (choice.doorPolicy === "isolated") return "isolated";
+  return choice.layout === "full" ? "trusted-full" : "trusted-shared-support";
+}
+
 function serveConversationSandboxUpdate(
   res: ServerResponse,
-  _body: Record<string, unknown>,
-  _services: AdminServices,
-  _token: AdminToken,
+  body: Record<string, unknown>,
+  services: AdminServices,
+  token: AdminToken,
 ): void {
-  jsonRes(res, 403, {
-    error: "Office door policy is host-controlled until administrator authorization is configured",
-  });
+  const parsed = parseDoorPolicyChoice(body.doorPolicy);
+  if (!parsed) {
+    jsonRes(res, 400, {
+      error:
+        "doorPolicy must be 'default', 'isolated', 'trusted-shared-support', or 'trusted-full'",
+    });
+    return;
+  }
+  const scope = resolveTargetConversation(body, token);
+  if (scope.error) {
+    jsonRes(res, 403, { error: scope.error });
+    return;
+  }
+  const workingDir = requireAdminWorkingDir(res, services);
+  if (!workingDir) return;
+  try {
+    const result = applyConversationWorkspacePolicy(
+      services.runtime,
+      workingDir,
+      scope.address,
+      parsed.choice,
+    );
+    if (!result.ok) {
+      jsonRes(res, 409, { error: "Conversation is busy; retry when the current run finishes" });
+      return;
+    }
+    jsonRes(res, 200, { ok: true });
+  } catch (err) {
+    jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+function serveGlobalWorkspaceUpdate(
+  res: ServerResponse,
+  body: Record<string, unknown>,
+  services: AdminServices,
+): void {
+  const parsed = parseDoorPolicyChoice(body.doorPolicy);
+  if (!parsed) {
+    jsonRes(res, 400, {
+      error:
+        "doorPolicy must be 'default', 'isolated', 'trusted-shared-support', or 'trusted-full'",
+    });
+    return;
+  }
+  try {
+    const result = applyGlobalWorkspacePolicy(services.runtime, parsed.choice);
+    jsonRes(res, 200, { ok: true, staleConversations: result.staleConversations.length });
+  } catch (err) {
+    jsonRes(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
 }
 
 function serveConversationSlackUpdate(
@@ -1978,6 +2064,15 @@ function renderAdminPage(token: AdminToken): string {
       const globalReplyMode = (data.slack && data.slack.globalReplyMode) || 'top-level';
       const globalModel = [data.globalProvider, data.globalModel].filter(Boolean).join('/');
       const globalModelLabel = globalModel + (data.globalThinkingLevel ? ':' + data.globalThinkingLevel : '');
+      const doorPolicyChoices = [
+        ['default', 'Global default (' + data.globalWorkspaceDoorPolicy + ' / ' + data.globalWorkspaceLayout + ')'],
+        ['isolated', 'isolated — own office only'],
+        ['trusted-shared-support', 'trusted / shared-support — office + shared memory, skills, events'],
+        ['trusted-full', 'trusted / full — entire workspace'],
+      ];
+      const doorPolicyOpts = doorPolicyChoices.map(([value, label]) =>
+        '<option value="' + value + '"' + ((data.workspaceOverride || 'default') === value ? ' selected' : '') + '>' + escHtml(label) + '</option>'
+      ).join('');
       return [
         '<div class="config-grid">',
           '<div class="config-block">',
@@ -1997,7 +2092,10 @@ function renderAdminPage(token: AdminToken): string {
           '</div>',
           '<div class="config-block">',
             '<h3 class="card-subtitle">Office data policy</h3>',
-            '<p class="muted-note">Door policy is host-controlled until administrator authorization is configured. Effective: ' + escHtml(data.workspaceDoorPolicy + ' / ' + data.workspaceLayout) + '</p>',
+            '<div class="config-row"><label>Door policy</label><select id="m-door-policy">' + doorPolicyOpts + '</select></div>',
+            '<p class="muted-note">Effective: ' + escHtml(data.workspaceDoorPolicy + ' / ' + data.workspaceLayout) + '</p>',
+            '<p class="muted-note">Changing the policy rebuilds the office sandbox container on its next message; software installed inside it is reset.</p>',
+            '<button class="primary-action-btn" onclick="saveDoorPolicy(this)">Save door policy</button>',
             '<div id="mount-save-result" class="inline-result" style="display:none"></div>',
           '</div>',
           '<div class="config-block">',
@@ -2067,6 +2165,23 @@ function renderAdminPage(token: AdminToken): string {
         result.style.display = 'block'; result.className = 'inline-result err'; result.textContent = err.message;
       } finally {
         btn.disabled = false; btn.textContent = 'Save Slack';
+      }
+    }
+
+    async function saveDoorPolicy(btn) {
+      const doorPolicy = document.getElementById('m-door-policy').value;
+      const result = document.getElementById('mount-save-result');
+      btn.disabled = true; btn.textContent = 'Saving…'; result.style.display = 'none';
+      try {
+        await apiPost('/admin/api/conversations/sandbox', {
+          ...scopeBody(), doorPolicy,
+        });
+        result.style.display = 'block'; result.className = 'inline-result ok'; result.textContent = 'Saved ✓';
+        loadSettings();
+      } catch (err) {
+        result.style.display = 'block'; result.className = 'inline-result err'; result.textContent = err.message;
+      } finally {
+        btn.disabled = false; btn.textContent = 'Save door policy';
       }
     }
 
@@ -2599,6 +2714,17 @@ function renderAdminPage(token: AdminToken): string {
       const replyModeOpts = replyModes.map((m) =>
         '<option value="' + m + '"' + (((data.slack && data.slack.replyMode) || 'top-level') === m ? ' selected' : '') + '>' + m + '</option>'
       ).join('');
+      const gDoorKey = data.workspaceDoorPolicy === 'isolated'
+        ? 'isolated'
+        : (data.workspaceLayout === 'full' ? 'trusted-full' : 'trusted-shared-support');
+      const gDoorPolicyChoices = [
+        ['isolated', 'isolated — own office only (built-in default)'],
+        ['trusted-shared-support', 'trusted / shared-support — office + shared memory, skills, events'],
+        ['trusted-full', 'trusted / full — entire workspace'],
+      ];
+      const gDoorPolicyOpts = gDoorPolicyChoices.map(([value, label]) =>
+        '<option value="' + value + '"' + (gDoorKey === value ? ' selected' : '') + '>' + escHtml(label) + '</option>'
+      ).join('');
       return [
         '<div class="config-grid">',
           '<div class="config-block">',
@@ -2614,9 +2740,15 @@ function renderAdminPage(token: AdminToken): string {
             '<div class="config-row"><label>Memory</label><input id="g-mem" placeholder="1g" value="' + escAttr(data.sandboxMemory || '') + '"></div>',
             '<div class="config-row"><label>Boost CPUs</label><input id="g-bcpus" placeholder="2" value="' + escAttr(data.sandboxBoostCpus || '') + '"></div>',
             '<div class="config-row"><label>Boost Mem</label><input id="g-bmem" placeholder="4g" value="' + escAttr(data.sandboxBoostMemory || '') + '"></div>',
-            '<p class="muted-note">Office door policy is configured in host settings. Effective default: ' + escHtml(data.workspaceDoorPolicy + ' / ' + data.workspaceLayout) + '</p>',
             '<button class="primary-action-btn" onclick="saveGlobalSandbox(this)">Save sandbox</button>',
             '<div id="g-sandbox-result" class="inline-result" style="display:none"></div>',
+          '</div>',
+          '<div class="config-block">',
+            '<h3 class="card-subtitle">Office door policy</h3>',
+            '<div class="config-row"><label>Default</label><select id="g-door-policy">' + gDoorPolicyOpts + '</select></div>',
+            '<p class="muted-note">Applies to offices without their own policy. Affected offices rebuild their sandbox container on the next message; software installed inside is reset.</p>',
+            '<button class="primary-action-btn" onclick="saveGlobalWorkspace(this)">Save door policy</button>',
+            '<div id="g-workspace-result" class="inline-result" style="display:none"></div>',
           '</div>',
           '<div class="config-block">',
             '<h3 class="card-subtitle">Slack</h3>',
@@ -2663,6 +2795,23 @@ function renderAdminPage(token: AdminToken): string {
         result.style.display = 'block'; result.className = 'inline-result err'; result.textContent = err.message;
       } finally {
         btn.disabled = false; btn.textContent = 'Save sandbox';
+      }
+    }
+
+    async function saveGlobalWorkspace(btn) {
+      const doorPolicy = document.getElementById('g-door-policy').value;
+      const result = document.getElementById('g-workspace-result');
+      btn.disabled = true; btn.textContent = 'Saving…'; result.style.display = 'none';
+      try {
+        const data = await apiPost('/admin/api/settings/workspace', { doorPolicy });
+        result.style.display = 'block'; result.className = 'inline-result ok';
+        result.textContent = data.staleConversations > 0
+          ? 'Saved ✓ (' + data.staleConversations + ' busy conversation(s) refresh after their current run)'
+          : 'Saved ✓';
+      } catch (err) {
+        result.style.display = 'block'; result.className = 'inline-result err'; result.textContent = err.message;
+      } finally {
+        btn.disabled = false; btn.textContent = 'Save door policy';
       }
     }
 

--- a/src/web/admin/types.ts
+++ b/src/web/admin/types.ts
@@ -10,6 +10,7 @@ import type { InMemoryAdminTokenStore } from "./store.js";
 export interface AdminRuntimeBridge {
   getRunningSessions(): RunningSession[];
   switchConversationModel(address: OfficeAddress, provider: string, model: string): boolean;
+  refreshConversationEnvironment(address: OfficeAddress): boolean;
   refreshAllConversations(): { busy: OfficeAddress[] };
 }
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -7,7 +7,11 @@ import { MikanModels } from "../src/harness/index.js";
 import { AdminCommandHandler } from "../src/commands/admin.js";
 import { AutoReplyCommandHandler } from "../src/commands/auto-reply.js";
 import { ExtensionsCommandHandler } from "../src/commands/extensions.js";
-import { conversationSettingsPath, createGlobalSettingsFile } from "../src/config.js";
+import {
+  conversationSettingsPath,
+  createGlobalSettingsFile,
+  loadConversationWorkspaceOverride,
+} from "../src/config.js";
 import { dispatchCommand } from "../src/commands/registry.js";
 import { LoginCommandHandler, parseLoginCommand } from "../src/commands/login.js";
 import { ModelCommandHandler } from "../src/commands/model.js";
@@ -794,6 +798,84 @@ describe("SandboxCommandHandler", () => {
       ),
     ).toEqual({});
     expect(ctx.responder.responses[0]).toContain("Workspace policy: isolated");
+  });
+
+  function doorContext(commandText: string, refreshResult = true) {
+    return buildContext({
+      commandText,
+      conversationId: "C123",
+      services: {
+        workingDir,
+        sandbox: { type: "image", image: "ubuntu:24.04" },
+        runtime: {
+          refreshConversationEnvironment: vi.fn().mockReturnValue(refreshResult),
+          switchConversationModel: vi.fn(),
+        } as any,
+        resourceController: {
+          getLimitStatus: () => ({ limits: undefined, boosted: false }),
+          getDefaultLimits: () => undefined,
+          getBoostLimits: () => undefined,
+        } as any,
+      },
+    });
+  }
+
+  function doorSettingsFile(): string {
+    return conversationSettingsPath({
+      address: createOfficeAddress("slack", "C123"),
+      conversationDir: join(workingDir, "C123"),
+    });
+  }
+
+  function doorOverride() {
+    return loadConversationWorkspaceOverride({
+      address: createOfficeAddress("slack", "C123"),
+      conversationDir: join(workingDir, "C123"),
+    });
+  }
+
+  test("door without an argument shows usage and the current policy", async () => {
+    const ctx = doorContext("/pi-sandbox door");
+    expect(await handler.tryHandle(ctx)).toBe(true);
+    expect(ctx.responder.responses[0]).toContain("Current: isolated / conversation");
+    expect(ctx.responder.responses[0]).toContain("door <default|isolated|shared|full>");
+    expect(doorOverride()).toBeNull();
+  });
+
+  test("door full writes the override, clears the runner, and warns about the rebuild", async () => {
+    const ctx = doorContext("/pi-sandbox door full");
+    expect(await handler.tryHandle(ctx)).toBe(true);
+    const written = JSON.parse(readFileSync(doorSettingsFile(), "utf-8"));
+    expect(written.sandbox.workspace).toEqual({ doorPolicy: "trusted", layout: "full" });
+    expect(ctx.services.runtime?.refreshConversationEnvironment).toHaveBeenCalledWith(
+      createOfficeAddress("slack", "C123"),
+    );
+    expect(ctx.responder.responses[0]).toContain("Effective: trusted / full");
+    expect(ctx.responder.responses[0]).toContain("重建 sandbox 容器");
+  });
+
+  test("door default clears an existing override", async () => {
+    const setCtx = doorContext("/pi-sandbox door shared");
+    expect(await handler.tryHandle(setCtx)).toBe(true);
+    const clearCtx = doorContext("/pi-sandbox door default");
+    expect(await handler.tryHandle(clearCtx)).toBe(true);
+    const written = JSON.parse(readFileSync(doorSettingsFile(), "utf-8"));
+    expect(written.sandbox?.workspace).toBeUndefined();
+    expect(clearCtx.responder.responses[0]).toContain("Effective: isolated / conversation");
+  });
+
+  test("door refuses while the conversation is busy", async () => {
+    const ctx = doorContext("/pi-sandbox door isolated", false);
+    expect(await handler.tryHandle(ctx)).toBe(true);
+    expect(ctx.responder.responses[0]).toContain("工作正在執行");
+    expect(doorOverride()).toBeNull();
+  });
+
+  test("door rejects unknown policies with the accepted values", async () => {
+    const ctx = doorContext("/pi-sandbox door banana");
+    expect(await handler.tryHandle(ctx)).toBe(true);
+    expect(ctx.responder.responses[0]).toContain("未知的 door policy");
+    expect(doorOverride()).toBeNull();
   });
 
   test("boosts a Gondolin conversation", async () => {

--- a/test/settings-mutation.test.ts
+++ b/test/settings-mutation.test.ts
@@ -2,8 +2,18 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { createOfficeAddress, officeStateDir } from "../src/office-address.js";
-import { applyConversationSettings, applyGlobalSettings } from "../src/settings-mutation.js";
+import { loadConversationWorkspaceOverride } from "../src/config.js";
+import {
+  createOfficeAddress,
+  conversationOfficeDir,
+  officeStateDir,
+} from "../src/office-address.js";
+import {
+  applyConversationSettings,
+  applyConversationWorkspacePolicy,
+  applyGlobalSettings,
+  applyGlobalWorkspacePolicy,
+} from "../src/settings-mutation.js";
 
 const C1 = createOfficeAddress("slack", "C1");
 
@@ -76,6 +86,75 @@ describe("applyConversationSettings", () => {
     });
     expect(result).toEqual({ ok: true, runtimeSwitched: null });
     expect(existsSync(conversationSettingsFile("C1"))).toBe(true);
+  });
+});
+
+describe("applyConversationWorkspacePolicy", () => {
+  const scope = () => ({ address: C1, conversationDir: conversationOfficeDir(workingDir, C1) });
+
+  test("writes the explicit choice, clears the legacy mount, keeps other leaves", () => {
+    applyConversationSettings(undefined, workingDir, C1, {
+      sandbox: { cpus: "2", image: { workspaceMount: "full" } },
+    });
+    const runtime = {
+      switchConversationModel: vi.fn(),
+      refreshConversationEnvironment: vi.fn().mockReturnValue(true),
+    };
+    const result = applyConversationWorkspacePolicy(runtime, workingDir, C1, {
+      doorPolicy: "trusted",
+      layout: "shared-support",
+    });
+    expect(result).toEqual({ ok: true, runtimeSwitched: true });
+    expect(runtime.refreshConversationEnvironment).toHaveBeenCalledWith(C1);
+    const written = JSON.parse(readFileSync(conversationSettingsFile("C1"), "utf-8"));
+    expect(written.sandbox.workspace).toEqual({ doorPolicy: "trusted", layout: "shared-support" });
+    expect(written.sandbox.image).toBeUndefined();
+    expect(written.sandbox.cpus).toBe("2");
+  });
+
+  test("null clears both the explicit override and the legacy mount", () => {
+    applyConversationSettings(undefined, workingDir, C1, {
+      sandbox: { image: { workspaceMount: "private" } },
+    });
+    const result = applyConversationWorkspacePolicy(undefined, workingDir, C1, null);
+    expect(result).toEqual({ ok: true, runtimeSwitched: null });
+    const written = JSON.parse(readFileSync(conversationSettingsFile("C1"), "utf-8"));
+    expect(written.sandbox).toBeUndefined();
+    expect(loadConversationWorkspaceOverride(scope())).toBeNull();
+  });
+
+  test("busy conversation refuses without writing", () => {
+    const runtime = {
+      switchConversationModel: vi.fn(),
+      refreshConversationEnvironment: vi.fn().mockReturnValue(false),
+    };
+    const result = applyConversationWorkspacePolicy(runtime, workingDir, C1, {
+      doorPolicy: "isolated",
+    });
+    expect(result).toEqual({ ok: false, reason: "busy" });
+    expect(existsSync(conversationSettingsFile("C1"))).toBe(false);
+  });
+
+  test("legacy workspaceMount reads back as a trusted override", () => {
+    applyConversationSettings(undefined, workingDir, C1, {
+      sandbox: { image: { workspaceMount: "full" } },
+    });
+    expect(loadConversationWorkspaceOverride(scope())).toEqual({
+      doorPolicy: "trusted",
+      layout: "full",
+    });
+  });
+});
+
+describe("applyGlobalWorkspacePolicy", () => {
+  test("writes the global default and reports busy conversations", () => {
+    const busyOffice = createOfficeAddress("slack", "C9");
+    const runtime = { refreshAllConversations: vi.fn().mockReturnValue({ busy: [busyOffice] }) };
+    const result = applyGlobalWorkspacePolicy(runtime, { doorPolicy: "trusted", layout: "full" });
+    expect(result).toEqual({ ok: true, staleConversations: [busyOffice] });
+    const written = JSON.parse(readFileSync(join(stateDir, "settings.json"), "utf-8"));
+    expect(written.sandbox.workspace).toEqual({ doorPolicy: "trusted", layout: "full" });
+    expect(written.sandbox.cpus).toBe("0.5");
   });
 });
 


### PR DESCRIPTION
The Admin portal's "Office data policy" card was read-only after the office refactor retired the raw-id mount editor, so there was nowhere to change an office's door policy (user report: testing in a legacy trusted/full office). This restores control on two surfaces, both host-side:

## Portal
- Per-office selector: **Global default / isolated / trusted shared-support / trusted full**, preselected from the office's own override (legacy `image.workspaceMount` included), with the effective value and a rebuild warning shown alongside.
- Global settings page: matching default selector; reports how many busy conversations refresh later.

## Chat
- `/pi-sandbox door <default|isolated|shared|full>` on the existing command — no Slack App manifest change needed. Bare `door` shows current policy + usage; unknown words get the accepted values; bare `private`/`full` words still do nothing (unchanged).

## Semantics
- Writes go through a new settings-mutation seam (`applyConversationWorkspacePolicy` / `applyGlobalWorkspacePolicy`): clear-or-refuse the cached runner first (the system prompt bakes the workspace projection), reusing `refreshConversationEnvironment`; busy → 409/refusal reply, no write.
- Files store the explicit `sandbox.workspace` group and always retire the legacy `image.workspaceMount` key; "default" removes the override — a removal the leaf-merging patch path cannot express, hence the dedicated writer in config.ts.
- Container rebuild happens naturally on the next message via the mount-signature drift check.

## Verification
- 1614 tests (+10): seam write/clear/busy/reset matrix, legacy read-back, `/pi-sandbox door` usage/set/clear/busy/unknown; lint/fmt/knip/build/docs green.