### PR TITLE
fix(tools): upload generate_image output by host path from the office dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ any release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `generate_image` losing its generated file at the upload step (`sh: … cannot open /workspace/<file>: No such file`): the tool wrote the image host-side into the workspace base and then handed a bare filename to the attach upload path, which reads through the sandbox — where the base is no longer mounted since the office layout migration. The image is now written into the conversation's own office directory (guest-visible) and uploaded directly by host path, with no sandbox round-trip, under every door policy. Image-generation provider errors now also name the model id that was sent.
+
 ## [1.0.0-beta.38]
 
 ### Fixed

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1512,6 +1512,7 @@ async function prepareRunContext(params: {
   }) => void;
   setSandboxContext: (context: { conversationId: string; userId: string }) => void;
   setUploadFunction: (fn: (filePath: string, title?: string) => Promise<void>) => void;
+  setImageUploadFunction: (fn: (hostPath: string, title?: string) => Promise<void>) => void;
   setReactFunction: (fn: ((emoji: string) => Promise<void>) | null) => void;
   bindPlatformToolPacks: (ctx: PlatformToolRunContext) => void;
   pathContext: RuntimePathContext;
@@ -1532,6 +1533,7 @@ async function prepareRunContext(params: {
     setEventContext,
     setSandboxContext,
     setUploadFunction,
+    setImageUploadFunction,
     setReactFunction,
     bindPlatformToolPacks,
   } = params;
@@ -1599,6 +1601,12 @@ async function prepareRunContext(params: {
     await withStagedRuntimeFile(executor, runtimePath, (stagedPath) =>
       responder.uploadFile(stagedPath, title),
     );
+  });
+
+  // generate_image writes its file host-side, so it uploads by host path —
+  // no staging through the sandbox, where the file may not be mounted.
+  setImageUploadFunction(async (hostPath: string, title?: string) => {
+    await responder.uploadFile(hostPath, title);
   });
 
   // The react tool is available only when the responder supports reactions
@@ -2107,6 +2115,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
   const {
     tools,
     setUploadFunction,
+    setImageUploadFunction,
     setReactFunction,
     bindPlatformToolPacks,
     setEventContext,
@@ -2119,6 +2128,10 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
     {
       model,
       getApiKey: () => modelRegistry.getApiKeyForProvider(model.provider),
+      // The conversation's own office dir: mounted into the sandbox, unlike
+      // the workspace base — generated images must land somewhere the agent
+      // (and a future run) can still reach.
+      outputDir: conversationDir,
     },
   );
 
@@ -2218,6 +2231,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
         setEventContext,
         setSandboxContext,
         setUploadFunction,
+        setImageUploadFunction,
         setReactFunction,
         bindPlatformToolPacks,
         pathContext,
@@ -2364,6 +2378,7 @@ export async function createRunner(options: CreateRunnerOptions): Promise<PiAgen
         setEventContext,
         setSandboxContext,
         setUploadFunction,
+        setImageUploadFunction,
         setReactFunction,
         bindPlatformToolPacks,
         pathContext,

--- a/src/tools/generate-image.ts
+++ b/src/tools/generate-image.ts
@@ -21,12 +21,18 @@ interface ImageResponse {
 export function createGenerateImageTool(options: {
   model: Model<Api>;
   getApiKey: () => Promise<string | undefined>;
-  workspaceDir: string;
+  /** Host directory the generated image is written into. Must be the
+   *  conversation's own office dir so the agent can also reach the file
+   *  from inside the sandbox; the workspace base is NOT guest-visible. */
+  outputDir: string;
 }): {
   tool: AgentTool<typeof schema>;
-  setUploadFunction: (fn: (filePath: string, title?: string) => Promise<void>) => void;
+  /** The callback receives the HOST path of the generated file. The image is
+   *  written host-side, so upload must not stage it through the sandbox the
+   *  way the attach tool does — the file may not be mounted there. */
+  setUploadFunction: (fn: (hostPath: string, title?: string) => Promise<void>) => void;
 } {
-  let uploadFn: ((filePath: string, title?: string) => Promise<void>) | null = null;
+  let uploadFn: ((hostPath: string, title?: string) => Promise<void>) | null = null;
 
   return {
     tool: {
@@ -64,15 +70,17 @@ export function createGenerateImageTool(options: {
         const body = (await response.json()) as ImageResponse;
         if (!response.ok) {
           throw new Error(
-            body.error?.message ?? `Image generation failed with HTTP ${response.status}`,
+            `Image generation with model "${options.model.id}" failed: ` +
+              (body.error?.message ?? `HTTP ${response.status}`),
           );
         }
         const encoded = body.data?.[0]?.b64_json;
         if (!encoded) throw new Error("Image generation response contained no image");
 
         const fileName = `generated-${randomUUID()}.png`;
-        await writeFile(join(options.workspaceDir, fileName), Buffer.from(encoded, "base64"));
-        await uploadFn(fileName, fileName);
+        const filePath = join(options.outputDir, fileName);
+        await writeFile(filePath, Buffer.from(encoded, "base64"));
+        await uploadFn(filePath, fileName);
 
         return {
           content: [{ type: "text" as const, text: `Generated and attached image: ${fileName}` }],

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -31,10 +31,15 @@ export function createMikanTools(
   imageGeneration?: {
     model: Model<Api>;
     getApiKey: () => Promise<string | undefined>;
+    outputDir: string;
   },
 ): {
   tools: AgentTool<TSchema>[];
   setUploadFunction: (fn: (filePath: string, title?: string) => Promise<void>) => void;
+  /** Upload for generate_image. Receives the file's HOST path — the tool
+   *  writes host-side, so this must not stage through the sandbox like the
+   *  attach upload does. No-op when image generation is not configured. */
+  setImageUploadFunction: (fn: (hostPath: string, title?: string) => Promise<void>) => void;
   setReactFunction: (fn: ((emoji: string) => Promise<void>) | null) => void;
   bindPlatformToolPacks: (ctx: PlatformToolRunContext) => void;
   setEventContext: (context: {
@@ -46,9 +51,7 @@ export function createMikanTools(
   setSandboxContext: (context: { conversationId: string; userId: string }) => void;
 } {
   const { tool: attachTool, setUploadFunction } = createAttachTool();
-  const imageTool = imageGeneration
-    ? createGenerateImageTool({ ...imageGeneration, workspaceDir })
-    : undefined;
+  const imageTool = imageGeneration ? createGenerateImageTool(imageGeneration) : undefined;
   const { tool: reactTool, setReactFunction } = createReactTool();
   const { tool: eventTool, setEventContext } = createEventTool(
     HostEventStore.fromWorkspaceDir(workspaceDir),
@@ -71,8 +74,8 @@ export function createMikanTools(
       reactTool,
       ...packTools,
     ],
-    setUploadFunction: (fn) => {
-      setUploadFunction(fn);
+    setUploadFunction,
+    setImageUploadFunction: (fn) => {
       imageTool?.setUploadFunction(fn);
     },
     setReactFunction,

--- a/test/generate-image-tool.test.ts
+++ b/test/generate-image-tool.test.ts
@@ -11,10 +11,16 @@ afterEach(async () => {
   await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
+const model = {
+  id: "gpt-5.6-sol",
+  provider: "agent-model",
+  baseUrl: "http://127.0.0.1:8080/v1",
+} as Model<Api>;
+
 describe("generate_image tool", () => {
-  test("requests an image from the configured model and uploads it", async () => {
-    const workspaceDir = await mkdtemp(join(tmpdir(), "mikan-image-test-"));
-    dirs.push(workspaceDir);
+  test("writes the image into outputDir and uploads it by host path", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "mikan-image-test-"));
+    dirs.push(outputDir);
     const image = Buffer.from("png bytes");
     const fetchMock = vi.fn(
       async () =>
@@ -25,15 +31,10 @@ describe("generate_image tool", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
     const upload = vi.fn(async () => {});
-    const model = {
-      id: "gpt-5.6-sol",
-      provider: "agent-model",
-      baseUrl: "http://127.0.0.1:8080/v1",
-    } as Model<Api>;
     const { tool, setUploadFunction } = createGenerateImageTool({
       model,
       getApiKey: async () => "test-token",
-      workspaceDir,
+      outputDir,
     });
     setUploadFunction(upload);
 
@@ -60,7 +61,44 @@ describe("generate_image tool", () => {
       quality: "low",
       response_format: "b64_json",
     });
-    const [fileName] = upload.mock.calls[0]!;
-    expect(await readFile(join(workspaceDir, fileName))).toEqual(image);
+    // The upload callback gets the file's HOST path inside outputDir — not a
+    // bare name for the sandbox-staging attach path (that broke when the
+    // workspace base stopped being mounted into the guest).
+    const [hostPath, title] = upload.mock.calls[0]!;
+    expect(hostPath.startsWith(`${outputDir}/generated-`)).toBe(true);
+    expect(hostPath.endsWith(".png")).toBe(true);
+    expect(title).toBe(hostPath.slice(outputDir.length + 1));
+    expect(await readFile(hostPath)).toEqual(image);
+  });
+
+  test("surfaces provider errors with the model id that was requested", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "mikan-image-test-"));
+    dirs.push(outputDir);
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ error: { message: "all deployments and fallbacks exhausted" } }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { tool, setUploadFunction } = createGenerateImageTool({
+      model,
+      getApiKey: async () => "test-token",
+      outputDir,
+    });
+    setUploadFunction(async () => {});
+
+    await expect(
+      tool.execute(
+        "call-1",
+        { prompt: "a waving robot" },
+        undefined,
+        undefined,
+        undefined as never,
+      ),
+    ).rejects.toThrow(
+      'Image generation with model "gpt-5.6-sol" failed: all deployments and fallbacks exhausted',
+    );
   });
 });


### PR DESCRIPTION
## Root cause (diagnosed on the prod VM)

`generate_image` writes its file **host-side** into the workspace **base** (`workspaceDir` = the runtime working dir), then hands a bare filename to the attach upload path — which normalizes it to `/workspace/<file>` and reads it back **through the sandbox**. Since the office layout migration (2026-07-28), the base is no longer mounted into the guest (only `MEMORY.md`, `skills`, `events`, and the conversation's own office dir are), so every successful generation died at the handoff:

```
sh: 2: cannot open /workspace/generated-<uuid>.png: No such file
```

Evidence: the generated png sat orphaned at the workspace base on the prod host; the container mount table shows no base mount. The router/model id was never at fault — `POST /images/generations` with `agent-model/chatgpt` reproduces fine from the VM (200, image in 53s). Supersedes #118, which aimed at the wrong layer.

## Fix

- Write the image into the **conversation's own office dir** (guest-mounted, so the agent and later runs can still reach the file).
- Upload it **directly by host path** through a dedicated `setImageUploadFunction` seam (`responder.uploadFile` already takes host paths). A host-written file needs no guest round-trip; the attach tool's staging path is for guest-created files and keeps its behavior. Works under every door policy — no mount assumptions.
- Provider errors from the images endpoint now name the model id that was sent, so a router failure like "all deployments and fallbacks exhausted" is attributable at a glance.

Not addressed here (infra, not mikan): the router's timeout budget on the images route — a long prompt took >5min and exhausted retries; the agent-model service timeout is the knob for that.

## Verification

`vitest --run --dir test`: 115 files / 1622 tests green, including reworked generate_image tests covering the host-path upload contract and the incident error message. `npm run build`, oxlint, oxfmt clean.