### PR TITLE
test(slack-e2e): give the long-thread stub a prototype-linked receiver

### DIFF
--- a/e2e/slack/long-message-thread.e2e.ts
+++ b/e2e/slack/long-message-thread.e2e.ts
@@ -29,7 +29,13 @@ function createRealSlackResponderBot(botClient: WebClient): SlackMessagingBot {
         error.data = { error: "msg_too_long" };
         return Promise.reject(error);
       }
-      return Reflect.apply(SlackMessagingBot.prototype.postInThread, { webClient: botClient }, [
+      // The receiver must inherit the real prototype (postInThread reaches
+      // this.resolveMentions) and carry the fields it reads.
+      const receiver = Object.assign(Object.create(SlackMessagingBot.prototype) as object, {
+        webClient: botClient,
+        users: new Map(),
+      });
+      return Reflect.apply(SlackMessagingBot.prototype.postInThread, receiver, [
         channel,
         threadTs,
         text,


### PR DESCRIPTION
S-024 broke after #128: `postInThread` now calls `this.resolveMentions` (prototype method reading `this.users`), and this e2e delegates to the prototype with a bare `{ webClient }` receiver — the fallback post threw, so the msg_too_long fallback never landed. Production is unaffected (real instances always have both); the synthetic receiver now inherits the prototype and carries a users map.

Verified reasoning only (e2e needs real tokens); will re-trigger the workflow after merge.