### PR TITLE
refactor(office): collapse identity bags onto the Office value

### DIFF
--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -156,8 +156,9 @@ export class SlackMessagingBot implements MessagingBot {
   private resolveReplyMode(
     address: import("../../adapter.js").OfficeAddress,
   ): "top-level" | "thread" {
-    const scope = { address, conversationDir: this.conversationDir(address.conversationId) };
-    return resolveConversationSettings(scope).slack?.replyMode ?? "top-level";
+    return (
+      resolveConversationSettings(this.workspace.office(address)).slack?.replyMode ?? "top-level"
+    );
   }
 
   private createContext(event: SlackEvent): ConversationContext {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,7 +5,7 @@
 
 export type { CreateRunnerOptions, PiAgentWrapper } from "./types.js";
 import type { CreateRunnerOptions, OfficeAddress, PiAgentWrapper } from "./types.js";
-import { officeDirName } from "./office/index.js";
+import type { Office, Workspace } from "./office/index.js";
 
 import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { type Api, type ImageContent, type Model } from "@earendil-works/pi-ai";
@@ -56,7 +56,6 @@ import type {
 import { resolveConversationSettings } from "./config.js";
 import { resolveWorkspaceProjection } from "./workspace-projection/index.js";
 import type { WorkspaceProjection } from "./workspace-projection/types.js";
-import { effectiveStateDir } from "./cli/arg-grammar.js";
 import { packageSkillRuntimeDir, resolveConversationPackages } from "./packages/index.js";
 import { ActorExecutionResolver } from "./execution-resolver.js";
 import * as log from "./log.js";
@@ -314,17 +313,15 @@ function isRegularFile(path: string): boolean {
 }
 
 function loadMikanSkills(
-  address: OfficeAddress,
-  conversationDir: string,
+  office: Office,
   workspacePath: string,
   projection: WorkspaceProjection,
 ): { skills: MikanSkill[]; skippedSkillLinks: string[] } {
   const skillMap = new Map<string, MikanSkill>();
 
-  // conversationDir is the host path (e.g., /Users/.../data/C0A34FL8PMH)
-  // hostWorkspacePath is the parent directory on host
-  // workspacePath is the container path (e.g., /workspace)
-  const hostWorkspacePath = join(conversationDir, "..");
+  // workspacePath is the runtime-side root (e.g. /workspace); host paths under
+  // the workspace root translate onto it for prompt references.
+  const hostWorkspacePath = office.workspace.root;
 
   // Helper to translate host paths to container paths
   const translatePath = (hostPath: string): string => {
@@ -344,11 +341,7 @@ function loadMikanSkills(
   // so the agent can read the files — including any scripts or templates the
   // skill ships alongside its SKILL.md, which inlining could never carry.
   const mounted = workspacePath !== hostWorkspacePath;
-  for (const { slug, dir } of resolveConversationPackages({
-    address,
-    stateDir: effectiveStateDir(),
-    conversationDir,
-  }).skillDirs) {
+  for (const { slug, dir } of resolveConversationPackages({ office }).skillDirs) {
     const runtimeDir = packageSkillRuntimeDir(slug);
     for (const skill of loadSkillsFromDir({ dir, source: `package:${slug}` }).skills) {
       // In host mode there is no mount, so the host path is already the path
@@ -398,9 +391,9 @@ function loadMikanSkills(
   return { skills: Array.from(skillMap.values()), skippedSkillLinks };
 }
 
-function buildRuntimePaths(runtimeWorkspaceRoot: string, address: OfficeAddress) {
+function buildRuntimePaths(runtimeWorkspaceRoot: string, office: Office) {
   const workspaceRoot = runtimeWorkspaceRoot.replace(/\/+$/, "") || "/";
-  const conversationPath = posix.join(workspaceRoot, officeDirName(address));
+  const conversationPath = posix.join(workspaceRoot, office.key);
   return {
     workspaceRoot,
     conversationPath,
@@ -455,7 +448,7 @@ export function resolveTriggerAttribution(
 
 function buildSystemPrompt(
   workspacePath: string,
-  address: OfficeAddress,
+  office: Office,
   conversationKind: ConversationKind,
   currentUserId: string | undefined,
   memory: string,
@@ -465,10 +458,7 @@ function buildSystemPrompt(
   projection: WorkspaceProjection,
   skippedSkillLinks: string[] = [],
 ): string {
-  const { workspaceRoot, conversationPath, scratchPath } = buildRuntimePaths(
-    workspacePath,
-    address,
-  );
+  const { workspaceRoot, conversationPath, scratchPath } = buildRuntimePaths(workspacePath, office);
   const sandboxType = sandboxConfig.type;
   const isContainerLike = sandboxType === "container" || sandboxType === "image";
   const isFirecracker = sandboxType === "firecracker";
@@ -552,7 +542,7 @@ ${
     : `${workspaceRoot}/
 ├── MEMORY.md                    # Global memory (all conversations)
 ├── skills/                      # Global CLI tools you create
-└── ${officeDirName(address)}/           # This conversation`
+└── ${office.key}/           # This conversation`
 }
     ├── MEMORY.md                # Conversation-specific memory
     ├── log.jsonl                # Human-readable message history (no tool results)
@@ -1226,18 +1216,11 @@ function createRunnerExecutionContext(
   sandboxConfig: SandboxConfig,
   vaultManager: VaultManager | undefined,
   provisioner: DockerContainerManager | undefined,
-  workspaceDir: string,
-  hostWorkspacePath: string,
+  workspace: Workspace,
 ): RunnerExecutionContext {
   const executionResolver =
     vaultManager && sandboxConfig.type !== "host"
-      ? new ActorExecutionResolver(
-          sandboxConfig,
-          vaultManager,
-          provisioner,
-          workspaceDir,
-          hostWorkspacePath,
-        )
+      ? new ActorExecutionResolver(sandboxConfig, vaultManager, provisioner, workspace)
       : undefined;
 
   // activeExecutor is replaced at the start of each run() call when executionResolver
@@ -1273,7 +1256,7 @@ function createRunnerExecutionContext(
   return {
     executionResolver,
     executor,
-    getPathContext: () => executor.getPathContext(hostWorkspacePath),
+    getPathContext: () => executor.getPathContext(workspace.root),
     async resolveExecutorForRun(context): Promise<void> {
       if (!executionResolver) return;
       activeExecutor = await executionResolver.resolve(context);
@@ -1288,7 +1271,7 @@ function createRunnerExecutionContext(
  * notify posts through the platform bots when main.ts provides a notifier.
  */
 function buildExtensionHostServices(params: {
-  workspaceDir: string;
+  workspace: Workspace;
   vaultManager?: VaultManager;
   platformNotifier?: PlatformNotifier;
   platformReactor?: PlatformReactor;
@@ -1297,7 +1280,7 @@ function buildExtensionHostServices(params: {
   runSubagentService?: ExtensionHostServices["runSubagent"];
 }): ExtensionHostServices {
   const {
-    workspaceDir,
+    workspace,
     vaultManager,
     platformNotifier,
     platformReactor,
@@ -1305,9 +1288,9 @@ function buildExtensionHostServices(params: {
     platformBlockKit,
     runSubagentService,
   } = params;
-  const eventStore = HostEventStore.fromWorkspaceDir(workspaceDir);
+  const eventStore = HostEventStore.fromWorkspaceDir(workspace.root);
   return {
-    stateDir: effectiveStateDir(),
+    stateDir: workspace.stateDir,
     scheduleStore: {
       write: async (filename, payload) => {
         await eventStore.write(filename, payload);
@@ -1334,10 +1317,7 @@ function buildExtensionHostServices(params: {
 }
 
 async function createConfiguredAgentSession(params: {
-  address: OfficeAddress;
-  conversationId: string;
-  conversationDir: string;
-  workspaceDir: string;
+  office: Office;
   systemPrompt: string;
   model: Model<Api>;
   thinkingLevel: ThinkingLevel;
@@ -1351,10 +1331,7 @@ async function createConfiguredAgentSession(params: {
   platformBlockKit?: PlatformBlockKit;
 }): Promise<ConfiguredAgentSession> {
   const {
-    address,
-    conversationId,
-    conversationDir,
-    workspaceDir,
+    office,
     systemPrompt,
     model,
     thinkingLevel,
@@ -1367,6 +1344,9 @@ async function createConfiguredAgentSession(params: {
     platformUploader,
     platformBlockKit,
   } = params;
+  const { address } = office;
+  const conversationId = address.conversationId;
+  const workspaceDir = office.workspace.root;
 
   // Host-only dirs under the state dir: extension code runs in the mikan
   // process, so it must never load from workspace paths — those are mounted
@@ -1386,11 +1366,7 @@ async function createConfiguredAgentSession(params: {
   // contributed theirs. Both subagent entry points read this at call time, so
   // they always agree on which profiles are launchable.
   let runnableSubagentProfiles = loadedProfiles.profiles;
-  const resolvedPackages = resolveConversationPackages({
-    address,
-    stateDir: effectiveStateDir(),
-    conversationDir,
-  });
+  const resolvedPackages = resolveConversationPackages({ office });
   for (const error of resolvedPackages.errors) {
     log.logWarning(`Package unavailable: ${error.source}`, error.message);
   }
@@ -1399,7 +1375,7 @@ async function createConfiguredAgentSession(params: {
     roots: resolvedPackages.extensionRoots,
     context: { address, conversationId, workspaceDir, model, thinkingLevel },
     services: buildExtensionHostServices({
-      workspaceDir,
+      workspace: office.workspace,
       vaultManager,
       platformNotifier,
       platformReactor,
@@ -1494,8 +1470,7 @@ async function prepareRunContext(params: {
   message: ConversationMessage;
   responder: ConversationResponder;
   platform: MessagingInfo;
-  conversationId: string;
-  conversationDir: string;
+  office: Office;
   sessionUuid: string;
   runState: RunnerSessionState;
   executor: Executor;
@@ -1521,8 +1496,7 @@ async function prepareRunContext(params: {
     message,
     responder,
     platform,
-    conversationId,
-    conversationDir,
+    office,
     sessionUuid,
     runState,
     executor,
@@ -1537,10 +1511,11 @@ async function prepareRunContext(params: {
     setReactFunction,
     bindPlatformToolPacks,
   } = params;
+  const conversationId = office.address.conversationId;
   let pathContext = params.pathContext;
   const sessionConversation = conversationIdOf(message.sessionKey);
 
-  await mkdir(join(conversationDir, "scratch"), { recursive: true });
+  await mkdir(join(office.dir, "scratch"), { recursive: true });
 
   if (executionResolver) {
     await resolveExecutorForRun({
@@ -1553,11 +1528,10 @@ async function prepareRunContext(params: {
 
   reloadSessionMessages(session, conversationId);
 
-  const projection = resolveWorkspaceProjection(join(conversationDir, ".."), message.address);
+  const projection = resolveWorkspaceProjection(office);
   const memory = await getMemory(projection);
   const conversationSkillLoad = loadMikanSkills(
-    message.address,
-    conversationDir,
+    office,
     pathContext.runtimeWorkspaceRoot,
     projection,
   );
@@ -1565,7 +1539,7 @@ async function prepareRunContext(params: {
   const triggerAttribution = resolveTriggerAttribution(message);
   const systemPrompt = buildSystemPrompt(
     pathContext.runtimeWorkspaceRoot,
-    message.address,
+    office,
     message.conversationKind,
     message.userId,
     memory,
@@ -2076,9 +2050,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
   const {
     sandboxConfig,
     sessionKey,
-    conversationId,
-    conversationDir,
-    workspaceDir,
+    office,
     sessionScope,
     vaultManager,
     provisioner,
@@ -2090,20 +2062,16 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
     platformBlockKit,
     platformToolPackFactories,
   } = options;
-  const agentConfig = resolveConversationSettings({ address: options.address, conversationDir });
+  const conversationId = office.address.conversationId;
+  const conversationDir = office.dir;
+  const workspaceDir = office.workspace.root;
+  const agentConfig = resolveConversationSettings(office);
 
-  const workspaceBase = join(conversationDir, "..");
-  const projection = resolveWorkspaceProjection(workspaceBase, options.address);
+  const projection = resolveWorkspaceProjection(office);
   assertSandboxSupportsWorkspacePolicy(sandboxConfig, projection.doorPolicy);
   const { executionResolver, executor, getPathContext, resolveExecutorForRun } =
-    createRunnerExecutionContext(
-      sandboxConfig,
-      vaultManager,
-      provisioner,
-      workspaceDir,
-      workspaceBase,
-    );
-  let pathContext = getUnresolvedSandboxPathContext(sandboxConfig, workspaceBase);
+    createRunnerExecutionContext(sandboxConfig, vaultManager, provisioner, office.workspace);
+  let pathContext = getUnresolvedSandboxPathContext(sandboxConfig, workspaceDir);
 
   const modelRegistry = options.models ?? MikanModels.create();
   if (modelRegistry.getError()) {
@@ -2138,8 +2106,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
   // Initial system prompt (will be updated each run with fresh memory/channels/users/skills)
   const memory = await getMemory(projection);
   const { skills, skippedSkillLinks } = loadMikanSkills(
-    options.address,
-    conversationDir,
+    office,
     pathContext.runtimeWorkspaceRoot,
     projection,
   );
@@ -2152,7 +2119,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
   };
   const systemPrompt = buildSystemPrompt(
     pathContext.runtimeWorkspaceRoot,
-    options.address,
+    office,
     "shared",
     undefined,
     memory,
@@ -2178,10 +2145,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
   const chatSessionManager = new ChatHistorySync();
   const { session, extensionSkills, extensionRegistry, disposeExtensions } =
     await createConfiguredAgentSession({
-      address: options.address,
-      conversationId,
-      conversationDir,
-      workspaceDir,
+      office,
       systemPrompt,
       model,
       thinkingLevel: agentConfig.thinkingLevel,
@@ -2218,8 +2182,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
         message,
         responder,
         platform,
-        conversationId,
-        conversationDir,
+        office,
         sessionUuid,
         runState,
         executor,
@@ -2365,8 +2328,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
         message,
         responder,
         platform,
-        conversationId,
-        conversationDir,
+        office,
         sessionUuid,
         runState,
         executor,
@@ -2388,7 +2350,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
       try {
         const conversationMemoryPath = posix.join(
           prepared.pathContext.runtimeWorkspaceRoot,
-          officeDirName(message.address),
+          office.key,
           "MEMORY.md",
         );
         const dreamTools = sessionDreamTools(session.agent.state.tools, conversationMemoryPath);

--- a/src/cli/ext-dev.ts
+++ b/src/cli/ext-dev.ts
@@ -102,10 +102,7 @@ export async function runExtDevCommand(argv: string[]): Promise<number> {
   const workspace = createWorkspace({ root: workingDir, stateDir });
   const devOffice = workspace.office(createOfficeAddress("slack", conversationId));
   devOffice.ensure();
-  updateConversationSettings(
-    { address: devOffice.address, conversationDir: devOffice.dir },
-    { packages: [source] },
-  );
+  updateConversationSettings(devOffice, { packages: [source] });
 
   console.log(`mikan ext dev — ${source}`);
   console.log(`  conversation: ${conversationId}`);

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -100,9 +100,8 @@ export class ModelCommandHandler implements CommandHandler {
     }
 
     const office = context.services.workspace.office(context.address);
-    const settingsScope = { address: office.address, conversationDir: office.dir };
     if (!parsed.provider || !parsed.model) {
-      const current = resolveConversationSettings(settingsScope);
+      const current = resolveConversationSettings(office);
       await replyDiagnosticWithContext(
         context.responder,
         formatCommandSummary("Model", [

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -98,8 +98,7 @@ export class SandboxCommandHandler implements CommandHandler {
 
     if (parsed.action === "door") {
       const projection = resolveWorkspaceProjection(
-        context.services.workspace.root,
-        context.address,
+        context.services.workspace.office(context.address),
       );
       if (parsed.doorPolicy === undefined) {
         await replyDiagnosticWithContext(
@@ -144,7 +143,9 @@ export class SandboxCommandHandler implements CommandHandler {
         );
         return true;
       }
-      const updated = resolveWorkspaceProjection(context.services.workspace.root, context.address);
+      const updated = resolveWorkspaceProjection(
+        context.services.workspace.office(context.address),
+      );
       await replyDiagnosticWithContext(
         context.responder,
         formatCommandSummary("Sandbox Door", [
@@ -159,7 +160,9 @@ export class SandboxCommandHandler implements CommandHandler {
     const status = context.services.resourceController.getLimitStatus(containerKey);
     const defaultLimits = context.services.resourceController.getDefaultLimits();
     const boostLimits = context.services.resourceController.getBoostLimits();
-    const projection = resolveWorkspaceProjection(context.services.workspace.root, context.address);
+    const projection = resolveWorkspaceProjection(
+      context.services.workspace.office(context.address),
+    );
     await replyDiagnosticWithContext(
       context.responder,
       formatCommandSummary(

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,8 +17,7 @@ export class MissingGlobalSettingsError extends Error {
 
 export type { AgentConfig, AutoReplyConfig, JudgeModelConfig, SandboxSettings } from "./types.js";
 import type { AgentConfig, AutoReplyConfig, JudgeModelConfig, SandboxSettings } from "./types.js";
-import { officeStateDir } from "./office/index.js";
-import type { OfficeAddress } from "./types.js";
+import type { Office } from "./office/index.js";
 
 const ONBOARD_SETTINGS: SettingsFileConfig = {
   llm: {
@@ -285,19 +284,10 @@ export function loadGlobalSettings(): AgentConfig {
 }
 
 /**
- * Explicit identity for conversation-settings access. The state-dir key is
- * the office key derived from the address; the workspace directory is only
- * the legacy pre-host-migration settings location. Callers name both — the
- * key is never inferred from the directory basename.
- */
-export interface ConversationSettingsScope {
-  address: OfficeAddress;
-  conversationDir: string;
-}
-
-/**
  * Host-authoritative location of a conversation's settings file:
- * `<stateDir>/conversations/<conversationId>/settings.json`.
+ * `<office state dir>/settings.json`. The Office value names both the
+ * state-dir key and the legacy pre-host-migration location (its workspace
+ * dir) — the key is never inferred from a directory basename.
  *
  * Conversation settings used to live at `<conversationDir>/settings.json`,
  * but conversation dirs are bind-mounted read-write into sandbox containers
@@ -312,15 +302,15 @@ export interface ConversationSettingsScope {
  * migration marker — a legacy file (re)appearing later, e.g. planted from
  * inside the sandbox, is never read again.
  */
-export function conversationSettingsPath(scope: ConversationSettingsScope): string {
-  const hostPath = join(officeStateDir(getStateDir(), scope.address), "settings.json");
+export function conversationSettingsPath(office: Office): string {
+  const hostPath = join(office.stateDir, "settings.json");
   if (existsSync(hostPath)) {
     assertSettingsFile(hostPath, "Host conversation settings");
     return hostPath;
   }
 
   ensureDirExists(dirname(hostPath));
-  const legacyPath = join(scope.conversationDir, "settings.json");
+  const legacyPath = join(office.dir, "settings.json");
   let content = "{}\n";
   let migrated = false;
   if (existsSync(legacyPath)) {
@@ -355,10 +345,10 @@ function assertSettingsFile(path: string, label: string): void {
   }
 }
 
-export function resolveConversationSettings(scope: ConversationSettingsScope): AgentConfig {
+export function resolveConversationSettings(office: Office): AgentConfig {
   const globalConfig = loadRawGlobalSettings();
   const conversationConfig = normalizeSettingsConfig(
-    loadSettingsFile(conversationSettingsPath(scope)) ?? {},
+    loadSettingsFile(conversationSettingsPath(office)) ?? {},
   );
   // The sandbox group merges at the leaf level (see mergeSandboxSettings):
   // a conversation that only sets sandbox.memory keeps the global sandbox.cpus.
@@ -384,9 +374,9 @@ export function resolveConversationSettings(scope: ConversationSettingsScope): A
  *
  * @deprecated Auto-reply is kept for compatibility while its future is undecided.
  */
-export function loadAutoReplyJudgeModel(scope?: ConversationSettingsScope): JudgeModelConfig {
+export function loadAutoReplyJudgeModel(office?: Office): JudgeModelConfig {
   const global = requireGlobalSettings();
-  const local = scope ? (loadSettingsFile(conversationSettingsPath(scope)) ?? {}) : {};
+  const local = office ? (loadSettingsFile(conversationSettingsPath(office)) ?? {}) : {};
   const merged: SettingsFileConfig["llm"] = { ...global.llm, ...local.llm };
   const judge = { ...global.llm?.autoReply, ...local.llm?.autoReply };
   const provider = requireString(judge.provider ?? merged?.provider, "llm.autoReply.provider");
@@ -596,11 +586,8 @@ export function updateGlobalSettings(patch: Partial<AgentConfig>): void {
   updateSettingsFile(join(getStateDir(), "settings.json"), patch, ONBOARD_SETTINGS);
 }
 
-export function updateConversationSettings(
-  scope: ConversationSettingsScope,
-  patch: Partial<AgentConfig>,
-): void {
-  updateSettingsFile(conversationSettingsPath(scope), patch, {});
+export function updateConversationSettings(office: Office, patch: Partial<AgentConfig>): void {
+  updateSettingsFile(conversationSettingsPath(office), patch, {});
 }
 
 /** An explicit office door-policy selection; `layout` only exists behind a trusted door. */
@@ -612,10 +599,8 @@ export type WorkspacePolicyChoice =
  * The conversation's own door-policy override (legacy `image.workspaceMount`
  * included), or null when the office follows the global default.
  */
-export function loadConversationWorkspaceOverride(
-  scope: ConversationSettingsScope,
-): WorkspacePolicyChoice | null {
-  const file = loadSettingsFile(conversationSettingsPath(scope));
+export function loadConversationWorkspaceOverride(office: Office): WorkspacePolicyChoice | null {
+  const file = loadSettingsFile(conversationSettingsPath(office));
   const sandbox = file?.sandbox;
   if (sandbox?.workspace?.doorPolicy === "isolated") return { doorPolicy: "isolated" };
   if (sandbox?.workspace?.doorPolicy === "trusted") {
@@ -632,10 +617,10 @@ export function loadConversationWorkspaceOverride(
 }
 
 export function setConversationWorkspacePolicy(
-  scope: ConversationSettingsScope,
+  office: Office,
   choice: WorkspacePolicyChoice | null,
 ): void {
-  writeWorkspacePolicy(conversationSettingsPath(scope), choice, {});
+  writeWorkspacePolicy(conversationSettingsPath(office), choice, {});
 }
 
 export function setGlobalWorkspacePolicy(choice: WorkspacePolicyChoice | null): void {

--- a/src/execution-resolver.ts
+++ b/src/execution-resolver.ts
@@ -1,6 +1,5 @@
 import { posix } from "node:path";
-import { effectiveStateDir } from "./cli/arg-grammar.js";
-import { conversationOfficeDir } from "./office/index.js";
+import type { Office, Workspace } from "./office/index.js";
 import { conversationPackageSkillMounts } from "./packages/index.js";
 import { loadGlobalSettings } from "./config.js";
 import { DockerContainerManager, type ContainerMount } from "./provisioner.js";
@@ -21,23 +20,17 @@ import {
   runtimeResourceKey,
   scopeCloudflareSandboxId,
 } from "./sandbox/identity.js";
-import {
-  resolveWorkspaceProjection,
-  readWorkspaceProjectionMode,
-} from "./workspace-projection/index.js";
+import { resolveWorkspaceProjection } from "./workspace-projection/index.js";
 
 export type { ActorContext } from "./types.js";
 import type { ActorContext, ExecutionPlan } from "./types.js";
-
-export const readConversationWorkspaceMountMode = readWorkspaceProjectionMode;
 
 export class ActorExecutionResolver {
   constructor(
     private baseConfig: SandboxConfig,
     private vaultManager: VaultManager,
-    private provisioner?: DockerContainerManager,
-    private workspaceDir?: string,
-    private hostWorkspacePath?: string,
+    private provisioner: DockerContainerManager | undefined,
+    private workspace: Workspace,
   ) {}
 
   async resolve(context: ActorContext): Promise<Executor> {
@@ -64,14 +57,15 @@ export class ActorExecutionResolver {
       (legacyCredentialKey ? this.vaultManager.resolve(legacyCredentialKey) : undefined);
     const capabilities = getSandboxCredentialCapabilities(this.baseConfig.type);
     const workspaceCapabilities = getSandboxWorkspaceCapabilities(this.baseConfig.type);
-    const workspaceProjection = resolveWorkspaceProjection(this.workspaceDir, context.address);
+    const office = this.workspace.office(context.address);
+    const workspaceProjection = resolveWorkspaceProjection(office);
     const injection = resolveVaultInjection({
       vault,
       capabilities,
       sandboxType: this.baseConfig.type,
-      conversationId: context.address.conversationId,
+      address: office.address,
     });
-    const mounts = this.resolveMounts(context.address, injection.mounts, workspaceProjection);
+    const mounts = this.resolveMounts(office, injection.mounts, workspaceProjection);
     if (workspaceProjection.doorPolicy === "isolated" && !workspaceCapabilities.managedProjection) {
       throw new Error(
         `Sandbox '${this.baseConfig.type}' cannot provide an isolated conversation office; use image:* or gondolin:default, or explicitly choose trusted workspace policy`,
@@ -119,7 +113,7 @@ export class ActorExecutionResolver {
     if (this.baseConfig.type === "gondolin") {
       return {
         ...this.baseConfig,
-        workspacePath: this.hostWorkspacePath,
+        workspacePath: this.workspace.root,
         mounts,
         instanceId: resourceKey,
         resourceKey,
@@ -175,7 +169,7 @@ export class ActorExecutionResolver {
   }
 
   private resolveMounts(
-    address: ActorContext["address"],
+    office: Office,
     vaultMounts: ContainerMount[],
     projection: ReturnType<typeof resolveWorkspaceProjection>,
   ): ContainerMount[] {
@@ -183,13 +177,7 @@ export class ActorExecutionResolver {
     // Package skills mount outside /workspace, so they cannot collide with the
     // workspace projection; they are still checked against vault mounts below,
     // which are administrator-chosen targets and could be aimed anywhere.
-    const packageMounts = this.workspaceDir
-      ? conversationPackageSkillMounts({
-          address,
-          stateDir: effectiveStateDir(),
-          conversationDir: conversationOfficeDir(this.workspaceDir, address),
-        })
-      : [];
+    const packageMounts = conversationPackageSkillMounts({ office });
     const protectedMounts = [...workspaceMounts, ...packageMounts];
     for (let index = 0; index < vaultMounts.length; index += 1) {
       const vaultMount = vaultMounts[index];

--- a/src/office/README.md
+++ b/src/office/README.md
@@ -9,8 +9,9 @@ its host-side directory layout, its durable record, and the legacy migration.
 - `address.ts`: Canonical identity. `OfficeAddress` is `platform` plus the
   platform's raw `conversationId`; raw ids stay at platform I/O boundaries.
   Storage paths use the versioned `OfficeKey`, derived by SHA-256 from both
-  values (ADR 0005). Also holds the transitional `(root, address)` path
-  helpers that retire when every option bag carries an `Office` value.
+  values (ADR 0005). `officeStateDir(stateDir, address)` remains the one
+  low-level path helper, for stateDir-only surfaces (CLI, extension loader,
+  package materialization) that hold no Office value.
 - `layout.ts`: The two layout values. `createWorkspace({root, stateDir})`
   builds the per-process `Workspace` (workspace-global paths, reserved-name
   set, office factory); `workspace.office(address)` returns the memoized,

--- a/src/office/address.ts
+++ b/src/office/address.ts
@@ -89,30 +89,6 @@ export function officeStateDir(stateDir: string, address: OfficeAddress): string
   return join(stateDir, "conversations", officeKey(address));
 }
 
-/**
- * The directory segment naming an office under a workspace root — the same
- * segment on the host and inside the sandbox runtime, so mounts stay a plain
- * root swap. This is the office key: platform-scoped and collision-resistant,
- * so two platforms sharing a raw conversation id can never share a directory.
- * Raw ids reach the filesystem only through the office registry's migration
- * journal (ADR 0005).
- */
-export function officeDirName(address: OfficeAddress): string {
-  return officeKey(address);
-}
-
-/**
- * The host working directory for an office (see officeDirName).
- *
- * Transitional: callers whose option bags still carry `(workspaceRoot,
- * address)` string pairs (agent runner, execution resolver, projection) keep
- * using this until those bags carry an `Office` value. New code asks the
- * `Office` value for `dir`.
- */
-export function conversationOfficeDir(workspaceRoot: string, address: OfficeAddress): string {
-  return join(workspaceRoot, officeDirName(address));
-}
-
 /** Compare canonical office identities without relying on their readable key. */
 export function sameOffice(left: OfficeAddress, right: OfficeAddress): boolean {
   const leftAddress = validateOfficeAddress(left);

--- a/src/office/index.ts
+++ b/src/office/index.ts
@@ -8,10 +8,8 @@ export {
   assertConversationId,
   assertOfficeKey,
   assertPlatformName,
-  conversationOfficeDir,
   createOfficeAddress,
   isOfficeKey,
-  officeDirName,
   officeKey,
   officeStateDir,
   sameOffice,
@@ -19,7 +17,6 @@ export {
 } from "./address.js";
 export {
   createWorkspace,
-  ensureOfficeDir,
   RESERVED_WORKSPACE_NAMES,
   type Office,
   type Workspace,

--- a/src/office/layout.ts
+++ b/src/office/layout.ts
@@ -4,7 +4,6 @@ import type { OfficeAddress } from "../types.js";
 import type { Office, Workspace } from "./types.js";
 import { officeKey, validateOfficeAddress } from "./address.js";
 import { OfficeRegistry } from "./registry.js";
-import { effectiveStateDir } from "../cli/arg-grammar.js";
 
 export type { Office, Workspace } from "./types.js";
 
@@ -78,24 +77,6 @@ export function createWorkspace(options: { root: string; stateDir: string }): Wo
     },
   });
   return workspace;
-}
-
-/**
- * Materialize an office working directory from `(workspaceRoot, address)`
- * strings.
- *
- * Transitional: only for callers whose options do not yet carry an `Office`
- * value (the workspace projection). Constructs a registry per call — fine at
- * runner-creation frequency, wrong for per-message paths, which go through
- * `Office.ensure()`. Reads the state dir from the CLI grammar because its
- * callers do not hold one; both facts retire with the option-bag collapse.
- */
-export function ensureOfficeDir(workspaceRoot: string, address: OfficeAddress): string {
-  const normalized = validateOfficeAddress(address);
-  new OfficeRegistry(effectiveStateDir()).recordOffice(normalized);
-  const dir = join(workspaceRoot, officeKey(normalized));
-  ensureRegularOfficeDirectory(dir);
-  return dir;
 }
 
 /** mkdir-if-missing with the same fail-closed type guard as projection roots. */

--- a/src/packages/admin.ts
+++ b/src/packages/admin.ts
@@ -32,8 +32,8 @@ export function addPackage(
   const source = formatSource(parseSource(rawSource));
   const materialized = materializeSource(source, {
     scope,
-    address: context.address,
-    stateDir: context.stateDir,
+    address: context.office.address,
+    stateDir: context.office.workspace.stateDir,
     mode: "fetch",
   });
 
@@ -73,8 +73,8 @@ export function refreshPackage(
   }
   const materialized = materializeSource(rawSource, {
     scope,
-    address: context.address,
-    stateDir: context.stateDir,
+    address: context.office.address,
+    stateDir: context.office.workspace.stateDir,
     mode: "refresh",
   });
   return { source: rawSource, dir: materialized.dir };

--- a/src/packages/inspect.ts
+++ b/src/packages/inspect.ts
@@ -52,12 +52,7 @@ export async function inspectConversationPackages(
 export function declaredSources(scope: PackageScope, options: ResolvePackagesOptions): string[] {
   try {
     const settings =
-      scope === "global"
-        ? loadGlobalSettings()
-        : resolveConversationSettings({
-            address: options.address,
-            conversationDir: options.conversationDir,
-          });
+      scope === "global" ? loadGlobalSettings() : resolveConversationSettings(options.office);
     return settings.packages ?? [];
   } catch {
     return [];
@@ -91,8 +86,8 @@ async function describe(
   try {
     dir = materializeSource(source, {
       scope,
-      address: options.address,
-      stateDir: options.stateDir,
+      address: options.office.address,
+      stateDir: options.office.workspace.stateDir,
       mode: "offline",
     }).dir;
   } catch (err) {

--- a/src/packages/resolve.ts
+++ b/src/packages/resolve.ts
@@ -134,10 +134,7 @@ function readScope(scope: PackageScope, options: ResolvePackagesOptions): Declar
     const sources =
       scope === "global"
         ? loadGlobalSettings().packages
-        : resolveConversationSettings({
-            address: options.address,
-            conversationDir: options.conversationDir,
-          }).packages;
+        : resolveConversationSettings(options.office).packages;
     return (sources ?? []).map((source) => ({ source, scope }));
   } catch (err) {
     // Unreadable settings must not take the conversation down; the other
@@ -155,8 +152,8 @@ function materialize(
   try {
     return materializeSource(declaration.source, {
       scope: declaration.scope,
-      address: options.address,
-      stateDir: options.stateDir,
+      address: options.office.address,
+      stateDir: options.office.workspace.stateDir,
       mode: options.fetchMissing ? "fetch" : "offline",
     });
   } catch (err) {
@@ -174,8 +171,11 @@ function materialize(
  */
 function scopeConventionDirs(options: ResolvePackagesOptions): string[] {
   return [
-    join(packageScopeDir("global", undefined, options.stateDir), EXTENSIONS_SUBDIR),
-    join(packageScopeDir("conversation", options.address, options.stateDir), EXTENSIONS_SUBDIR),
+    join(
+      packageScopeDir("global", undefined, options.office.workspace.stateDir),
+      EXTENSIONS_SUBDIR,
+    ),
+    join(options.office.stateDir, EXTENSIONS_SUBDIR),
   ];
 }
 

--- a/src/packages/types.ts
+++ b/src/packages/types.ts
@@ -76,10 +76,8 @@ export interface PackageSkillDir {
 }
 
 export interface ResolvePackagesOptions {
-  /** Office whose packages resolve; state-dir keys derive from it. */
-  address: import("../types.js").OfficeAddress;
-  stateDir: string;
-  conversationDir: string;
+  /** Office whose packages resolve; identity and state-dir keys derive from it. */
+  office: import("../office/types.js").Office;
   fetchMissing?: boolean;
 }
 
@@ -109,7 +107,6 @@ export interface PackageInventory {
 }
 
 export interface PackageAdminContext extends ResolvePackagesOptions {
-  office: import("../office/types.js").Office;
   runtime?: import("../types.js").RunnerCacheControl &
     import("../types.js").GlobalRunnerCacheControl;
 }

--- a/src/runtime/conversation-runtime.ts
+++ b/src/runtime/conversation-runtime.ts
@@ -714,10 +714,7 @@ class ConversationRuntimeImpl implements ConversationRuntime {
       const runner = await createRunner({
         sandboxConfig: this.options.sandbox,
         sessionKey: options.sessionKey,
-        address: options.address,
-        conversationId: options.conversationId,
-        conversationDir,
-        workspaceDir: this.options.workspace.root,
+        office: this.options.workspace.office(options.address),
         sessionScope,
         vaultManager: this.options.vaultManager,
         provisioner: this.options.provisioner,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -57,8 +57,9 @@ export interface SessionStateOptions {
   /** Canonical office identity; the runtime keys all state by this. */
   address: OfficeAddress;
   /**
-   * The office's raw platform id. Filesystem layout, settings, and Admin scope
-   * still address offices this way; see ADR 0005.
+   * The office's raw platform id — the session-key grammar's conversation
+   * value (a bare conversation session key equals it). Never a storage key;
+   * layout and settings are addressed through the Office value.
    */
   conversationId: string;
   sessionKey: string;

--- a/src/settings-mutation.ts
+++ b/src/settings-mutation.ts
@@ -55,7 +55,7 @@ export function applyConversationSettings(
     }
     runtimeSwitched = true;
   }
-  updateConversationSettings({ address: office.address, conversationDir: office.dir }, patch);
+  updateConversationSettings(office, patch);
   return { ok: true, runtimeSwitched };
 }
 
@@ -84,7 +84,7 @@ export function applyConversationWorkspacePolicy(
   if (runtime && !runtime.refreshConversationEnvironment(office.address)) {
     return { ok: false, reason: "busy" };
   }
-  setConversationWorkspacePolicy({ address: office.address, conversationDir: office.dir }, choice);
+  setConversationWorkspacePolicy(office, choice);
   return { ok: true, runtimeSwitched: runtime ? true : null };
 }
 

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -34,19 +34,14 @@ export async function evaluateAutoReplyPolicy(input: {
   const { event, office, judge = judgeAutoReplyWithLlm, timeoutMs = JUDGE_TIMEOUT_MS } = input;
   if (!office) return { trigger: false, reason: "auto-reply-unconfigured" };
 
-  const conversationDir = office.dir;
-
   try {
-    const config = loadConversationAutoReplyConfig(conversationDir);
+    const config = loadConversationAutoReplyConfig(office.dir);
     if (!config.enabled) return { trigger: false, reason: "auto-reply-disabled" };
     if (config.rules.length === 0) {
       return { trigger: true, reason: "auto-reply-enabled" };
     }
 
-    const shouldReply = await withTimeout(
-      judge({ event, rules: config.rules, conversationDir }),
-      timeoutMs,
-    );
+    const shouldReply = await withTimeout(judge({ event, rules: config.rules, office }), timeoutMs);
     return shouldReply
       ? { trigger: true, reason: "auto-reply-rule-match" }
       : { trigger: false, reason: "auto-reply-rule-no-match" };
@@ -86,12 +81,9 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 async function judgeAutoReplyWithLlm(input: {
   event: ConversationEvent;
   rules: string[];
-  conversationDir: string;
+  office: import("./office/types.js").Office;
 }): Promise<boolean> {
-  const judgeConfig = loadAutoReplyJudgeModel({
-    address: input.event.address,
-    conversationDir: input.conversationDir,
-  });
+  const judgeConfig = loadAutoReplyJudgeModel(input.office);
   const models = MikanModels.create();
   const model = models.resolve(judgeConfig.provider, judgeConfig.model);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -626,7 +626,7 @@ export type TriggerResult = { trigger: true; reason: string } | { trigger: false
 export type AutoReplyJudge = (input: {
   event: ConversationEvent;
   rules: string[];
-  conversationDir: string;
+  office: import("./office/types.js").Office;
 }) => Promise<boolean>;
 
 // ── shared implementation contracts ─────────────────────────────────────────
@@ -665,12 +665,8 @@ export type SettingsApplyResult =
 export interface CreateRunnerOptions {
   sandboxConfig: import("./sandbox/types.js").SandboxConfig;
   sessionKey: string;
-  /** Canonical office identity for workspace paths and execution scoping. */
-  address: OfficeAddress;
-  /** Raw platform id; settings/vault/package keys keep it until ADR 0005. */
-  conversationId: string;
-  conversationDir: string;
-  workspaceDir: string;
+  /** The Conversation office this runner serves; identity and layout derive from it. */
+  office: import("./office/types.js").Office;
   sessionScope: import("./sessions/types.js").ResolvedSessionScope;
   vaultManager?: import("./vault/types.js").VaultManager;
   provisioner?: import("./provisioner.js").DockerContainerManager;

--- a/src/vault/injection.ts
+++ b/src/vault/injection.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "fs";
 import { reportUserFacingError } from "../observability/sentry.js";
 import type { SandboxConfig, SandboxCredentialCapabilities } from "../sandbox/types.js";
+import type { OfficeAddress } from "../types.js";
 import type { ResolvedVault, ResolvedVaultMount, VaultInjection } from "./types.js";
 
 export type { VaultInjection } from "./types.js";
@@ -9,9 +10,10 @@ export function resolveVaultInjection(options: {
   vault: ResolvedVault | undefined;
   capabilities: SandboxCredentialCapabilities;
   sandboxType: SandboxConfig["type"];
-  conversationId: string;
+  /** Diagnostic identity for error reports only; no injection decision reads it. */
+  address: OfficeAddress;
 }): VaultInjection {
-  const { vault, capabilities, sandboxType, conversationId } = options;
+  const { vault, capabilities, sandboxType, address } = options;
   if (vault && vault.mounts.length > 0 && !capabilities.fileMounts) {
     throw new Error(`Sandbox type "${sandboxType}" does not support vault file mounts`);
   }
@@ -26,7 +28,7 @@ export function resolveVaultInjection(options: {
         severity: "warning",
         context: {
           sandboxType,
-          conversationId,
+          conversationId: address.conversationId,
           target: mount.target,
           hasVault: Boolean(vault),
         },

--- a/src/web/admin/portal.ts
+++ b/src/web/admin/portal.ts
@@ -617,15 +617,12 @@ function serveConversationState(
   }
   const conversationId = scope.conversationId;
 
-  const dir = workspace.office(scope.address).dir;
+  const office = workspace.office(scope.address);
   const globalConfig = loadGlobalSettings();
-  const conversationConfig = resolveConversationSettings({
-    address: scope.address,
-    conversationDir: dir,
-  });
-  const conversationWorkspace = resolveWorkspaceProjection(workspace.root, scope.address);
+  const conversationConfig = resolveConversationSettings(office);
+  const conversationWorkspace = resolveWorkspaceProjection(office);
   const globalWorkspaceSettings = globalConfig.sandbox?.workspace;
-  const autoReply = loadConversationAutoReplyConfig(dir);
+  const autoReply = loadConversationAutoReplyConfig(office.dir);
 
   jsonRes(res, 200, {
     conversationId,
@@ -637,9 +634,7 @@ function serveConversationState(
     globalThinkingLevel: globalConfig.thinkingLevel,
     workspaceDoorPolicy: conversationWorkspace.doorPolicy,
     workspaceLayout: conversationWorkspace.layout,
-    workspaceOverride: doorPolicyChoiceKey(
-      loadConversationWorkspaceOverride({ address: scope.address, conversationDir: dir }),
-    ),
+    workspaceOverride: doorPolicyChoiceKey(loadConversationWorkspaceOverride(office)),
     globalWorkspaceDoorPolicy: globalWorkspaceSettings?.doorPolicy ?? "isolated",
     globalWorkspaceLayout: globalWorkspaceSettings?.layout ?? "conversation",
     autoReplyEnabled: autoReply.enabled,
@@ -1399,11 +1394,8 @@ async function servePackagesList(
   const workspace = requireAdminWorkspace(res, services);
   if (!workspace) return;
   try {
-    const office = workspace.office(scope.address);
     const inventory = await inspectConversationPackages({
-      address: office.address,
-      stateDir: workspace.stateDir,
-      conversationDir: office.dir,
+      office: workspace.office(scope.address),
     });
     jsonRes(res, 200, { conversationId: scope.conversationId, ...inventory });
   } catch (err) {
@@ -1441,12 +1433,8 @@ function servePackageMutation(
   const workspace = requireAdminWorkspace(res, services);
   if (!workspace) return;
 
-  const office = workspace.office(scope.address);
   const context = {
-    address: office.address,
-    stateDir: workspace.stateDir,
-    conversationDir: office.dir,
-    office,
+    office: workspace.office(scope.address),
     runtime: services.runtime,
   };
 

--- a/src/workspace-projection/index.ts
+++ b/src/workspace-projection/index.ts
@@ -1,16 +1,10 @@
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import { lstatSync, mkdirSync, writeFileSync } from "node:fs";
 import { ensureDirExists } from "../utils/file-guards.js";
 import { resolveConversationSettings } from "../config.js";
-import { ensureOfficeDir } from "../office/index.js";
+import type { Office } from "../office/index.js";
 import * as log from "../log.js";
-import { conversationOfficeDir, officeDirName, validateOfficeAddress } from "../office/index.js";
-import type {
-  ImageWorkspaceMountMode,
-  OfficeAddress,
-  WorkspaceDoorPolicy,
-  WorkspaceLayout,
-} from "../types.js";
+import type { ImageWorkspaceMountMode, WorkspaceDoorPolicy, WorkspaceLayout } from "../types.js";
 import type { WorkspaceProjection } from "./types.js";
 
 export type { WorkspaceProjection } from "./types.js";
@@ -20,93 +14,50 @@ export type { WorkspaceProjection } from "./types.js";
  * host-side roots and authorizes the prompt sources that describe them.
  * Legacy image settings are deliberately translated here, never at callers.
  */
-export function resolveWorkspaceProjection(
-  hostWorkspaceRoot: string | undefined,
-  address: OfficeAddress,
-): WorkspaceProjection {
-  const normalized = validateOfficeAddress(address);
-  const officeSegment = officeDirName(normalized);
-  const conversationDir = hostWorkspaceRoot
-    ? conversationOfficeDir(hostWorkspaceRoot, normalized)
-    : join("/workspace", officeSegment);
-  const effective = resolveEffectiveWorkspace(hostWorkspaceRoot, normalized, conversationDir);
+export function resolveWorkspaceProjection(office: Office): WorkspaceProjection {
+  const { workspace } = office;
+  const effective = resolveEffectiveWorkspace(office);
 
-  if (!hostWorkspaceRoot) {
-    return {
-      ...effective,
-      mode: effective.layout === "full" ? "full" : "private",
-      mounts: [],
-      promptSources: {
-        conversationDir,
-        conversationMemoryPath: join(conversationDir, "MEMORY.md"),
-        conversationSkillsDir: join(conversationDir, "skills"),
-        ...(effective.layout === "shared-support" || effective.layout === "full"
-          ? {
-              globalMemoryPath: "/workspace/MEMORY.md",
-              globalSkillsDir: "/workspace/skills",
-            }
-          : {}),
-      },
-    };
-  }
-
-  assertDirectory(hostWorkspaceRoot, "Host workspace root");
-  ensureOfficeDir(hostWorkspaceRoot, normalized);
-  const memoryPath = join(hostWorkspaceRoot, "MEMORY.md");
-  const skillsPath = join(hostWorkspaceRoot, "skills");
-  const eventsPath = join(hostWorkspaceRoot, "events");
+  assertDirectory(workspace.root, "Host workspace root");
+  office.ensure();
   const shared = effective.layout === "shared-support";
   if (shared) {
-    ensureRegularFile(memoryPath, "Workspace memory");
-    ensureDirectoryRoot(skillsPath, "Workspace skills");
-    ensureDirectoryRoot(eventsPath, "Workspace events");
+    ensureRegularFile(workspace.memoryPath, "Workspace memory");
+    ensureDirectoryRoot(workspace.skillsDir, "Workspace skills");
+    ensureDirectoryRoot(workspace.eventsDir, "Workspace events");
   }
 
   const mounts =
     effective.layout === "full"
-      ? [{ source: hostWorkspaceRoot, target: "/workspace" }]
+      ? [{ source: workspace.root, target: "/workspace" }]
       : effective.layout === "shared-support"
         ? [
-            { source: memoryPath, target: "/workspace/MEMORY.md" },
-            { source: skillsPath, target: "/workspace/skills" },
-            { source: eventsPath, target: "/workspace/events" },
-            { source: conversationDir, target: `/workspace/${officeSegment}` },
+            { source: workspace.memoryPath, target: "/workspace/MEMORY.md" },
+            { source: workspace.skillsDir, target: "/workspace/skills" },
+            { source: workspace.eventsDir, target: "/workspace/events" },
+            { source: office.dir, target: `/workspace/${office.key}` },
           ]
-        : [{ source: conversationDir, target: `/workspace/${officeSegment}` }];
+        : [{ source: office.dir, target: `/workspace/${office.key}` }];
 
   return {
     ...effective,
-    mode: effective.layout === "full" ? "full" : "private",
     mounts,
     promptSources: {
-      conversationDir,
-      conversationMemoryPath: join(conversationDir, "MEMORY.md"),
-      conversationSkillsDir: join(conversationDir, "skills"),
+      conversationDir: office.dir,
+      conversationMemoryPath: office.memoryPath,
+      conversationSkillsDir: office.skillsDir,
       ...(effective.layout === "shared-support" || effective.layout === "full"
-        ? { globalMemoryPath: memoryPath, globalSkillsDir: skillsPath }
+        ? { globalMemoryPath: workspace.memoryPath, globalSkillsDir: workspace.skillsDir }
         : {}),
     },
   };
 }
 
-/** Compatibility reader for old status callers. */
-export function readWorkspaceProjectionMode(
-  hostWorkspaceRoot: string | undefined,
-  address: OfficeAddress,
-): ImageWorkspaceMountMode {
-  return resolveWorkspaceProjection(hostWorkspaceRoot, address).mode;
-}
-
 function resolveEffectiveWorkspace(
-  hostWorkspaceRoot: string | undefined,
-  address: OfficeAddress,
-  conversationDir: string,
+  office: Office,
 ): Pick<WorkspaceProjection, "doorPolicy" | "layout"> {
-  const fallback = { doorPolicy: "isolated" as const, layout: "conversation" as const };
-  if (!hostWorkspaceRoot) return fallback;
-
   try {
-    const settings = resolveConversationSettings({ address, conversationDir }).sandbox;
+    const settings = resolveConversationSettings(office).sandbox;
     if (settings?.workspace) {
       return normalizeWorkspace(settings.workspace.doorPolicy, settings.workspace.layout);
     }

--- a/src/workspace-projection/types.ts
+++ b/src/workspace-projection/types.ts
@@ -11,8 +11,6 @@ interface WorkspacePromptSources {
 export interface WorkspaceProjection {
   doorPolicy: WorkspaceDoorPolicy;
   layout: WorkspaceLayout;
-  /** Legacy layout name for callers that only display the old setting. */
-  mode: "private" | "full";
   mounts: ContainerMount[];
   promptSources: WorkspacePromptSources;
 }

--- a/test/admin-portal-packages.test.ts
+++ b/test/admin-portal-packages.test.ts
@@ -9,8 +9,8 @@ import { handleAdminRequest } from "../src/web/admin/portal.js";
 import { InMemoryAdminTokenStore } from "../src/web/admin/store.js";
 import { FileVaultManager } from "../src/vault/index.js";
 import type { AdminServices } from "../src/web/admin/types.js";
-import { createOfficeAddress, createWorkspace, officeDirName } from "../src/office/index.js";
-import { OfficeRegistry } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace } from "../src/office/index.js";
+import type { Workspace } from "../src/office/index.js";
 
 const CONVERSATION_ID = "C03045VJJAY";
 const CONVERSATION_ADDRESS = createOfficeAddress("slack", CONVERSATION_ID);
@@ -18,6 +18,7 @@ const CONVERSATION_ADDRESS = createOfficeAddress("slack", CONVERSATION_ID);
 let base: string;
 let stateDir: string;
 let workingDir: string;
+let workspace: Workspace;
 let repo: string;
 let source: string;
 let server: Server;
@@ -69,8 +70,10 @@ beforeEach(async () => {
   stateDir = join(base, "state");
   workingDir = join(base, "workspace");
   mkdirSync(stateDir, { recursive: true });
-  new OfficeRegistry(stateDir).recordOffice(CONVERSATION_ADDRESS);
-  mkdirSync(join(workingDir, officeDirName(CONVERSATION_ADDRESS)), { recursive: true });
+  // ensure() both records the office in the registry the portal resolves
+  // through and materializes its workspace dir.
+  workspace = createWorkspace({ root: workingDir, stateDir });
+  workspace.office(CONVERSATION_ADDRESS).ensure();
   process.env.MIKAN_STATE_DIR = stateDir;
   writeFileSync(
     join(stateDir, "settings.json"),
@@ -101,7 +104,7 @@ beforeEach(async () => {
     vaultManager: new FileVaultManager(stateDir),
     linkTokenStore: { create: () => ({ token: "x", expiresAt: 0 }) } as never,
     adminTokenStore,
-    workspace: createWorkspace({ root: workingDir, stateDir }),
+    workspace,
   });
   server = started.server;
   origin = started.origin;

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -11,7 +11,7 @@ import { loadSkillsFromDir } from "../src/harness/skills.js";
 import { MikanAgentSession, MikanModels } from "../src/harness/index.js";
 import { createManagedSessionFile, getChannelSessionDir } from "../src/sessions/store.js";
 import type { PlatformToolPackFactory } from "../src/tools/types.js";
-import { createOfficeAddress, officeDirName } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, type Office } from "../src/office/index.js";
 
 /**
  * Drives PiAgentWrapper.run() end to end with a faux provider: the runner is
@@ -43,6 +43,15 @@ afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
 });
 
+const C1_ADDRESS = createOfficeAddress("slack", "C1");
+
+/** The office every test in this file drives, rooted in the per-test tmpdir. */
+function testOffice(): Office {
+  return createWorkspace({ root: join(dir, "workspace"), stateDir: join(dir, "state") }).office(
+    C1_ADDRESS,
+  );
+}
+
 function createFauxModels(): { models: MikanModels; faux: ReturnType<typeof fauxProvider> } {
   const authPath = join(dir, "auth.json");
   writeFileSync(authPath, JSON.stringify({ faux: { type: "api_key", key: "test-key" } }));
@@ -59,19 +68,15 @@ async function createTestRunner(
   platformToolPackFactories: readonly PlatformToolPackFactory[] = [],
 ) {
   const { models, faux } = createFauxModels();
-  const workspaceDir = join(dir, "workspace");
-  const conversationDir = join(workspaceDir, officeDirName(createOfficeAddress("slack", "C1")));
-  mkdirSync(conversationDir, { recursive: true });
+  const office = testOffice();
+  const conversationDir = office.ensure();
   const sessionDir = getChannelSessionDir(conversationDir);
   const contextFile = createManagedSessionFile(sessionDir, conversationDir);
 
   const runner = await createRunner({
     sandboxConfig: { type: "host" },
     sessionKey: "C1",
-    address: createOfficeAddress("slack", "C1"),
-    conversationId: "C1",
-    conversationDir,
-    workspaceDir,
+    office,
     sessionScope: { sessionDir, contextFile, threadRootMessage: null },
     models,
     platformToolPackFactories,
@@ -125,15 +130,9 @@ describe("PiAgentWrapper.run", () => {
   test("does not follow conversation memory symlinks during host prompt construction", async () => {
     const outside = join(dir, "outside-secret.txt");
     writeFileSync(outside, "DO_NOT_LEAK_THIS_SECRET");
-    const memoryPath = join(
-      dir,
-      "workspace",
-      officeDirName(createOfficeAddress("slack", "C1")),
-      "MEMORY.md",
-    );
-    mkdirSync(join(dir, "workspace", officeDirName(createOfficeAddress("slack", "C1"))), {
-      recursive: true,
-    });
+    const office = testOffice();
+    const memoryPath = office.memoryPath;
+    office.ensure();
     rmSync(memoryPath, { force: true });
     symlinkSync(outside, memoryPath);
     const { runner } = await createTestRunner();
@@ -339,12 +338,7 @@ describe("PiAgentWrapper.run", () => {
   test("hidden session Dream sees the old transcript and writes memory", async () => {
     const promptSpy = vi.spyOn(MikanAgentSession.prototype, "prompt");
     const { runner, faux } = await createTestRunner();
-    const memoryPath = join(
-      dir,
-      "workspace",
-      officeDirName(createOfficeAddress("slack", "C1")),
-      "MEMORY.md",
-    );
+    const memoryPath = testOffice().memoryPath;
     const setupResponder = makeResponder();
     let maintenancePrompt = "";
     faux.setResponses([

--- a/test/channel-store.test.ts
+++ b/test/channel-store.test.ts
@@ -2,10 +2,10 @@ import { existsSync, mkdirSync, readFileSync, rmSync, rmdirSync, writeFileSync }
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { createOfficeAddress, createWorkspace, officeDirName } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 import { ChannelStore } from "../src/store.js";
 
-const office = (channelId: string) => officeDirName(createOfficeAddress("slack", channelId));
+const office = (channelId: string) => officeKey(createOfficeAddress("slack", channelId));
 
 function okResponse(body: string): Response {
   return new Response(Buffer.from(body), { status: 200 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -18,12 +18,7 @@ import { ModelCommandHandler } from "../src/commands/model.js";
 import { NewCommandHandler } from "../src/commands/new.js";
 import { SandboxCommandHandler } from "../src/commands/sandbox.js";
 import { SessionViewCommandHandler } from "../src/commands/session-view.js";
-import {
-  createOfficeAddress,
-  createWorkspace,
-  officeDirName,
-  officeKey,
-} from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 import type { CommandContext, CommandHandler, CommandServices } from "../src/commands/types.js";
 import { createManagedSessionFile, getChannelSessionDir } from "../src/sessions/store.js";
 import type { SandboxConfig } from "../src/sandbox/index.js";
@@ -359,7 +354,7 @@ describe("AutoReplyCommandHandler", () => {
 
     const enabledPath = join(
       workingDir,
-      officeDirName(createOfficeAddress("slack", "C123")),
+      officeKey(createOfficeAddress("slack", "C123")),
       "auto-reply",
     );
     expect(readFileSync(enabledPath, "utf-8")).toBe("");
@@ -379,18 +374,14 @@ describe("AutoReplyCommandHandler", () => {
     expect(existsSync(enabledPath)).toBe(false);
     expect(
       readFileSync(
-        join(
-          workingDir,
-          officeDirName(createOfficeAddress("slack", "C123")),
-          "auto-reply.disabled",
-        ),
+        join(workingDir, officeKey(createOfficeAddress("slack", "C123")), "auto-reply.disabled"),
         "utf-8",
       ),
     ).toBe("Reply when someone asks about deployments.");
   });
 
   test("shows auto-reply file contents in status", async () => {
-    const conversationDir = join(workingDir, officeDirName(createOfficeAddress("slack", "C123")));
+    const conversationDir = join(workingDir, officeKey(createOfficeAddress("slack", "C123")));
     mkdirSync(conversationDir, { recursive: true });
     writeFileSync(
       join(conversationDir, "auto-reply"),
@@ -797,25 +788,8 @@ describe("SandboxCommandHandler", () => {
     });
 
     expect(await handler.tryHandle(ctx)).toBe(true);
-    expect(
-      existsSync(
-        conversationSettingsPath({
-          address: createOfficeAddress("slack", "C123"),
-          conversationDir: join(workingDir, "C123"),
-        }),
-      ),
-    ).toBe(true);
-    expect(
-      JSON.parse(
-        readFileSync(
-          conversationSettingsPath({
-            address: createOfficeAddress("slack", "C123"),
-            conversationDir: join(workingDir, "C123"),
-          }),
-          "utf-8",
-        ),
-      ),
-    ).toEqual({});
+    expect(existsSync(conversationSettingsPath(doorOffice()))).toBe(true);
+    expect(JSON.parse(readFileSync(conversationSettingsPath(doorOffice()), "utf-8"))).toEqual({});
     expect(ctx.responder.responses[0]).toContain("Workspace policy: isolated");
   });
 
@@ -839,18 +813,17 @@ describe("SandboxCommandHandler", () => {
     });
   }
 
+  /** The office the handler mutates — same workspace the contexts are built on. */
+  function doorOffice() {
+    return testWorkspace(workingDir).office(createOfficeAddress("slack", "C123"));
+  }
+
   function doorSettingsFile(): string {
-    return conversationSettingsPath({
-      address: createOfficeAddress("slack", "C123"),
-      conversationDir: join(workingDir, "C123"),
-    });
+    return conversationSettingsPath(doorOffice());
   }
 
   function doorOverride() {
-    return loadConversationWorkspaceOverride({
-      address: createOfficeAddress("slack", "C123"),
-      conversationDir: join(workingDir, "C123"),
-    });
+    return loadConversationWorkspaceOverride(doorOffice());
   }
 
   test("door without an argument shows usage and the current policy", async () => {
@@ -949,7 +922,7 @@ describe("SessionViewCommandHandler", () => {
     const conversationId = "C123";
     const conversationDir = join(
       workingDir,
-      officeDirName(createOfficeAddress("slack", conversationId)),
+      officeKey(createOfficeAddress("slack", conversationId)),
     );
     mkdirSync(conversationDir, { recursive: true });
     createManagedSessionFile(getChannelSessionDir(conversationDir), conversationDir);
@@ -1005,7 +978,7 @@ describe("SessionViewCommandHandler", () => {
     const conversationId = "C123";
     const conversationDir = join(
       workingDir,
-      officeDirName(createOfficeAddress("slack", conversationId)),
+      officeKey(createOfficeAddress("slack", conversationId)),
     );
     mkdirSync(conversationDir, { recursive: true });
     const expectedFile = createManagedSessionFile(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { createOfficeAddress } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, type Office } from "../src/office/index.js";
 import {
   assertStateDirOutsideWorkspace,
   conversationSettingsPath,
@@ -17,6 +17,13 @@ import {
 
 describe("loadGlobalSettings", () => {
   let stateDir: string;
+
+  /** The C123 Slack office of a workspace rooted under this test's state dir. */
+  function office(): Office {
+    return createWorkspace({ root: join(stateDir, "workspace"), stateDir }).office(
+      createOfficeAddress("slack", "C123"),
+    );
+  }
 
   beforeEach(() => {
     stateDir = join(tmpdir(), `mikan-test-${Date.now()}-${Math.random()}`);
@@ -177,83 +184,50 @@ describe("loadGlobalSettings", () => {
 
   test("throws on conversation settings.json with invalid nested field types", () => {
     createGlobalSettingsFile(stateDir);
-    const conversationDir = join(stateDir, "workspace", "C123");
-    mkdirSync(conversationDir, { recursive: true });
+    const conversation = office();
+    mkdirSync(conversation.dir, { recursive: true });
     writeFileSync(
-      join(conversationDir, "settings.json"),
+      join(conversation.dir, "settings.json"),
       JSON.stringify({ sandbox: { image: { workspaceMount: "everything" } } }),
       "utf-8",
     );
 
-    expect(() =>
-      resolveConversationSettings({
-        address: createOfficeAddress("slack", "C123"),
-        conversationDir,
-      }),
-    ).toThrow(/Malformed settings file.*workspaceMount/);
+    expect(() => resolveConversationSettings(conversation)).toThrow(
+      /Malformed settings file.*workspaceMount/,
+    );
   });
 
   test("conversation model config overrides global provider and model only", () => {
     updateGlobalSettings({ provider: "anthropic", model: "claude-sonnet-4-6" });
-    const conversationDir = join(stateDir, "workspace", "C123");
-    updateConversationSettings(
-      { address: createOfficeAddress("slack", "C123"), conversationDir },
-      {
-        provider: "openai",
-        model: "gpt-4o",
-        thinkingLevel: "low",
-      },
-    );
-
-    const config = resolveConversationSettings({
-      address: createOfficeAddress("slack", "C123"),
-      conversationDir,
+    const conversation = office();
+    updateConversationSettings(conversation, {
+      provider: "openai",
+      model: "gpt-4o",
+      thinkingLevel: "low",
     });
+
+    const config = resolveConversationSettings(conversation);
     expect(config.provider).toBe("openai");
     expect(config.model).toBe("gpt-4o");
     expect(config.thinkingLevel).toBe("low");
     // Settings are host-authoritative: stored under the state dir, never in
     // the (sandbox-mounted) conversation dir.
-    expect(existsSync(join(conversationDir, "settings.json"))).toBe(false);
-    expect(
-      JSON.parse(
-        readFileSync(
-          conversationSettingsPath({
-            address: createOfficeAddress("slack", "C123"),
-            conversationDir,
-          }),
-          "utf-8",
-        ),
-      ),
-    ).toEqual({
+    expect(existsSync(join(conversation.dir, "settings.json"))).toBe(false);
+    expect(JSON.parse(readFileSync(conversationSettingsPath(conversation), "utf-8"))).toEqual({
       llm: { provider: "openai", model: "gpt-4o", thinkingLevel: "low" },
     });
   });
 
   test("conversation sandbox config overrides global image workspace mount", () => {
     createGlobalSettingsFile(stateDir);
-    const conversationDir = join(stateDir, "workspace", "C123");
-    updateConversationSettings(
-      { address: createOfficeAddress("slack", "C123"), conversationDir },
-      { sandbox: { image: { workspaceMount: "full" } } },
-    );
-
-    const config = resolveConversationSettings({
-      address: createOfficeAddress("slack", "C123"),
-      conversationDir,
+    const conversation = office();
+    updateConversationSettings(conversation, {
+      sandbox: { image: { workspaceMount: "full" } },
     });
+
+    const config = resolveConversationSettings(conversation);
     expect(config.sandbox?.image?.workspaceMount).toBe("full");
-    expect(
-      JSON.parse(
-        readFileSync(
-          conversationSettingsPath({
-            address: createOfficeAddress("slack", "C123"),
-            conversationDir,
-          }),
-          "utf-8",
-        ),
-      ),
-    ).toEqual({
+    expect(JSON.parse(readFileSync(conversationSettingsPath(conversation), "utf-8"))).toEqual({
       sandbox: { image: { workspaceMount: "full" } },
     });
   });
@@ -261,18 +235,12 @@ describe("loadGlobalSettings", () => {
   test("sandbox settings merge at the leaf level across global and conversation", () => {
     createGlobalSettingsFile(stateDir);
     updateGlobalSettings({ sandbox: { cpus: "1", boost: { cpus: "4" } } });
-    const conversationDir = join(stateDir, "workspace", "C123");
-    updateConversationSettings(
-      { address: createOfficeAddress("slack", "C123"), conversationDir },
-      {
-        sandbox: { memory: "2g", boost: { memory: "8g" } },
-      },
-    );
-
-    const config = resolveConversationSettings({
-      address: createOfficeAddress("slack", "C123"),
-      conversationDir,
+    const conversation = office();
+    updateConversationSettings(conversation, {
+      sandbox: { memory: "2g", boost: { memory: "8g" } },
     });
+
+    const config = resolveConversationSettings(conversation);
     // Global sandbox.cpus survives a conversation that only sets sandbox.memory.
     expect(config.sandbox?.cpus).toBe("1");
     expect(config.sandbox?.memory).toBe("2g");
@@ -283,88 +251,52 @@ describe("loadGlobalSettings", () => {
 
   test("conversation slack config overrides global reply mode", () => {
     updateGlobalSettings({ slack: { replyMode: "top-level" } });
-    const conversationDir = join(stateDir, "workspace", "C123");
-    updateConversationSettings(
-      { address: createOfficeAddress("slack", "C123"), conversationDir },
-      { slack: { replyMode: "thread" } },
-    );
+    const conversation = office();
+    updateConversationSettings(conversation, { slack: { replyMode: "thread" } });
 
-    const config = resolveConversationSettings({
-      address: createOfficeAddress("slack", "C123"),
-      conversationDir,
-    });
+    const config = resolveConversationSettings(conversation);
     expect(config.slack?.replyMode).toBe("thread");
-    expect(
-      JSON.parse(
-        readFileSync(
-          conversationSettingsPath({
-            address: createOfficeAddress("slack", "C123"),
-            conversationDir,
-          }),
-          "utf-8",
-        ),
-      ),
-    ).toEqual({
+    expect(JSON.parse(readFileSync(conversationSettingsPath(conversation), "utf-8"))).toEqual({
       slack: { replyMode: "thread" },
     });
   });
 
   test("migrates a legacy conversation settings.json into the state dir once", () => {
     createGlobalSettingsFile(stateDir);
-    const conversationDir = join(stateDir, "workspace", "C123");
-    mkdirSync(conversationDir, { recursive: true });
-    const legacyPath = join(conversationDir, "settings.json");
+    const conversation = office();
+    mkdirSync(conversation.dir, { recursive: true });
+    const legacyPath = join(conversation.dir, "settings.json");
     writeFileSync(legacyPath, JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }));
 
-    const config = resolveConversationSettings({
-      address: createOfficeAddress("slack", "C123"),
-      conversationDir,
-    });
+    const config = resolveConversationSettings(conversation);
     expect(config.sandbox?.image?.workspaceMount).toBe("full");
     // Legacy file was moved out of the (sandbox-mounted) conversation dir.
     expect(existsSync(legacyPath)).toBe(false);
-    expect(
-      existsSync(
-        conversationSettingsPath({
-          address: createOfficeAddress("slack", "C123"),
-          conversationDir,
-        }),
-      ),
-    ).toBe(true);
+    expect(existsSync(conversationSettingsPath(conversation))).toBe(true);
   });
 
   test("a legacy settings.json appearing after migration is never read (sandbox plant)", () => {
     createGlobalSettingsFile(stateDir);
-    const conversationDir = join(stateDir, "workspace", "C123");
-    mkdirSync(conversationDir, { recursive: true });
+    const conversation = office();
+    mkdirSync(conversation.dir, { recursive: true });
 
     // First access with no legacy file writes the migration marker.
     // Global onboarding now defaults to an isolated office.
-    expect(
-      resolveConversationSettings({
-        address: createOfficeAddress("slack", "C123"),
-        conversationDir,
-      }).sandbox?.workspace,
-    ).toEqual({
+    expect(resolveConversationSettings(conversation).sandbox?.workspace).toEqual({
       doorPolicy: "isolated",
     });
 
     // An agent inside the sandbox plants a legacy settings.json afterwards,
     // trying to flip its own mount mode to full. It must stay ignored.
     writeFileSync(
-      join(conversationDir, "settings.json"),
+      join(conversation.dir, "settings.json"),
       JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }),
     );
-    expect(
-      resolveConversationSettings({
-        address: createOfficeAddress("slack", "C123"),
-        conversationDir,
-      }).sandbox?.workspace,
-    ).toEqual({
+    expect(resolveConversationSettings(conversation).sandbox?.workspace).toEqual({
       doorPolicy: "isolated",
     });
     // And it is not deleted either: only pre-migration files are moved.
-    expect(existsSync(join(conversationDir, "settings.json"))).toBe(true);
+    expect(existsSync(join(conversation.dir, "settings.json"))).toBe(true);
   });
 });
 

--- a/test/discord-bot.test.ts
+++ b/test/discord-bot.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { Collection } from "discord.js";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { MessagingEventHandler } from "../src/adapter.js";
-import { createOfficeAddress, createWorkspace, officeDirName } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 import type { Workspace } from "../src/office/index.js";
 import { DiscordMessagingBot } from "../src/adapters/discord/bot.js";
 
@@ -96,13 +96,13 @@ describe("DiscordMessagingBot attachments", () => {
 
     expect(downloadAttachment).toHaveBeenNthCalledWith(
       1,
-      join(workingDir, officeDirName(createOfficeAddress("discord", "C123")), "attachments"),
+      join(workingDir, officeKey(createOfficeAddress("discord", "C123")), "attachments"),
       expect.stringMatching(/^\d+_clip\.mov$/),
       "https://example.com/clip.mov",
     );
     expect(downloadAttachment).toHaveBeenNthCalledWith(
       2,
-      join(workingDir, officeDirName(createOfficeAddress("discord", "C123")), "attachments"),
+      join(workingDir, officeKey(createOfficeAddress("discord", "C123")), "attachments"),
       expect.stringMatching(/^\d+_broken\.mov$/),
       "https://example.com/broken.mov",
     );
@@ -111,7 +111,7 @@ describe("DiscordMessagingBot attachments", () => {
         name: "clip.mov",
         localPath: expect.stringMatching(
           new RegExp(
-            `^${officeDirName(createOfficeAddress("discord", "C123"))}/attachments/\\d+_clip\\.mov$`,
+            `^${officeKey(createOfficeAddress("discord", "C123"))}/attachments/\\d+_clip\\.mov$`,
           ),
         ),
       },
@@ -339,7 +339,7 @@ describe("DiscordMessagingBot message routing", () => {
     );
 
     const lines = readFileSync(
-      join(workingDir, officeDirName(createOfficeAddress("discord", "C1")), "log.jsonl"),
+      join(workingDir, officeKey(createOfficeAddress("discord", "C1")), "log.jsonl"),
       "utf-8",
     )
       .trim()

--- a/test/execution-resolver.test.ts
+++ b/test/execution-resolver.test.ts
@@ -4,20 +4,19 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { credentialAuthorizationKey } from "../src/sandbox/identity.js";
 import { createGlobalSettingsFile } from "../src/config.js";
-import {
-  ActorExecutionResolver,
-  readConversationWorkspaceMountMode,
-} from "../src/execution-resolver.js";
+import { ActorExecutionResolver } from "../src/execution-resolver.js";
 import { FileVaultManager } from "../src/vault/index.js";
-import { createOfficeAddress, officeDirName } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 
-const C123_OFFICE = officeDirName(createOfficeAddress("slack", "C123"));
+const C123_OFFICE = officeKey(createOfficeAddress("slack", "C123"));
 
-describe("readConversationWorkspaceMountMode", () => {
+describe("ActorExecutionResolver", () => {
   // the Gondolin executor asserts Node >=23.6, but CI also runs the 22.19.0 floor
   const nodeVersion = Object.getOwnPropertyDescriptor(process.versions, "node");
   let stateDir: string;
   let workspaceDir: string;
+
+  const workspace = () => createWorkspace({ root: workspaceDir, stateDir });
 
   beforeEach(() => {
     // mkdtemp, not Date.now(): two tests entering the same millisecond would
@@ -38,15 +37,7 @@ describe("readConversationWorkspaceMountMode", () => {
     }
   });
 
-  test("uses the global default when conversation settings are missing", () => {
-    createGlobalSettingsFile(stateDir);
-
-    expect(
-      readConversationWorkspaceMountMode(workspaceDir, createOfficeAddress("slack", "C123")),
-    ).toBe("private");
-  });
-
-  test("fails closed instead of escalating from raw fallback settings", () => {
+  test("fails closed instead of escalating from raw fallback settings", async () => {
     writeFileSync(join(stateDir, "settings.json"), "{ invalid json }", "utf-8");
     const conversationDir = join(workspaceDir, C123_OFFICE);
     mkdirSync(conversationDir, { recursive: true });
@@ -55,25 +46,43 @@ describe("readConversationWorkspaceMountMode", () => {
       JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }),
       "utf-8",
     );
+    const resolver = new ActorExecutionResolver(
+      { type: "gondolin", profile: "default" },
+      new FileVaultManager(stateDir),
+      undefined,
+      workspace(),
+    );
 
-    expect(() =>
-      readConversationWorkspaceMountMode(workspaceDir, createOfficeAddress("slack", "C123")),
-    ).toThrow(/settings are malformed/);
+    await expect(
+      resolver.resolve({ userId: "U123", address: createOfficeAddress("slack", "C123") }),
+    ).rejects.toThrow(/settings are malformed/);
   });
 
-  test("fails closed when legacy conversation settings are malformed", () => {
+  test("fails closed when legacy conversation settings are malformed", async () => {
     createGlobalSettingsFile(stateDir);
     const conversationDir = join(workspaceDir, C123_OFFICE);
     mkdirSync(conversationDir, { recursive: true });
     writeFileSync(join(conversationDir, "settings.json"), "{ invalid json }", "utf-8");
+    const resolver = new ActorExecutionResolver(
+      { type: "gondolin", profile: "default" },
+      new FileVaultManager(stateDir),
+      undefined,
+      workspace(),
+    );
 
-    expect(() =>
-      readConversationWorkspaceMountMode(workspaceDir, createOfficeAddress("slack", "C123")),
-    ).toThrow(/settings are malformed/);
+    await expect(
+      resolver.resolve({ userId: "U123", address: createOfficeAddress("slack", "C123") }),
+    ).rejects.toThrow(/settings are malformed/);
   });
 
   test("rejects path-bearing conversation ids before reading or creating directories", () => {
     createGlobalSettingsFile(stateDir);
+    const resolver = new ActorExecutionResolver(
+      { type: "gondolin", profile: "default" },
+      new FileVaultManager(stateDir),
+      undefined,
+      workspace(),
+    );
 
     for (const conversationId of [
       "",
@@ -85,12 +94,12 @@ describe("readConversationWorkspaceMountMode", () => {
       "nested\\id",
     ]) {
       // Identity validation moved to the address factory, ahead of any
-      // directory reads or creation.
+      // directory reads or creation: the address never reaches `resolve`.
       expect(() =>
-        readConversationWorkspaceMountMode(
-          workspaceDir,
-          createOfficeAddress("slack", conversationId),
-        ),
+        resolver.resolve({
+          userId: "U123",
+          address: createOfficeAddress("slack", conversationId),
+        }),
       ).toThrow(/Conversation id|Unsupported platform/);
     }
   });
@@ -101,8 +110,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "gondolin", profile: "default" },
       new FileVaultManager(stateDir),
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
 
     const executor = await resolver.resolve({
@@ -129,8 +137,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "gondolin", profile: "default" },
       new FileVaultManager(stateDir),
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
 
     const executor = await resolver.resolve({
@@ -159,8 +166,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "gondolin", profile: "default" },
       new FileVaultManager(stateDir),
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
 
     const executor = await resolver.resolve({
@@ -179,8 +185,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "gondolin", profile: "default" },
       new FileVaultManager(stateDir),
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
     const context = { userId: "U123", address: createOfficeAddress("slack", "C123") } as const;
 
@@ -223,8 +228,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "gondolin", profile: "default" },
       vault,
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
 
     await expect(
@@ -246,8 +250,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "gondolin", profile: "default" },
       vault,
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
 
     await resolver.resolve({ userId: "U123", address: createOfficeAddress("slack", "A_B") });
@@ -268,7 +271,7 @@ describe("readConversationWorkspaceMountMode", () => {
         return undefined;
       },
     } as unknown as FileVaultManager;
-    const resolver = new ActorExecutionResolver({ type: "host" }, vault, undefined, workspaceDir);
+    const resolver = new ActorExecutionResolver({ type: "host" }, vault, undefined, workspace());
 
     await expect(
       resolver.resolve({ userId: "U123", address: createOfficeAddress("slack", "C123") }),
@@ -300,8 +303,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "gondolin", profile: "default" },
       vault,
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
 
     await expect(
@@ -324,8 +326,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "cloudflare", sandboxId: "base" },
       vault,
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
 
     await expect(
@@ -339,8 +340,7 @@ describe("readConversationWorkspaceMountMode", () => {
       { type: "cloudflare", sandboxId: "mikan-remote" },
       new FileVaultManager(stateDir),
       undefined,
-      workspaceDir,
-      workspaceDir,
+      workspace(),
     );
 
     await expect(

--- a/test/github-bot.test.ts
+++ b/test/github-bot.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { MessagingEventHandler, OfficeAddress } from "../src/adapter.js";
-import { createOfficeAddress, createWorkspace, officeDirName } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 import { conversationIdOf } from "../src/sessions/session-key.js";
 import { GithubMessagingBot } from "../src/adapters/github/bot.js";
 import type { GithubClient } from "../src/adapters/github/client.js";
@@ -164,7 +164,7 @@ function makeFakeClient(): FakeClient {
 }
 
 const CONVERSATION_ID = "GH_octo_widgets_5";
-const CONVERSATION_OFFICE = officeDirName(createOfficeAddress("github", CONVERSATION_ID));
+const CONVERSATION_OFFICE = officeKey(createOfficeAddress("github", CONVERSATION_ID));
 
 async function settleQueues(): Promise<void> {
   // MessagingEventQueue processes asynchronously; yield a few microtask turns.

--- a/test/office-address.test.ts
+++ b/test/office-address.test.ts
@@ -7,10 +7,9 @@ import { officeDir } from "../src/office/address.js";
 import {
   assertConversationId,
   assertOfficeKey,
-  conversationOfficeDir,
   createOfficeAddress,
+  createWorkspace,
   isOfficeKey,
-  officeDirName,
   officeKey,
   officeStateDir,
   sameOffice,
@@ -135,19 +134,21 @@ describe("office address", () => {
     const address = createOfficeAddress("slack", "C123");
 
     test("host dir and runtime segment agree on the office key", () => {
-      expect(officeDirName(address)).toBe(officeKey(address));
-      expect(conversationOfficeDir("/data/workspace", address)).toBe(
-        `/data/workspace/${officeKey(address)}`,
+      const office = createWorkspace({ root: "/data/workspace", stateDir: "/data/state" }).office(
+        address,
       );
-      expect(conversationOfficeDir("/data/workspace", address)).toBe(
-        officeDir("/data/workspace", address),
-      );
+
+      expect(office.key).toBe(officeKey(address));
+      expect(office.dir).toBe(`/data/workspace/${officeKey(address)}`);
+      expect(office.dir).toBe(officeDir("/data/workspace", address));
+      expect(office.stateDir).toBe(officeStateDir("/data/state", address));
     });
 
     test("platforms sharing a raw id resolve to different directories", () => {
+      const workspace = createWorkspace({ root: "/w", stateDir: "/s" });
       const discord = createOfficeAddress("discord", "900100");
       const telegram = createOfficeAddress("telegram", "900100");
-      expect(conversationOfficeDir("/w", discord)).not.toBe(conversationOfficeDir("/w", telegram));
+      expect(workspace.office(discord).dir).not.toBe(workspace.office(telegram).dir);
     });
   });
 });

--- a/test/office-registry.test.ts
+++ b/test/office-registry.test.ts
@@ -11,8 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { officeDir } from "../src/office/address.js";
-import { conversationOfficeDir, createOfficeAddress } from "../src/office/index.js";
-import { ensureOfficeDir, OfficeRegistry } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, OfficeRegistry } from "../src/office/index.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -340,40 +339,36 @@ describe("OfficeRegistry", () => {
     expect(new OfficeRegistry(fixture.stateDir).getOffices()).toEqual([]);
   });
 
-  describe("ensureOfficeDir", () => {
+  describe("office.ensure()", () => {
     test("registers the office, creates its directory, and stays idempotent", () => {
       const fixture = makeFixture();
-      process.env.MIKAN_STATE_DIR = fixture.stateDir;
-      try {
-        const address = createOfficeAddress("slack", "C900");
-        const dir = ensureOfficeDir(fixture.workspaceRoot, address);
+      const office = createWorkspace({
+        root: fixture.workspaceRoot,
+        stateDir: fixture.stateDir,
+      }).office(createOfficeAddress("slack", "C900"));
 
-        expect(dir).toBe(conversationOfficeDir(fixture.workspaceRoot, address));
-        expect(existsSync(dir)).toBe(true);
-        expect(ensureOfficeDir(fixture.workspaceRoot, address)).toBe(dir);
-        const registry = new OfficeRegistry(fixture.stateDir);
-        expect(registry.getOffices()).toContainEqual(
-          expect.objectContaining({ platform: "slack", conversationId: "C900" }),
-        );
-      } finally {
-        delete process.env.MIKAN_STATE_DIR;
-      }
+      const dir = office.ensure();
+
+      expect(dir).toBe(office.dir);
+      expect(dir).toBe(officeDir(fixture.workspaceRoot, office.address));
+      expect(existsSync(dir)).toBe(true);
+      expect(office.ensure()).toBe(dir);
+      const registry = new OfficeRegistry(fixture.stateDir);
+      expect(registry.getOffices()).toContainEqual(
+        expect.objectContaining({ platform: "slack", conversationId: "C900" }),
+      );
     });
 
     test("fails closed when the office path is a symlink", () => {
       const fixture = makeFixture();
-      process.env.MIKAN_STATE_DIR = fixture.stateDir;
-      try {
-        const address = createOfficeAddress("slack", "C901");
-        mkdirSync(fixture.workspaceRoot, { recursive: true });
-        symlinkSync(fixture.root, conversationOfficeDir(fixture.workspaceRoot, address));
+      const office = createWorkspace({
+        root: fixture.workspaceRoot,
+        stateDir: fixture.stateDir,
+      }).office(createOfficeAddress("slack", "C901"));
+      mkdirSync(fixture.workspaceRoot, { recursive: true });
+      symlinkSync(fixture.root, office.dir);
 
-        expect(() => ensureOfficeDir(fixture.workspaceRoot, address)).toThrow(
-          /regular non-symlink directory/,
-        );
-      } finally {
-        delete process.env.MIKAN_STATE_DIR;
-      }
+      expect(() => office.ensure()).toThrow(/regular non-symlink directory/);
     });
   });
 

--- a/test/packages-admin.test.ts
+++ b/test/packages-admin.test.ts
@@ -6,10 +6,9 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   createOfficeAddress,
   createWorkspace,
-  officeDirName,
   officeKey,
+  OfficeRegistry,
 } from "../src/office/index.js";
-import { OfficeRegistry } from "../src/office/index.js";
 import {
   addPackage,
   inspectConversationPackages,
@@ -43,13 +42,7 @@ function readPackages(path: string): string[] {
 }
 
 function context() {
-  const office = createWorkspace({ root: workingDir, stateDir }).office(CONVERSATION_ADDRESS);
-  return {
-    address: CONVERSATION_ADDRESS,
-    stateDir,
-    conversationDir: office.dir,
-    office,
-  };
+  return { office: createWorkspace({ root: workingDir, stateDir }).office(CONVERSATION_ADDRESS) };
 }
 
 beforeEach(() => {
@@ -58,7 +51,7 @@ beforeEach(() => {
   workingDir = join(base, "workspace");
   mkdirSync(stateDir, { recursive: true });
   new OfficeRegistry(stateDir).recordOffice(CONVERSATION_ADDRESS);
-  mkdirSync(join(workingDir, officeDirName(CONVERSATION_ADDRESS)), { recursive: true });
+  mkdirSync(join(workingDir, officeKey(CONVERSATION_ADDRESS)), { recursive: true });
   process.env.MIKAN_STATE_DIR = stateDir;
   writeFileSync(
     globalSettingsFile(),

--- a/test/packages-mounts.test.ts
+++ b/test/packages-mounts.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { createOfficeAddress } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 import {
   conversationPackageSkillMounts,
   packageSkillRuntimeDir,
@@ -11,6 +11,7 @@ import {
 } from "../src/packages/index.js";
 
 const CONVERSATION_ID = "C03045VJJAY";
+const CONVERSATION_ADDRESS = createOfficeAddress("slack", CONVERSATION_ID);
 
 let base: string;
 let stateDir: string;
@@ -48,9 +49,7 @@ function makeSkillPackage(): string {
 
 function options() {
   return {
-    address: createOfficeAddress("slack", CONVERSATION_ID),
-    stateDir,
-    conversationDir: join(workingDir, CONVERSATION_ID),
+    office: createWorkspace({ root: workingDir, stateDir }).office(CONVERSATION_ADDRESS),
   };
 }
 
@@ -59,7 +58,7 @@ beforeEach(() => {
   stateDir = join(base, "state");
   workingDir = join(base, "workspace");
   mkdirSync(stateDir, { recursive: true });
-  mkdirSync(join(workingDir, CONVERSATION_ID), { recursive: true });
+  mkdirSync(join(workingDir, officeKey(CONVERSATION_ADDRESS)), { recursive: true });
   process.env.MIKAN_STATE_DIR = stateDir;
   globalPackages([]);
 });

--- a/test/packages-resolve.test.ts
+++ b/test/packages-resolve.test.ts
@@ -4,9 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { resolveConversationPackages } from "../src/packages/resolve.js";
-import { createOfficeAddress, officeKey } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 
 const CONVERSATION_ID = "C03045VJJAY";
+const CONVERSATION_ADDRESS = createOfficeAddress("slack", CONVERSATION_ID);
 
 let base: string;
 let stateDir: string;
@@ -25,15 +26,9 @@ function globalSettings(packages: string[]): void {
 }
 
 function conversationSettings(packages: string[]): void {
-  writeSettings(
-    join(
-      stateDir,
-      "conversations",
-      officeKey(createOfficeAddress("slack", CONVERSATION_ID)),
-      "settings.json",
-    ),
-    { packages },
-  );
+  writeSettings(join(stateDir, "conversations", officeKey(CONVERSATION_ADDRESS), "settings.json"), {
+    packages,
+  });
 }
 
 /** A package repo whose extensions live in the `extensions/` collection dir. */
@@ -90,9 +85,7 @@ function makeTwoRefRepo(): string {
 
 function resolve(options?: { fetchMissing?: boolean }) {
   return resolveConversationPackages({
-    address: createOfficeAddress("slack", CONVERSATION_ID),
-    stateDir,
-    conversationDir: join(workingDir, CONVERSATION_ID),
+    office: createWorkspace({ root: workingDir, stateDir }).office(CONVERSATION_ADDRESS),
     ...options,
   });
 }
@@ -102,7 +95,7 @@ beforeEach(() => {
   stateDir = join(base, "state");
   workingDir = join(base, "workspace");
   mkdirSync(stateDir, { recursive: true });
-  mkdirSync(join(workingDir, CONVERSATION_ID), { recursive: true });
+  mkdirSync(join(workingDir, officeKey(CONVERSATION_ADDRESS)), { recursive: true });
   process.env.MIKAN_STATE_DIR = stateDir;
   globalSettings([]);
 });
@@ -117,12 +110,7 @@ describe("scope convention directories", () => {
     const result = resolve();
     expect(result.extensionDirs).toEqual([
       join(stateDir, "global", "extensions"),
-      join(
-        stateDir,
-        "conversations",
-        officeKey(createOfficeAddress("slack", CONVERSATION_ID)),
-        "extensions",
-      ),
+      join(stateDir, "conversations", officeKey(CONVERSATION_ADDRESS), "extensions"),
     ]);
     expect(result.errors).toEqual([]);
   });
@@ -130,14 +118,7 @@ describe("scope convention directories", () => {
   test("the global convention dir is scanned before the conversation's", () => {
     const dirs = resolve().extensionDirs;
     expect(dirs.indexOf(join(stateDir, "global", "extensions"))).toBeLessThan(
-      dirs.indexOf(
-        join(
-          stateDir,
-          "conversations",
-          officeKey(createOfficeAddress("slack", CONVERSATION_ID)),
-          "extensions",
-        ),
-      ),
+      dirs.indexOf(join(stateDir, "conversations", officeKey(CONVERSATION_ADDRESS), "extensions")),
     );
   });
 });

--- a/test/session-runtime.test.ts
+++ b/test/session-runtime.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { fauxAssistantMessage, fauxProvider, fauxToolCall } from "@earendil-works/pi-ai";
 import type { MutableModels } from "@earendil-works/pi-ai";
-import { createOfficeAddress, createWorkspace, officeDirName } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace } from "../src/office/index.js";
 import { createGlobalSettingsFile } from "../src/config.js";
 import type {
   MessagingBot,
@@ -40,14 +40,13 @@ beforeEach(() => {
     tmpdir(),
     `mikan-session-runtime-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
-  conversationDir = join(workingDir, officeDirName(testAddress));
-  mkdirSync(conversationDir, { recursive: true });
   // Every runtime path reads global settings and the office registry; a
   // test-scoped state dir keeps that off the developer's real ~/.mikan.
   const stateDir = join(workingDir, "state");
   mkdirSync(stateDir, { recursive: true });
   process.env.MIKAN_STATE_DIR = stateDir;
   createGlobalSettingsFile(stateDir);
+  conversationDir = createWorkspace({ root: workingDir, stateDir }).office(testAddress).ensure();
 });
 
 afterEach(() => {

--- a/test/settings-mutation.test.ts
+++ b/test/settings-mutation.test.ts
@@ -45,7 +45,10 @@ function conversationSettingsFile(conversationId: string): string {
 
 describe("applyConversationSettings", () => {
   test("llm change clears cached runners, then writes", () => {
-    const runtime = { switchConversationModel: vi.fn().mockReturnValue(true) };
+    const runtime = {
+      switchConversationModel: vi.fn().mockReturnValue(true),
+      refreshConversationEnvironment: vi.fn(),
+    };
     const result = applyConversationSettings(runtime, office, {
       provider: "anthropic",
       model: "claude-sonnet-4-6",
@@ -61,7 +64,10 @@ describe("applyConversationSettings", () => {
   });
 
   test("busy conversation refuses: no write, disk and cache stay agreed", () => {
-    const runtime = { switchConversationModel: vi.fn().mockReturnValue(false) };
+    const runtime = {
+      switchConversationModel: vi.fn().mockReturnValue(false),
+      refreshConversationEnvironment: vi.fn(),
+    };
     const result = applyConversationSettings(runtime, office, {
       provider: "anthropic",
       model: "claude-sonnet-4-6",
@@ -71,7 +77,10 @@ describe("applyConversationSettings", () => {
   });
 
   test("non-llm patch writes without touching runners", () => {
-    const runtime = { switchConversationModel: vi.fn().mockReturnValue(false) };
+    const runtime = {
+      switchConversationModel: vi.fn().mockReturnValue(false),
+      refreshConversationEnvironment: vi.fn(),
+    };
     const result = applyConversationSettings(runtime, office, {
       sandbox: { image: { workspaceMount: "full" } },
     });
@@ -92,8 +101,6 @@ describe("applyConversationSettings", () => {
 });
 
 describe("applyConversationWorkspacePolicy", () => {
-  const scope = () => ({ address: C1, conversationDir: office.dir });
-
   test("writes the explicit choice, clears the legacy mount, keeps other leaves", () => {
     applyConversationSettings(undefined, office, {
       sandbox: { cpus: "2", image: { workspaceMount: "full" } },
@@ -122,7 +129,7 @@ describe("applyConversationWorkspacePolicy", () => {
     expect(result).toEqual({ ok: true, runtimeSwitched: null });
     const written = JSON.parse(readFileSync(conversationSettingsFile("C1"), "utf-8"));
     expect(written.sandbox).toBeUndefined();
-    expect(loadConversationWorkspaceOverride(scope())).toBeNull();
+    expect(loadConversationWorkspaceOverride(office)).toBeNull();
   });
 
   test("busy conversation refuses without writing", () => {
@@ -141,7 +148,7 @@ describe("applyConversationWorkspacePolicy", () => {
     applyConversationSettings(undefined, office, {
       sandbox: { image: { workspaceMount: "full" } },
     });
-    expect(loadConversationWorkspaceOverride(scope())).toEqual({
+    expect(loadConversationWorkspaceOverride(office)).toEqual({
       doorPolicy: "trusted",
       layout: "full",
     });

--- a/test/slack-bot.test.ts
+++ b/test/slack-bot.test.ts
@@ -3,10 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { MessagingEventHandler } from "../src/adapter.js";
-import { createOfficeAddress, createWorkspace, officeDirName } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 import type { Workspace } from "../src/office/index.js";
 
-const C123_OFFICE = officeDirName(createOfficeAddress("slack", "C123"));
+const C123_OFFICE = officeKey(createOfficeAddress("slack", "C123"));
 import { SlackMessagingBot } from "../src/adapters/slack/bot.js";
 import { defaultCommandHandlers } from "../src/commands/registry.js";
 import { commandManifestEntry } from "../src/commands/manifest.js";
@@ -1883,7 +1883,7 @@ describe("SlackMessagingBot backfill", () => {
 
     expect(count).toBe(1);
     const logContent = readFileSync(
-      join(workingDir, officeDirName(createOfficeAddress("slack", "C123")), "log.jsonl"),
+      join(workingDir, officeKey(createOfficeAddress("slack", "C123")), "log.jsonl"),
       "utf-8",
     );
     expect(logContent).toContain('"threadTs":"1000.0001"');
@@ -1937,7 +1937,7 @@ describe("SlackMessagingBot backfill", () => {
 
     expect(count).toBe(1);
     const logContent = readFileSync(
-      join(workingDir, officeDirName(createOfficeAddress("slack", "C123")), "log.jsonl"),
+      join(workingDir, officeKey(createOfficeAddress("slack", "C123")), "log.jsonl"),
       "utf-8",
     );
     expect(logContent).toContain('"userName":"Sentry"');
@@ -1981,7 +1981,7 @@ describe("SlackMessagingBot backfill", () => {
 
     expect(count).toBe(1);
     const logContent = readFileSync(
-      join(workingDir, officeDirName(createOfficeAddress("slack", "C123")), "log.jsonl"),
+      join(workingDir, officeKey(createOfficeAddress("slack", "C123")), "log.jsonl"),
       "utf-8",
     );
     expect(logContent).toContain('"text":"ask <@U999> about this"');

--- a/test/telegram-bot.test.ts
+++ b/test/telegram-bot.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { MessagingEventHandler, OfficeAddress } from "../src/adapter.js";
-import { createOfficeAddress, createWorkspace, officeDirName } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 import type { Workspace } from "../src/office/index.js";
 import { conversationIdOf } from "../src/sessions/session-key.js";
 
@@ -286,10 +286,7 @@ describe("TelegramMessagingBot message logging", () => {
       }),
     });
 
-    const lines = readFileSync(
-      join(workingDir, officeDirName(officeOf("999")), "log.jsonl"),
-      "utf-8",
-    )
+    const lines = readFileSync(join(workingDir, officeKey(officeOf("999")), "log.jsonl"), "utf-8")
       .trim()
       .split("\n");
     const entry = JSON.parse(lines[0]);
@@ -309,10 +306,7 @@ describe("TelegramMessagingBot message logging", () => {
       }),
     });
 
-    const lines = readFileSync(
-      join(workingDir, officeDirName(officeOf("123")), "log.jsonl"),
-      "utf-8",
-    )
+    const lines = readFileSync(join(workingDir, officeKey(officeOf("123")), "log.jsonl"), "utf-8")
       .trim()
       .split("\n");
     const entry = JSON.parse(lines[0]);
@@ -467,7 +461,7 @@ describe("TelegramMessagingBot attachments", () => {
       name: "photo.jpg",
       localPath: expect.stringMatching(
         new RegExp(
-          `^${officeDirName(createOfficeAddress("telegram", "456"))}/attachments/\\d+_photo\\.jpg$`,
+          `^${officeKey(createOfficeAddress("telegram", "456"))}/attachments/\\d+_photo\\.jpg$`,
         ),
       ),
     });

--- a/test/vault.test.ts
+++ b/test/vault.test.ts
@@ -15,9 +15,9 @@ import { DockerContainerManager } from "../src/provisioner.js";
 import { HostExecutor } from "../src/sandbox/index.js";
 import { credentialAuthorizationKey } from "../src/sandbox/identity.js";
 import { FileVaultManager, parseEnvFile, sharedVaultKey } from "../src/vault/index.js";
-import { createOfficeAddress, officeDirName, officeKey } from "../src/office/index.js";
+import { createOfficeAddress, createWorkspace, officeKey } from "../src/office/index.js";
 
-const D123_OFFICE = officeDirName(createOfficeAddress("slack", "D123"));
+const D123_OFFICE = officeKey(createOfficeAddress("slack", "D123"));
 
 function mode(path: string): number {
   return statSync(path).mode & 0o777;
@@ -248,6 +248,10 @@ describe("ActorExecutionResolver image mode", () => {
   let tmpDir: string;
   let vaultsDir: string;
 
+  // The image-mode fixtures keep workspace root and state dir on the same
+  // directory, so the office dir and its state dir both hang off tmpDir.
+  const workspace = () => createWorkspace({ root: tmpDir, stateDir: tmpDir });
+
   beforeEach(() => {
     tmpDir = join(tmpdir(), `mikan-image-vault-test-${Date.now()}-${Math.random()}`);
     vaultsDir = join(tmpDir, "vaults");
@@ -274,7 +278,7 @@ describe("ActorExecutionResolver image mode", () => {
       { type: "image", image: "ubuntu:24.04" },
       mgr,
       undefined,
-      tmpDir,
+      workspace(),
     );
 
     const executor = await resolver.resolve({
@@ -304,7 +308,7 @@ describe("ActorExecutionResolver image mode", () => {
       { type: "image", image: "ubuntu:24.04" },
       new FileVaultManager(tmpDir),
       undefined,
-      tmpDir,
+      workspace(),
     );
     const executor = await resolver.resolve({
       userId: "U123",
@@ -339,7 +343,7 @@ describe("ActorExecutionResolver image mode", () => {
       { type: "image", image: "ubuntu:24.04" },
       mgr,
       undefined,
-      tmpDir,
+      workspace(),
     );
     await resolver.resolve({
       userId: "alice",
@@ -387,7 +391,7 @@ describe("ActorExecutionResolver image mode", () => {
       { type: "image", image: "ubuntu:24.04" },
       new FileVaultManager(tmpDir),
       undefined,
-      tmpDir,
+      workspace(),
     );
     await resolver.resolve({
       userId: "U123",
@@ -407,7 +411,7 @@ describe("ActorExecutionResolver image mode", () => {
       address: createOfficeAddress("slack", "D123"),
     });
 
-    const resolver = new ActorExecutionResolver(baseConfig, mgr, undefined, tmpDir);
+    const resolver = new ActorExecutionResolver(baseConfig, mgr, undefined, workspace());
     const executor = await resolver.resolve({
       userId: "U123",
       address: createOfficeAddress("slack", "D123"),
@@ -425,6 +429,8 @@ describe("ActorExecutionResolver image mode", () => {
     const resolver = new ActorExecutionResolver(
       { type: "cloudflare", sandboxId: "mikan-remote" },
       mgr,
+      undefined,
+      workspace(),
     );
 
     await expect(
@@ -457,7 +463,7 @@ describe("ActorExecutionResolver image mode", () => {
       { type: "image", image: "ubuntu:24.04" },
       mgr,
       { provision } as any,
-      tmpDir,
+      workspace(),
     );
 
     const executor = await resolver.resolve({
@@ -496,7 +502,7 @@ describe("ActorExecutionResolver image mode", () => {
       { type: "image", image: "ubuntu:24.04" },
       mgr,
       { provision } as any,
-      tmpDir,
+      workspace(),
     );
 
     const executor = await resolver.resolve({

--- a/test/workspace-projection.test.ts
+++ b/test/workspace-projection.test.ts
@@ -17,15 +17,23 @@ import {
   updateGlobalSettings,
 } from "../src/config.js";
 import { resolveWorkspaceProjection } from "../src/workspace-projection/index.js";
-import { createOfficeAddress, officeDirName } from "../src/office/index.js";
+import {
+  createOfficeAddress,
+  createWorkspace,
+  officeKey,
+  type Office,
+  type Workspace,
+} from "../src/office/index.js";
 
 const conversationId = "C123";
 const address = createOfficeAddress("slack", conversationId);
-const officeSegment = officeDirName(address);
+const officeSegment = officeKey(address);
 
 describe("workspace office projection", () => {
   let stateDir: string;
   let workspaceDir: string;
+  let workspace: Workspace;
+  let office: Office;
 
   beforeEach(() => {
     stateDir = mkdtempSync(join(tmpdir(), "mikan-office-projection-"));
@@ -33,6 +41,8 @@ describe("workspace office projection", () => {
     mkdirSync(workspaceDir, { recursive: true });
     process.env.MIKAN_STATE_DIR = stateDir;
     createGlobalSettingsFile(stateDir);
+    workspace = createWorkspace({ root: workspaceDir, stateDir });
+    office = workspace.office(address);
   });
 
   afterEach(() => {
@@ -41,7 +51,7 @@ describe("workspace office projection", () => {
   });
 
   test("fresh installs expose only the conversation office", () => {
-    const projection = resolveWorkspaceProjection(workspaceDir, address);
+    const projection = resolveWorkspaceProjection(office);
 
     expect(projection).toMatchObject({
       doorPolicy: "isolated",
@@ -70,7 +80,7 @@ describe("workspace office projection", () => {
       }),
     );
 
-    const projection = resolveWorkspaceProjection(workspaceDir, address);
+    const projection = resolveWorkspaceProjection(office);
 
     expect(projection).toMatchObject({
       doorPolicy: "trusted",
@@ -88,13 +98,10 @@ describe("workspace office projection", () => {
   });
 
   test("maps legacy full conversation override above canonical global defaults", () => {
-    const settingsPath = conversationSettingsPath({
-      address,
-      conversationDir: join(workspaceDir, officeSegment),
-    });
+    const settingsPath = conversationSettingsPath(office);
     writeFileSync(settingsPath, JSON.stringify({ sandbox: { image: { workspaceMount: "full" } } }));
 
-    expect(resolveWorkspaceProjection(workspaceDir, address)).toMatchObject({
+    expect(resolveWorkspaceProjection(office)).toMatchObject({
       doorPolicy: "trusted",
       layout: "full",
       mounts: [{ source: workspaceDir, target: "/workspace" }],
@@ -105,14 +112,11 @@ describe("workspace office projection", () => {
     updateGlobalSettings({
       sandbox: { workspace: { doorPolicy: "trusted", layout: "full" } },
     });
-    updateConversationSettings(
-      { address, conversationDir: join(workspaceDir, officeSegment) },
-      {
-        sandbox: { workspace: { doorPolicy: "isolated" } },
-      },
-    );
+    updateConversationSettings(office, {
+      sandbox: { workspace: { doorPolicy: "isolated" } },
+    });
 
-    expect(resolveWorkspaceProjection(workspaceDir, address)).toMatchObject({
+    expect(resolveWorkspaceProjection(office)).toMatchObject({
       doorPolicy: "isolated",
       layout: "conversation",
     });
@@ -123,11 +127,11 @@ describe("workspace office projection", () => {
       sandbox: { workspace: { doorPolicy: "trusted", layout: "shared-support" } },
     });
 
-    resolveWorkspaceProjection(workspaceDir, address);
+    resolveWorkspaceProjection(office);
     rmSync(join(workspaceDir, "MEMORY.md"));
     rmSync(join(workspaceDir, "skills"), { recursive: true });
     rmSync(join(workspaceDir, "events"), { recursive: true });
-    resolveWorkspaceProjection(workspaceDir, address);
+    resolveWorkspaceProjection(office);
 
     expect(lstatSync(join(workspaceDir, "MEMORY.md")).isFile()).toBe(true);
     expect(lstatSync(join(workspaceDir, "skills")).isDirectory()).toBe(true);
@@ -139,9 +143,7 @@ describe("workspace office projection", () => {
     ["conversation file", (root: string) => writeFileSync(join(root, officeSegment), "wrong")],
   ])("rejects a suspicious %s", (_label, arrange) => {
     arrange(workspaceDir);
-    expect(() => resolveWorkspaceProjection(workspaceDir, address)).toThrow(
-      /regular non-symlink directory/,
-    );
+    expect(() => resolveWorkspaceProjection(office)).toThrow(/regular non-symlink directory/);
   });
 
   test("rejects wrong-type trusted support roots", () => {
@@ -150,7 +152,7 @@ describe("workspace office projection", () => {
     });
     mkdirSync(join(workspaceDir, "MEMORY.md"));
 
-    expect(() => resolveWorkspaceProjection(workspaceDir, address)).toThrow(
+    expect(() => resolveWorkspaceProjection(office)).toThrow(
       /workspace memory must be a regular non-symlink file/i,
     );
   });
@@ -158,9 +160,7 @@ describe("workspace office projection", () => {
   test("fails closed on malformed host settings", () => {
     writeFileSync(join(stateDir, "settings.json"), "{ broken");
 
-    expect(() => resolveWorkspaceProjection(workspaceDir, address)).toThrow(
-      /settings are malformed/,
-    );
+    expect(() => resolveWorkspaceProjection(office)).toThrow(/settings are malformed/);
   });
 
   test.each(["", ".", "..", "../events", "nested/id", "nested\\id", "nul\0id"])(
@@ -169,7 +169,7 @@ describe("workspace office projection", () => {
       // The address factory owns identity validation now, so an unsafe id can
       // never reach the projection.
       expect(() =>
-        resolveWorkspaceProjection(workspaceDir, createOfficeAddress("slack", id)),
+        resolveWorkspaceProjection(workspace.office(createOfficeAddress("slack", id))),
       ).toThrow(/Conversation id/);
     },
   );


### PR DESCRIPTION
## What

PR 2 of 3 (stacked on #119). Every option bag that carried several representations of one office now carries the Office value — net **−316 lines**.

- `CreateRunnerOptions`: `address`/`conversationId`/`conversationDir`/`workspaceDir` → one `office` field. `agent.ts` derives locals from it; the `join(conversationDir, "..")` workspace-root climb is gone.
- `ConversationSettingsScope` deleted — all conversation-settings functions take an `Office`; the settings path comes from `office.stateDir` instead of a config-internal state-dir read.
- `ResolvePackagesOptions` → `{ office, fetchMissing? }`; `PackageAdminContext` → `{ office, runtime? }`.
- `resolveWorkspaceProjection(office)`: the undefined-root branch (dead once every caller holds an Office), the legacy `mode` field, and `readWorkspaceProjectionMode`/`readConversationWorkspaceMountMode` are deleted; materialization goes through `office.ensure()`.
- `ActorExecutionResolver` takes the Workspace value; `resolveVaultInjection` takes the typed address (diagnostic-only) instead of a raw id string; `AutoReplyJudge` input carries the office.
- Transitional helpers retire: `conversationOfficeDir`, `officeDirName`, free `ensureOfficeDir` deleted. `officeStateDir` remains the one low-level helper for stateDir-only surfaces (CLI, extension loader, package materialization).
- `agent.ts` and the execution resolver no longer import `effectiveStateDir` — the state dir flows from the Workspace value everywhere a value exists.

## Verification

- `vitest --run --dir test`: **1631/1631** green. One test deleted with its subject (the projection `mode` field; behavior covered by the projection fresh-install test).
- build / oxlint / oxfmt / knip clean. `tsgo --noEmit` clean on the touched test files.

## Follow-up

PR 3: fold `ChannelStore` into `saveIncomingAttachments` on the shared adapter surface.