### PR TITLE
fix(slack-e2e): repair the e2e environment after door policy and the office-key layout

### DIFF
--- a/.github/workflows/slack-e2e.yml
+++ b/.github/workflows/slack-e2e.yml
@@ -43,12 +43,19 @@ jobs:
           node dist/main.js --onboard --state-dir "$STATE_DIR"
           # E2E runs on OpenRouter; onboard defaults to Anthropic, so point
           # both the main model and the auto-reply judge at deepseek.
+          # The runner is a disposable single-tenant workspace on the host
+          # sandbox, so opt into the trusted door policy explicitly — the
+          # isolated default refuses host mode by design.
           node -e '
             const fs = require("fs");
             const p = process.argv[1];
             const s = JSON.parse(fs.readFileSync(p, "utf8"));
             const model = { provider: "openrouter", model: "deepseek/deepseek-v4-flash" };
             s.llm = { ...s.llm, ...model, autoReply: { ...model } };
+            s.sandbox = {
+              ...s.sandbox,
+              workspace: { doorPolicy: "trusted", layout: "shared-support" },
+            };
             fs.writeFileSync(p, JSON.stringify(s, null, 2));
           ' "$STATE_DIR/settings.json"
           node dist/main.js --state-dir "$STATE_DIR" "$WORKING_DIR" >"$LOG_FILE" 2>&1 &

--- a/e2e/slack/helpers/slack.ts
+++ b/e2e/slack/helpers/slack.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { createOfficeAddress, officeKey } from "../../../src/office/index.js";
 import type { KnownBlock } from "@slack/types";
 import type { WebClient } from "@slack/web-api";
 
@@ -99,7 +100,12 @@ async function waitForLocalLogMessage(options: {
   pollMs: number;
 }): Promise<boolean> {
   const deadline = Date.now() + options.timeoutMs;
-  const logPath = join(options.workingDir, options.channel, "log.jsonl");
+  // The daemon writes under the office-key layout, not the raw channel id.
+  const logPath = join(
+    options.workingDir,
+    officeKey(createOfficeAddress("slack", options.channel)),
+    "log.jsonl",
+  );
   while (Date.now() < deadline) {
     try {
       const lines = (await readFile(logPath, "utf-8")).split("\n");

--- a/e2e/slack/thread-isolation.e2e.ts
+++ b/e2e/slack/thread-isolation.e2e.ts
@@ -85,7 +85,10 @@ describe.skipIf(!ctx || !ctx.env.mikanBotUserId)("Slack thread session isolation
       channel: env.channel,
       workingDir: env.workingDir,
       threadTs: rootA,
-      text: () => `<@${botUserId}> 請只回覆我在這個 thread 要你記住的 token，不要加其他文字。`,
+      // Name the token's prefix explicitly: the store message also carried a
+      // QA_DELIVERY_ marker, and a weak judge model can echo that one instead.
+      text: () =>
+        `<@${botUserId}> 請只回覆我在這個 thread 要你記住、以 QA_ISOLATE_ 開頭的 token，不要加其他文字。`,
       timeoutMs: Math.max(env.timeoutMs, 15_000),
       pollMs: env.pollMs,
     });


### PR DESCRIPTION
## What

Slack E2E had not run since 2026-07-27 and three independent breakages had accumulated — none caused by the office-module PRs (#119–#121), all predating them:

1. **Workflow settings vs door policy (#115)**: the runner boots host mode, and the isolated-by-default door policy refuses host by design — every reply-dependent test timed out. The workflow's settings now declare `trusted/shared-support` explicitly (the policy the legacy `private` default translated to; the runner is a disposable single-tenant workspace).
2. **e2e helper vs office-key layout (#109)**: `waitForLocalLogMessage` still joined the raw channel id into the log path, so local-delivery verification never saw the daemon's `<officeKey>/log.jsonl` and misreported 'another Socket Mode client'.
3. **Recall prompt ambiguity (S-020)**: the store message carries both the `QA_ISOLATE_` token and a `QA_DELIVERY_` marker; the deepseek judge echoed the wrong one. The prompt now names the `QA_ISOLATE_` prefix.

## Verification

Four workflow runs on this branch tell the story: all-timeout → 23/25 → 24/25 → **[22/22 files, 25/25 tests green](https://github.com/geminixiang/mikan/actions/runs/30436758073)** on main + these fixes (i.e. this run is also the post-office-merge real-platform validation).