### PR TITLE
fix(skills): align the conversation symlink guard with the loader's read surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ any release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Align the conversation-skill symlink guard with what the host actually reads: symlinked entries are skipped per skill — with the skipped paths named in the host log and surfaced to the agent in its prompt — instead of one symlink anywhere disqualifying the whole tree, and symlinks inside vendored `node_modules` or dot directories (which the loader never reads) no longer disqualify anything. Offices whose skills vanished because a skill vendored npm dependencies (`.bin` symlinks) get them back.
+
 ## [1.0.0-beta.37]
 
 ### Fixed

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -33,7 +33,7 @@ import {
   settleSubagentProgress,
 } from "./subagent-progress.js";
 import { createHash } from "crypto";
-import { existsSync, lstatSync, readdirSync } from "fs";
+import { existsSync, lstatSync } from "fs";
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { basename, isAbsolute, join, posix, relative, resolve, sep } from "path";
@@ -318,7 +318,7 @@ function loadMikanSkills(
   conversationDir: string,
   workspacePath: string,
   projection: WorkspaceProjection,
-): MikanSkill[] {
+): { skills: MikanSkill[]; skippedSkillLinks: string[] } {
   const skillMap = new Map<string, MikanSkill>();
 
   // conversationDir is the host path (e.g., /Users/.../data/C0A34FL8PMH)
@@ -374,48 +374,28 @@ function loadMikanSkills(
 
   // Load conversation-specific skills (override workspace skills on collision).
   // Host prompt construction must never follow an agent-created symlink out of
-  // the conversation office.
+  // the conversation office, so this load rejects symlinks per entry — on
+  // exactly the paths it reads. Vendored node_modules and dot directories are
+  // never read and never disqualify anything.
   const conversationSkillsDir = projection.promptSources.conversationSkillsDir;
-  if (isSafePromptSkillTree(conversationSkillsDir, projection.promptSources.conversationDir)) {
-    for (const skill of loadSkillsFromDir({ dir: conversationSkillsDir, source: "channel" })
-      .skills) {
-      skill.filePath = translatePath(skill.filePath);
-      skill.baseDir = translatePath(skill.baseDir);
-      skillMap.set(skill.name, skill);
-    }
-  } else if (existsSync(conversationSkillsDir)) {
-    log.logWarning("Ignoring unsafe conversation skill tree", conversationSkillsDir);
+  const conversationSkills = loadSkillsFromDir({
+    dir: conversationSkillsDir,
+    source: "channel",
+    rejectSymlinks: true,
+  });
+  const skippedSkillLinks: string[] = [];
+  for (const diagnostic of conversationSkills.diagnostics) {
+    if (diagnostic.code !== "symlink") continue;
+    log.logWarning("Skipping conversation skill entry (symlink)", diagnostic.path);
+    skippedSkillLinks.push(translatePath(diagnostic.path));
+  }
+  for (const skill of conversationSkills.skills) {
+    skill.filePath = translatePath(skill.filePath);
+    skill.baseDir = translatePath(skill.baseDir);
+    skillMap.set(skill.name, skill);
   }
 
-  return Array.from(skillMap.values());
-}
-
-export function isSafePromptSkillTree(dir: string, conversationDir: string): boolean {
-  if (!existsSync(dir)) return true;
-  if (dir !== conversationDir && !dir.startsWith(`${conversationDir}${sep}`)) return false;
-  const stack = [dir];
-  while (stack.length > 0) {
-    const current = stack.pop()!;
-    let stats;
-    try {
-      stats = lstatSync(current);
-    } catch {
-      return false;
-    }
-    if (stats.isSymbolicLink()) return false;
-    if (!stats.isDirectory()) continue;
-    let entries;
-    try {
-      entries = readdirSync(current, { withFileTypes: true });
-    } catch {
-      return false;
-    }
-    for (const entry of entries) {
-      if (entry.isSymbolicLink()) return false;
-      stack.push(join(current, entry.name));
-    }
-  }
-  return true;
+  return { skills: Array.from(skillMap.values()), skippedSkillLinks };
 }
 
 function buildRuntimePaths(runtimeWorkspaceRoot: string, address: OfficeAddress) {
@@ -483,6 +463,7 @@ function buildSystemPrompt(
   platform: MessagingInfo,
   skills: MikanSkill[],
   projection: WorkspaceProjection,
+  skippedSkillLinks: string[] = [],
 ): string {
   const { workspaceRoot, conversationPath, scratchPath } = buildRuntimePaths(
     workspacePath,
@@ -605,7 +586,11 @@ Scripts are in: {baseDir}/
 \`name\` and \`description\` are required. Use \`{baseDir}\` as placeholder for the skill's directory path.
 
 ### Available Skills
-${skills.length > 0 ? formatSkillsForPrompt(skills) : "(no skills installed yet)"}
+${skills.length > 0 ? formatSkillsForPrompt(skills) : "(no skills installed yet)"}${
+    skippedSkillLinks.length > 0
+      ? `\n\nNote: these skill entries were skipped because they are symlinks, which the host never follows when reading this conversation's skills: ${skippedSkillLinks.join(", ")}. Replace each with a real file or directory (for example \`cp -rL\`) to load it.`
+      : ""
+  }
 
 ## Events
 Use the \`event\` tool to schedule immediate, one-shot, or periodic follow-ups. It writes to the host-side mikan control plane and fills routing fields for the current conversation automatically.
@@ -1568,10 +1553,13 @@ async function prepareRunContext(params: {
 
   const projection = resolveWorkspaceProjection(join(conversationDir, ".."), message.address);
   const memory = await getMemory(projection);
-  const skills = mergeExtensionSkills(
-    loadMikanSkills(message.address, conversationDir, pathContext.runtimeWorkspaceRoot, projection),
-    params.extensionSkills ?? [],
+  const conversationSkillLoad = loadMikanSkills(
+    message.address,
+    conversationDir,
+    pathContext.runtimeWorkspaceRoot,
+    projection,
   );
+  const skills = mergeExtensionSkills(conversationSkillLoad.skills, params.extensionSkills ?? []);
   const triggerAttribution = resolveTriggerAttribution(message);
   const systemPrompt = buildSystemPrompt(
     pathContext.runtimeWorkspaceRoot,
@@ -1583,6 +1571,7 @@ async function prepareRunContext(params: {
     platform,
     skills,
     projection,
+    conversationSkillLoad.skippedSkillLinks,
   );
   session.agent.state.systemPrompt = systemPrompt;
   // Cache diagnosis: a byte-stable system prompt is the precondition for
@@ -2135,7 +2124,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
 
   // Initial system prompt (will be updated each run with fresh memory/channels/users/skills)
   const memory = await getMemory(projection);
-  const skills = loadMikanSkills(
+  const { skills, skippedSkillLinks } = loadMikanSkills(
     options.address,
     conversationDir,
     pathContext.runtimeWorkspaceRoot,
@@ -2158,6 +2147,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
     emptyPlatform,
     skills,
     projection,
+    skippedSkillLinks,
   );
 
   // Create session manager and settings manager. Top-level/private sessions

--- a/src/harness/skills.ts
+++ b/src/harness/skills.ts
@@ -7,7 +7,7 @@
  * system prompt documents: a directory with a `SKILL.md` is a skill root
  * (no further recursion), other directories are traversed.
  */
-import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "fs";
 import { basename, dirname, join } from "path";
 import type { LoadSkillsResult, MikanSkill, SkillDiagnostic } from "./types.js";
 
@@ -117,14 +117,57 @@ function loadSkillFromFile(
  * - Direct `.md` children of the top-level directory load as skills.
  * - Dot-directories and `node_modules` are skipped.
  */
-export function loadSkillsFromDir(options: { dir: string; source: string }): LoadSkillsResult {
-  return loadSkillsFromDirInternal(options.dir, options.source, true);
+export function loadSkillsFromDir(options: {
+  dir: string;
+  source: string;
+  /**
+   * Refuse to follow symlinks on any path this load would read, skipping the
+   * offending entry with a `code: "symlink"` diagnostic instead of loading
+   * it. For untrusted trees (conversation offices) the host must never
+   * follow an agent-created link; entries the loader never reads — dot
+   * directories, vendored node_modules — cannot disqualify anything.
+   */
+  rejectSymlinks?: boolean;
+}): LoadSkillsResult {
+  const rejectSymlinks = options.rejectSymlinks === true;
+  if (rejectSymlinks && isSymlink(options.dir)) {
+    return {
+      skills: [],
+      diagnostics: [
+        {
+          type: "warning",
+          code: "symlink",
+          message: "Skills directory is a symlink; skipped",
+          path: options.dir,
+        },
+      ],
+    };
+  }
+  return loadSkillsFromDirInternal(options.dir, options.source, true, rejectSymlinks);
+}
+
+function isSymlink(path: string): boolean {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function symlinkDiagnostic(path: string): SkillDiagnostic {
+  return {
+    type: "warning",
+    code: "symlink",
+    message: "Skill entry is a symlink; skipped",
+    path,
+  };
 }
 
 function loadSkillsFromDirInternal(
   dir: string,
   source: string,
   includeRootFiles: boolean,
+  rejectSymlinks: boolean,
 ): LoadSkillsResult {
   const skills: MikanSkill[] = [];
   const diagnostics: SkillDiagnostic[] = [];
@@ -139,6 +182,10 @@ function loadSkillsFromDirInternal(
 
   const skillFile = entries.find((entry) => entry.name === "SKILL.md" && isFileLike(dir, entry));
   if (skillFile) {
+    if (rejectSymlinks && skillFile.isSymbolicLink()) {
+      diagnostics.push(symlinkDiagnostic(join(dir, skillFile.name)));
+      return { skills, diagnostics };
+    }
     const result = loadSkillFromFile(join(dir, skillFile.name), source);
     if (result.skill) skills.push(result.skill);
     diagnostics.push(...result.diagnostics);
@@ -150,13 +197,21 @@ function loadSkillsFromDirInternal(
     const fullPath = join(dir, entry.name);
 
     if (isDirectoryLike(dir, entry)) {
-      const subResult = loadSkillsFromDirInternal(fullPath, source, false);
+      if (rejectSymlinks && entry.isSymbolicLink()) {
+        diagnostics.push(symlinkDiagnostic(fullPath));
+        continue;
+      }
+      const subResult = loadSkillsFromDirInternal(fullPath, source, false, rejectSymlinks);
       skills.push(...subResult.skills);
       diagnostics.push(...subResult.diagnostics);
       continue;
     }
     if (!includeRootFiles || !entry.name.endsWith(".md") || !isFileLike(dir, entry)) continue;
 
+    if (rejectSymlinks && entry.isSymbolicLink()) {
+      diagnostics.push(symlinkDiagnostic(fullPath));
+      continue;
+    }
     const result = loadSkillFromFile(fullPath, source);
     if (result.skill) skills.push(result.skill);
     diagnostics.push(...result.diagnostics);

--- a/src/harness/types.ts
+++ b/src/harness/types.ts
@@ -263,6 +263,8 @@ export interface SkillDiagnostic {
   type: "warning";
   message: string;
   path: string;
+  /** Set when the entry was skipped because it is a symlink on a rejecting load. */
+  code?: "symlink";
 }
 
 export interface LoadSkillsResult {

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -6,7 +6,8 @@ import { fauxAssistantMessage, fauxProvider, fauxToolCall } from "@earendil-work
 import type { MutableModels } from "@earendil-works/pi-ai";
 import type { ConversationMessage, ConversationResponder, MessagingInfo } from "../src/adapter.js";
 import { createSlackToolPack } from "../src/adapters/slack/tool-pack.js";
-import { createRunner, isSafePromptSkillTree } from "../src/agent.js";
+import { createRunner } from "../src/agent.js";
+import { loadSkillsFromDir } from "../src/harness/skills.js";
 import { MikanAgentSession, MikanModels } from "../src/harness/index.js";
 import { createManagedSessionFile, getChannelSessionDir } from "../src/sessions/store.js";
 import type { PlatformToolPackFactory } from "../src/tools/types.js";
@@ -141,13 +142,19 @@ describe("PiAgentWrapper.run", () => {
     expect(readFileSync(outside, "utf-8")).toBe("DO_NOT_LEAK_THIS_SECRET");
   });
 
-  test("ignores a conversation skill tree containing symlinks", async () => {
+  test("skips symlinked conversation skill entries without loading them", async () => {
     const outside = join(dir, "outside-skill.md");
     writeFileSync(outside, "---\nname: escaped\ndescription: secret\n---\nDO_NOT_LOAD");
     const skillsDir = join(dir, "workspace", "C1", "skills");
     mkdirSync(skillsDir, { recursive: true });
     symlinkSync(outside, join(skillsDir, "escaped.md"));
-    expect(isSafePromptSkillTree(skillsDir, join(dir, "workspace", "C1"))).toBe(false);
+
+    const result = loadSkillsFromDir({ dir: skillsDir, source: "channel", rejectSymlinks: true });
+
+    expect(result.skills).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ code: "symlink", path: join(skillsDir, "escaped.md") }),
+    ]);
   });
 
   test("surfaces subagent batch progress through the platform-neutral responder", async () => {

--- a/test/harness-skills.test.ts
+++ b/test/harness-skills.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -73,6 +73,100 @@ describe("loadSkillsFromDir", () => {
   test("missing directory yields no skills", () => {
     const { skills } = loadSkillsFromDir({ dir: join(dir, "nope"), source: "workspace" });
     expect(skills).toHaveLength(0);
+  });
+});
+
+function writeSkill(base: string, name: string): string {
+  const skillDir = join(base, name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), `---\ndescription: ${name}\n---\nBody\n`);
+  return skillDir;
+}
+
+describe("loadSkillsFromDir with rejectSymlinks", () => {
+  test("npm .bin symlinks inside vendored node_modules never disqualify a skill", () => {
+    // The production regression: a skill vendoring node_modules carries npm's
+    // .bin symlinks, but the loader never reads node_modules — the skill and
+    // its siblings must load.
+    const skillDir = writeSkill(dir, "playwright-check");
+    const binDir = join(skillDir, "node_modules", ".bin");
+    mkdirSync(join(skillDir, "node_modules", "playwright"), { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(skillDir, "node_modules", "playwright", "cli.js"), "#!/usr/bin/env node\n");
+    symlinkSync(join("..", "playwright", "cli.js"), join(binDir, "playwright"));
+    writeSkill(dir, "sibling");
+
+    const { skills, diagnostics } = loadSkillsFromDir({
+      dir,
+      source: "channel",
+      rejectSymlinks: true,
+    });
+
+    expect(skills.map((skill) => skill.name).toSorted()).toEqual(["playwright-check", "sibling"]);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test("a symlinked skill directory is skipped per entry, siblings still load", () => {
+    const real = writeSkill(dir, "real-skill");
+    const elsewhere = writeSkill(join(dir, ".agents"), "linked-skill");
+    symlinkSync(elsewhere, join(dir, "linked-skill"));
+
+    const { skills, diagnostics } = loadSkillsFromDir({
+      dir,
+      source: "channel",
+      rejectSymlinks: true,
+    });
+
+    expect(skills.map((skill) => skill.name)).toEqual(["real-skill"]);
+    expect(skills[0].baseDir).toBe(real);
+    expect(diagnostics).toEqual([
+      expect.objectContaining({ code: "symlink", path: join(dir, "linked-skill") }),
+    ]);
+  });
+
+  test("a symlinked SKILL.md inside a real directory is skipped", () => {
+    const skillDir = join(dir, "offsite");
+    mkdirSync(skillDir, { recursive: true });
+    const target = join(dir, ".agents", "offsite-def.md");
+    mkdirSync(join(dir, ".agents"), { recursive: true });
+    writeFileSync(target, "---\ndescription: offsite\n---\nBody\n");
+    symlinkSync(target, join(skillDir, "SKILL.md"));
+
+    const { skills, diagnostics } = loadSkillsFromDir({
+      dir,
+      source: "channel",
+      rejectSymlinks: true,
+    });
+
+    expect(skills).toHaveLength(0);
+    expect(diagnostics).toEqual([
+      expect.objectContaining({ code: "symlink", path: join(skillDir, "SKILL.md") }),
+    ]);
+  });
+
+  test("a skills root that is itself a symlink loads nothing", () => {
+    const actual = writeSkill(join(dir, "elsewhere"), "hidden");
+    const linkRoot = join(dir, "skills");
+    symlinkSync(join(dir, "elsewhere"), linkRoot);
+
+    const { skills, diagnostics } = loadSkillsFromDir({
+      dir: linkRoot,
+      source: "channel",
+      rejectSymlinks: true,
+    });
+
+    expect(skills).toHaveLength(0);
+    expect(diagnostics).toEqual([expect.objectContaining({ code: "symlink", path: linkRoot })]);
+    expect(actual).toContain("hidden");
+  });
+
+  test("without the option, symlinked entries still load (trusted sources)", () => {
+    const elsewhere = writeSkill(join(dir, ".agents"), "linked-skill");
+    symlinkSync(elsewhere, join(dir, "linked-skill"));
+
+    const { skills } = loadSkillsFromDir({ dir, source: "package:x" });
+
+    expect(skills.map((skill) => skill.name)).toEqual(["linked-skill"]);
   });
 });
 


### PR DESCRIPTION
User-approved boundary decision (option A): keep the no-symlink rule for host-read paths, but enforce it on exactly what the host reads, per entry.

## Problem

The #107 guard rejected the whole conversation skill tree on any symlink anywhere. Production impact (3 of 18 offices with skills):
- One office lost **all ~17 skills** because a single skill vendored `node_modules` — npm's `.bin` entries are always symlinks, and the loader never even reads `node_modules`.
- Two offices with organizational links (skill dir → elsewhere in the same office) lost their trees wholesale, with only a host-log warning nobody sees.

## Change

- `loadSkillsFromDir` gains `rejectSymlinks`: the guard **is** the load — a symlinked skills root, skill directory, `SKILL.md`, or root `.md` is skipped per entry with a `code:"symlink"` diagnostic; siblings load. One traversal for loading and enforcement, so guard and read surface can never drift again.
- `node_modules`/dot directories are skipped before the check (the loader never reads them) — vendored tooling can't disqualify anything.
- Skipped entries are logged host-side **and surfaced in the agent's prompt** with a `cp -rL` hint, so offices self-repair.
- Trusted sources (packages, workspace, extensions) keep today's symlink-following behavior.
- Security posture unchanged: no symlink is ever followed on a conversation-office read.

## Verification

- 1621 tests (+5): npm `.bin` immunity (the production regression), per-entry skip with sibling survival, symlinked `SKILL.md`, symlinked skills root, trusted-source default unchanged.