### PR TITLE
fix(commands): keep the /sandbox arg description inside Discord's limit

### DIFF
--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -55,8 +55,10 @@ export const COMMAND_MANIFEST: readonly CommandManifestEntry[] = [
     description: "Show sandbox status, boost limits, or set the office door policy",
     arg: {
       name: "action",
+      // Discord caps option descriptions at 100 characters (registration
+      // fails otherwise); commands.test.ts enforces the budget.
       description:
-        "Use 'boost' to temporarily apply the configured boost limits, or 'door default|isolated|shared|full' to set this office's data door policy",
+        "'boost' applies the configured boost limits; 'door default|isolated|shared|full' sets door policy",
       required: false,
     },
     slackCommand: "/pi-sandbox",

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -13,6 +13,7 @@ import {
   loadConversationWorkspaceOverride,
 } from "../src/config.js";
 import { dispatchCommand } from "../src/commands/registry.js";
+import { COMMAND_MANIFEST } from "../src/commands/manifest.js";
 import { LoginCommandHandler, parseLoginCommand } from "../src/commands/login.js";
 import { ModelCommandHandler } from "../src/commands/model.js";
 import { NewCommandHandler } from "../src/commands/new.js";
@@ -186,6 +187,27 @@ function buildContext(args: BuildContextArgs): CommandContext & {
     services,
   };
 }
+
+describe("COMMAND_MANIFEST platform registration budgets", () => {
+  // Discord rejects the whole registration batch when any command or option
+  // description exceeds 100 characters — a silent-until-restart failure.
+  test("descriptions fit Discord's 100-character limits", () => {
+    for (const entry of COMMAND_MANIFEST) {
+      expect(entry.description.length, `${entry.name} description`).toBeLessThanOrEqual(100);
+      if (entry.arg) {
+        expect(entry.arg.description.length, `${entry.name} arg description`).toBeLessThanOrEqual(
+          100,
+        );
+      }
+      if (entry.telegramMenu?.description) {
+        expect(
+          entry.telegramMenu.description.length,
+          `${entry.name} telegram description`,
+        ).toBeLessThanOrEqual(100);
+      }
+    }
+  });
+});
 
 describe("dispatchCommand", () => {
   test("returns false when no handler accepts the command", async () => {


### PR DESCRIPTION
The door-policy wording (#115) pushed `/sandbox`'s option description to 137 characters; Discord caps command/option descriptions at 100 and rejects the whole registration batch — every slash command silently fails to register on daemon restart (`Invalid Form Body … 3.options[0].description[BASE_TYPE_BAD_LENGTH]`).

- Shorten the description to 97 chars (same content: boost + door words).
- New test in `commands.test.ts` enforces the 100-char budget for every manifest description (command, arg, telegram menu), so the next wording change fails in CI instead of silently at restart.

Not from the office PRs — latent since #115; surfaces on the first daemon restart that re-registers Discord commands.