### PR TITLE
fix(slack): resolve response-source mentions to native user ids

### DIFF
--- a/src/adapters/slack/blocks.ts
+++ b/src/adapters/slack/blocks.ts
@@ -21,6 +21,41 @@ function convertLegacyMrkdwnLinks(source: string): string {
   return source.replace(LEGACY_MRKDWN_LINK_PATTERN, "[$2]($1)");
 }
 
+// Slack user/bot-user ids: U/W prefix. Already-native mentions pass through.
+const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{2,}$/;
+const MENTION_PATTERN = /<@([^<>\n]+)>/g;
+
+/**
+ * Resolve response-source mentions to Slack's native form.
+ *
+ * The response source is platform-neutral: the model writes `<@userName>`
+ * from the prompt's Users table, and the adapter owns the conversion to
+ * `<@U…>` — Slack only links and notifies on the raw user id. Lookup covers
+ * userName and displayName case-insensitively; native-id mentions pass
+ * through, and unknown names stay verbatim rather than guessing.
+ */
+export function resolveSlackMentions(
+  source: string,
+  users: Iterable<{ id: string; userName: string; displayName: string }>,
+): string {
+  if (!source.includes("<@")) return source;
+  const list = [...users];
+  const byName = new Map<string, string>();
+  for (const user of list) {
+    if (user.userName) byName.set(user.userName.toLowerCase(), user.id);
+  }
+  // Display names never shadow a userName held by someone else.
+  for (const user of list) {
+    const display = user.displayName?.toLowerCase();
+    if (display && !byName.has(display)) byName.set(display, user.id);
+  }
+  return source.replace(MENTION_PATTERN, (mention, name: string) => {
+    if (SLACK_USER_ID_PATTERN.test(name)) return mention;
+    const id = byName.get(name.trim().replace(/^@/, "").toLowerCase());
+    return id ? `<@${id}>` : mention;
+  });
+}
+
 function normalizeMarkdownTables(source: string): string {
   return source
     .split("\n")

--- a/src/adapters/slack/bot.ts
+++ b/src/adapters/slack/bot.ts
@@ -53,7 +53,7 @@ import {
   resolveSlackSessionKey,
 } from "./session.js";
 import { reportUserFacingError } from "../../observability/sentry.js";
-import { renderSlackBlocks } from "./blocks.js";
+import { renderSlackBlocks, resolveSlackMentions } from "./blocks.js";
 
 const SLACK_EVENT_ANCHOR_TEXT = "Working on it...";
 
@@ -255,9 +255,18 @@ export class SlackMessagingBot implements MessagingBot {
     return source.replace(this.ownMentionRegex, "").trim();
   }
 
+  /**
+   * Response-source `<@userName>` mentions become native `<@U…>` here — the
+   * one conversion every outgoing response path funnels through. Slack only
+   * links and notifies on raw user ids.
+   */
+  private resolveMentions(text: string): string {
+    return resolveSlackMentions(text, this.users.values());
+  }
+
   async postMessage(channel: string, text: string): Promise<string> {
     return slackRetry(async () => {
-      const payload = { channel, ...renderSlackBlocks(text) };
+      const payload = { channel, ...renderSlackBlocks(this.resolveMentions(text)) };
       const result = await this.webClient.chat.postMessage(payload);
       return result.ts as string;
     });
@@ -364,7 +373,7 @@ export class SlackMessagingBot implements MessagingBot {
 
   async updateMessage(channel: string, ts: string, text: string): Promise<void> {
     return slackRetry(async () => {
-      const payload = { channel, ts, ...renderSlackBlocks(text) };
+      const payload = { channel, ts, ...renderSlackBlocks(this.resolveMentions(text)) };
       await this.webClient.chat.update(payload);
     });
   }
@@ -378,7 +387,7 @@ export class SlackMessagingBot implements MessagingBot {
     return slackRetry(async () => {
       const result = await this.webClient.apiCall("chat.startStream", {
         channel,
-        markdown_text: text,
+        markdown_text: this.resolveMentions(text),
         ...(threadTs ? { thread_ts: threadTs } : {}),
         ...(this.teamId ? { recipient_team_id: this.teamId } : {}),
         ...(recipientUserId ? { recipient_user_id: recipientUserId } : {}),
@@ -394,7 +403,9 @@ export class SlackMessagingBot implements MessagingBot {
       await this.webClient.apiCall("chat.appendStream", {
         channel,
         ts,
-        markdown_text: text,
+        // A mention split across stream deltas stays unresolved here; the
+        // canonical final render (updateMessage) resolves the full text.
+        markdown_text: this.resolveMentions(text),
       });
     });
   }
@@ -428,7 +439,11 @@ export class SlackMessagingBot implements MessagingBot {
 
   async postInThread(channel: string, threadTs: string, text: string): Promise<string> {
     return slackRetry(async () => {
-      const payload = { channel, thread_ts: threadTs, ...renderSlackBlocks(text) };
+      const payload = {
+        channel,
+        thread_ts: threadTs,
+        ...renderSlackBlocks(this.resolveMentions(text)),
+      };
       const result = await this.webClient.chat.postMessage(payload);
       return result.ts as string;
     });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -527,7 +527,7 @@ Channels: ${channelMappings}
 
 Users: ${userMappings}
 
-When mentioning users, use <@username> format (e.g., <@mario>).
+When mentioning users, write <@userName> using the exact userName from the Users table above (e.g., <@mario>). Never invent handles from other platforms (GitHub, email); the platform adapter converts <@userName> to the platform's native mention form.
 
 ## Environment
 ${envDescription}

--- a/src/test/slack-blocks.test.ts
+++ b/src/test/slack-blocks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { renderSlackBlocks } from "../adapters/slack/blocks.js";
+import { renderSlackBlocks, resolveSlackMentions } from "../adapters/slack/blocks.js";
 
 interface MarkdownBlockShape {
   type: "markdown";
@@ -215,5 +215,46 @@ _Triggered by @requester_`;
   test("returns no blocks for blank source", () => {
     expect(renderSlackBlocks("").blocks).toEqual([]);
     expect(renderSlackBlocks("   \n  ").blocks).toEqual([]);
+  });
+});
+
+describe("resolveSlackMentions", () => {
+  const users = [
+    { id: "U0AAAAAA1", userName: "alice", displayName: "Alice Example" },
+    { id: "U0BBBBBB2", userName: "bob.lee", displayName: "Bob Lee" },
+  ];
+
+  test("userName mentions resolve to native user ids", () => {
+    expect(resolveSlackMentions("hi <@alice>!", users)).toBe("hi <@U0AAAAAA1>!");
+  });
+
+  test("displayName mentions resolve case-insensitively", () => {
+    expect(resolveSlackMentions("cc <@bob lee>", users)).toBe("cc <@U0BBBBBB2>");
+  });
+
+  test("native id mentions pass through untouched", () => {
+    expect(resolveSlackMentions("ping <@U0AAAAAA1>", users)).toBe("ping <@U0AAAAAA1>");
+  });
+
+  test("unknown handles stay verbatim instead of guessing", () => {
+    // e.g. a GitHub handle from channel memory — neither a userName nor an id.
+    expect(resolveSlackMentions("ask <@alicehub>", users)).toBe("ask <@alicehub>");
+  });
+
+  test("a stray leading @ inside the mention still resolves", () => {
+    expect(resolveSlackMentions("<@@alice>", users)).toBe("<@U0AAAAAA1>");
+  });
+
+  test("multiple mentions resolve independently", () => {
+    expect(resolveSlackMentions("<@alice> and <@bob.lee> and <@nobody>", users)).toBe(
+      "<@U0AAAAAA1> and <@U0BBBBBB2> and <@nobody>",
+    );
+  });
+
+  test("a consumable iterable (Map.values) works", () => {
+    const map = new Map(users.map((user) => [user.id, user]));
+    expect(resolveSlackMentions("<@alice> <@bob lee>", map.values())).toBe(
+      "<@U0AAAAAA1> <@U0BBBBBB2>",
+    );
   });
 });


### PR DESCRIPTION
Prod finding: every bot mention rendered as literal text — Slack only links/notifies on `<@U…>` raw ids, the prompt teaches `<@userName>`, and the adapter had no conversion. When corrected, the model even argued the username form was right, because the prompt said so. One observed case pulled a GitHub handle out of channel memory — neither a Slack username nor an id.

Fix per the Response source contract (the adapter owns native-markup conversion):

- `resolveSlackMentions` in `blocks.ts`: userName + displayName resolve case-insensitively to `<@id>`; native-id mentions pass through; unknown handles stay verbatim.
- Wired into all five outgoing response seams: `postMessage`, `updateMessage`, `postInThread`, `startStream`, `appendStream` (a mention split across stream deltas resolves at the canonical final render). Block Kit tool paths untouched (tool-authored payloads).
- Prompt line (`agent.ts`) now names the Users table as the source of userName and forbids inventing handles from other platforms.

Tests: 7 fictional-user cases covering the observed shapes (unknown external handle stays verbatim; displayName resolves; native ids pass through). Full suite 116 files / 1621 green.

After merge+deploy, scheduled-event texts that hard-require raw IDs as a workaround can go back to plain `<@userName>` — both forms work.