### PR TITLE
feat(web): React SPA — web-client shell + session/admin/vault pages (S3–S5)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>mikan</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@geminixiang/mikan-web-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "description": "mikan web application entry: Vite build over the mikan-web-client shell; dist/ is served by the web-host seam",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "watch": "vite build --watch"
+  },
+  "dependencies": {
+    "@geminixiang/mikan-web-client": "workspace:^",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "~18.3.1",
+    "@types/react-dom": "~18.3.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^6.0.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,0 +1,10 @@
+/**
+ * Web application entry: thin bootstrap over the shell library. Everything —
+ * boot-manifest parsing, router wiring, feature mounting — lives in
+ * @geminixiang/mikan-web-client; this file only finds the mount point.
+ */
+import { AppWebEntry } from "@geminixiang/mikan-web-client";
+
+const el = document.getElementById("root");
+if (el === null) throw new Error("web app: missing #root");
+void new AppWebEntry(el).run();

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vite/client"],
+    "paths": {
+      "@geminixiang/mikan-web-client": ["../../packages/web-client/src/index.ts"],
+      "@geminixiang/mikan-ui-session": ["../../packages/ui-session/src/index.ts"],
+      "@geminixiang/mikan-ui-admin": ["../../packages/ui-admin/src/index.ts"],
+      "@geminixiang/mikan-ui-vault": ["../../packages/ui-vault/src/index.ts"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,36 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+const src = (rel: string): string => fileURLToPath(new URL(rel, import.meta.url));
+
+/**
+ * Workspace packages resolve to SOURCE so CSS and TSX ride Vite's pipeline
+ * (DSH pattern: the shell packages are aliased to src, never pre-built).
+ */
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: [
+      {
+        find: /^@geminixiang\/mikan-web-client$/,
+        replacement: src("../../packages/web-client/src/index.ts"),
+      },
+      {
+        find: /^@geminixiang\/mikan-ui-session$/,
+        replacement: src("../../packages/ui-session/src/index.ts"),
+      },
+      {
+        find: /^@geminixiang\/mikan-ui-admin$/,
+        replacement: src("../../packages/ui-admin/src/index.ts"),
+      },
+      {
+        find: /^@geminixiang\/mikan-ui-vault$/,
+        replacement: src("../../packages/ui-vault/src/index.ts"),
+      },
+    ],
+  },
+  build: {
+    sourcemap: true,
+  },
+});

--- a/docs/research/mikan-web-website.md
+++ b/docs/research/mikan-web-website.md
@@ -1,0 +1,246 @@
+# mikan Web 網站化架構規劃（以 deepseek-harness 為參考）
+
+> 研究日期：2026-06-09。目標：把現有的 `session / admin / vault（login）` 三個 server-rendered HTML portal 重構成一個真正的網站（React + Vite 全 SPA），架構對齊 `../deepseek-harness`（下稱 DSH）的 web 層。研究期間未修改 production code。
+>
+> 已確認之決策：
+>
+> 1. 前端框架採用 **React + Vite**（最貼近 DSH 的 `@deepseek-ai/dsh-client-web` shell）。
+> 2. mikan 由單一 package 改為 **workspace monorepo**，但**只拆「網站相關」packages**，既有 daemon `src/` 維持原狀（或僅包成 `packages/daemon` 而不動其 import）。
+> 3. 本文件先交付規劃，確認後再動工。
+
+## 摘要與建議
+
+今天 mikan 的 web 是「單一 Node HTTP server + 三份 server-rendered HTML 字串 + 內嵌 JS/CSS」，只解決「把連結開給使用者看單一 session / 管理操作 / 收 credential」。它已具備 DSH 的「host API」一半（每個 portal 內有具名的 JSON/SSE route），但**缺少** DSH 的另一半：前端 build 與 bundling、SPA client shell、boot-manifest 注入、static-dist fallback seat、與 `/plugins` bundle route。
+
+建議採分階段、以「host seam」與「client boot」對齊 DSH 的混和落地，而非一次把整個既有 `src/` 搬進 packages：
+
+1. **先建立 pnpm workspace + packages 骨架**（`packages/web-host`、`packages/web-client`、`packages/ui-*`、`packages/web-bundle`、`apps/web`），不動任何既有檔案。
+2. **把 `src/web/server.ts` 泛化成 DSH 的 route-registry 服務**（`register(kind/path/handler)`、`registerUpgrade`、`registerFallback`、`tapIndex`），既有 portal route 先「平移」成具名 route，行為不變。
+3. **新增 React Vite client**，採用 DSH 的 `__MIKAN_BOOT__` boot-manifest：host 在 `index.html` 注入 boot graph，shell 讀取後載入各 UI bundle，取代 `renderPortalShell` + 內嵌 script。
+4. **逐 portal 遷移**：session-view → admin → vault/login，每步以既有 JSON API 為新 host API，前端 React 直接 fetch/SSE。
+5. 最後才考慮把新 web packages 真正接上既有 `main.ts` 的 boot（`startWebServer`），並用既有 `dist/main.js` 跑起驗證。
+
+## 研究標記
+
+- **[觀察]**: 由本 repo 或 DSH 原始碼直接確認。
+- **[實測]**: 可本地重現；命令與輸出列於文末。
+- **[假說]**: 尚未 end-to-end 證明，附驗證方式。
+
+---
+
+## Part 1 — 現況分析
+
+### 1.1 現有 mikan web 表面
+
+**[觀察]** 單一 `createServer`（`src/web/server.ts::startWebServer`）依序掛載 route；portals 共用 `src/web/portal-shell.ts::renderPortalShell`（浮動三鈕 nav + topbar + CSS）。
+
+| 區塊         | 檔案                                                       | 目前表面                                                                                                                                                               |
+| ------------ | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| admin        | `src/web/admin/portal.ts`（~3400 行）                      | `GET /admin` + ~26 支具名 `/admin/api/*`（models/conversations/settings/workspace tree/skills/packages/extension-secrets/events/session-usage…），30 分鐘 `AdminToken` |
+| session-view | `src/web/session-view/portal.ts`（~1800 行）+ `service.ts` | `GET /session?token&session`（頁）、`GET /session/stream`（SSE）、`POST /session/message`（聊天送出）；24 小時 `SessionViewToken`                                      |
+| vault/login  | `src/web/login/portal.ts` + `oauth.ts`                     | `GET /link`、`POST /api/link/complete`（API key）、`POST /api/oauth/start` + `GET /oauth/callback`（OAuth/PKCE）、CSRF；15 分鐘 `LinkToken`                            |
+
+**[觀察]** token 都是 in-memory TTL store（`InMemoryAdminTokenStore`、`InMemorySessionViewTokenStore`、`InMemoryLinkTokenStore`，皆基於 `src/web/token-store.ts::InMemoryTokenStore`）。無 cookie、無 session cookie；連結攜帶 token query/body。bind 規則：`MIKAN_LINK_URL` 設了才 `0.0.0.0`，否則 `127.0.0.1`（`src/web/server.ts:119`）。
+
+**[觀察]** session 資料落在 office 的 `<office>/sessions/*.jsonl`（v3 append-only JSONL，`src/harness/session-store.ts::SessionStore`，header + entries tree：`message` / `model_change` / `compaction` / `branch_summary` / `custom` / `label` / `session_info`…）。`session-view/service.ts::loadSessionViewModel` 已是現成的「session → UI model」載入器，含 parent/thread lineage。**沒有跨 office 的單一 session listing API**；admin 用 office registry + `readdirSync` + `SessionStore.open` 逐檔掃。
+
+**[觀察]** vault 落在 `<state-dir>/vaults/<key>`，key 由 sandbox identity 依 office 推導（`src/sandbox/identity.ts::credentialAuthorizationKey`），`FileVaultManager`（`src/vault/index.ts`）提供 `resolve/list/upsertEnv/deleteEnvKey/upsertFile/hasEntry/isEnabled` 與 shared-profile 操作。
+
+**[觀察]** 三 portal 的 UI 全部是 HTML 字串 + 內嵌 `<script>`/`<style>`，沒有前端 build；admin/login UI 文案為繁體中文。
+
+### 1.2 DSH 的 web 架構（參考模型）
+
+**[觀察]** DSH 是 monorepo（pnpm workspace），web 分「host seam」與「client boot」兩半，中間靠 `window.__MIKAN_BOOT__` 傳遞：
+
+- **host seam**（`packages/host/*`）：
+  - `@deepseek-ai/dsh-host-webserver`：一個 `node:http` server + 屬性註冊服務。`register({kind:'exact'|'prefix', path, handler})`、`registerUpgrade({path, handler})`、單一 `registerFallback(handler)` seat、`tapIndex(transform)`。exact 優先、prefix 最長匹配。
+  - `@deepseek-ai/dsh-host-frontend-static`：認領 fallback seat，serve built dist；path traversal → 403；任何 miss（含 `/`、`index.html`）→ serve `index.html` with 200（SPA routing），並跑過所有 index taps。
+  - `@deepseek-ai/dsh-client-modules`（node half）：掃 loader entries 中宣告 `dsh.client` 的 packages，解析每支 client bundle 並 hash（`rev`），serve `/plugins/<id>/client.js`，並注入 `__MIKAN_BOOT__` 到 `<head>` 第一個 script。
+- **client boot**（`packages/client/*`）：
+  - `@deepseek-ai/dsh-client-web`：`boot.tsx` 的 `AppWebEntry`。讀 `__MIKAN_BOOT__` → `ClientModuleSystem`（module table）→ prefetch → mount Cordis Loader → 每支 plugin 一個 entry → `loader.await()` + `assertEntriesActive()`。
+  - `@deepseek-ai/dsh-client-web-react`：slot renderer（`renderRoot` + `SlotRenderer`）。
+  - 每支 UI feature 是獨立 package（`ui-slots`、`ui-layout`、`ui-conversation`、`ui-settings*`…），`dsh.client.platform:'web'` + `./client` export，由共用 `tsdown.client.ts` 編成 CJS closure-factory，並有「purity gate」防止跨 package value import。
+- **bundle**（`packages/bundle/web-app`）：`cordis.patch.yml` 組合所有 web 列（webserver、frontend-static、connection、modules、每個 ui-*），`src/index.ts` 認領 dist、印 URL line。
+- **apps/web**：薄 Vite entry（`main.ts` 只 `new AppWebEntry(el).run()`），`vite.config.ts` 將 shell-only packages alias 到 source、`manualChunks` 拆 vendor、`define` 修掉 loader 的 Node probe。
+
+**[觀察]** 瀏覽器 ↔ host 的 runtime API：無名 RPC `POST /api/<domain>.<method>`（`ClientRequest` envelope → trust fence → `apiProxy` gateway）+ WebSocket 下行流 `/api/events.mux` `/api/events.host`（`ConnectionController` reconnection loop）+ HMR SSE `/plugins/events`（node half stat-poll → `rebuilt` frame → client hot-swap）。
+
+---
+
+## Part 2 — 目標架構
+
+### 2.1 Monorepo package 佈局（只拆網站相關）
+
+```
+mikan/
+  package.json               # 根；private + scripts（pnpm -r 聚合）
+  pnpm-workspace.yaml        # 新增
+  src/                       # 既有 daemon 維持原狀（不動 import）
+  packages/
+    daemon-web-bridge/       # 新增（薄型：連接 token store / runtime bridge 給 host，避免直接碰 src/*）
+    web-host/                # 新增：route registry + fallback seat + boot-manifest 注入 + static dist
+    web-client/              # 新增：React shell（讀 __MIKAN_BOOT__ → 載入 ui-* bundles）
+    ui-session/              # 新增：session-view SPA 頁
+    ui-admin/                # 新增：admin SPA 頁
+    ui-vault/                # 新增：vault/login SPA 頁
+    web-bundle/              # 新增：組合清單（要載入哪些 ui-*）；產出 boot graph
+  apps/web/                  # 新增：薄 Vite entry（main.ts + index.html）
+  web-dist/                  # 建置產出（.gitignore）
+```
+
+> 「只拆網站相關」的落點：**不動 `src/`**。`web-host` 與既有 `src/web/server.ts` 的關係是「host 保留在 daemon 內，`src/web/server.ts` 呼叫/包 `web-host` 的 registry 服務」——詳見 §5 遷移順序。若只想先不動既有 portal，則 `web-host` 可作為新增 route 的註冊面，舊 portal 維持原 route 直到逐個替換。
+
+### 2.2 host seam（`packages/web-host`）
+
+對齊 DSH 的抽象，但用 mikan 既有的 `node:http`（不引入 Cordis）：
+
+```ts
+// packages/web-host/src/router.ts
+export type WebRouteKind = "exact" | "prefix";
+export interface WebRoute {
+  kind: WebRouteKind;
+  path: string;
+  handler: (req, res) => void | Promise<void>;
+}
+export interface WebUpgradeRoute {
+  path: string;
+  handler: (req, socket, head) => void | Promise<void>;
+}
+
+export class WebServer {
+  // 取代/包裹 src/web/server.ts::createServer 的 dispatch
+  register(route): () => void;
+  registerUpgrade(route): () => void;
+  registerFallback(handler): () => void; // 單一 seat，static dist 認領
+  tapIndex(fn): () => void; // 對每個 index.html 依序套用
+  applyIndexTaps(html): string;
+  listen(port, host);
+}
+```
+
+- 既有 route（`/admin*`、`/session*`、`/link`、`/api/*`、`/health`、agent-events SSE、github webhook）平移為具名 route，**行為不變**。
+- `client-boot` 或 `web-bundle` 認領 fallback seat + 注入 `__MIKAN_BOOT__` + serve `/plugins/<id>/client.{js,map}`。
+- 保留現有 bind/`MIKAN_LINK_URL`/`127.0.0.1` 規則與 token store。
+
+### 2.3 client shell（`packages/web-client`）
+
+對齊 DSH `boot.tsx` 但**只用 React + react-router**（不搬 Cordis/plugin 那套，因為 mikan 無此生態、也不需要動態掛 plugin）：
+
+```ts
+// apps/web/src/main.ts
+const el = document.getElementById("root");
+const manifest = parseBootManifest(globalThis.__MIKAN_BOOT__); // {rev, entries:[{id,url,rev}]}
+void createApp(el, manifest).run();
+```
+
+- `__MIKAN_BOOT__` 由 host 注入，內容是「該頁需要的 ui-* bundle 清單」。shell 用動態 `import()` 載入各 `ui-*` 的 vanilla/React 頁，透過一個輕量 **slot/route 註冊面**（見下）組合，但不需要 Cordis。
+- **跨模組通訊**：用一個純 TypeScript 的 「web service context」（`packages/web-client/src/context.ts`），提供 `api`（fetch wrapper）、`sessions`、`host` 描述；不引入重的 IoC。
+
+### 2.4 boot manifest 與 bundle 組合
+
+參考 DSH 的 wire 形狀（`WebBootGraph { rev, entries }`），但簡化：
+
+```ts
+interface WebBootEntry {
+  id: string;
+  url: string;
+  rev: string;
+  immediately?: boolean;
+}
+interface WebBootGraph {
+  rev: string;
+  entries: WebBootEntry[];
+}
+```
+
+- `packages/web-bundle` 設定「這個 deploy 要含哪些 ui-*」（session / admin / vault 的頁）。
+- host 在 serve `index.html` 前用 `tapIndex` 注入 `window.__MIKAN_BOOT__ = {…}`（先於 shell bundle），並 serve 每支 bundle。
+- 每支 `ui-*` bundle = 獨立 Vite build 產物（CJS/IIFE closure-factory，對 `web-client` 的 export 保持 external），類似 DSH 的 `tsdown.client.ts`。**若不想整套「runtime-fetch plugin」**，退路是：單一支 app bundle（所有 ui-* 一起 build），`__MIKAN_BOOT__` 只帶 `rev`/版本資訊當快取錨。第一階段建議先做**單支 app bundle**（低複雜度、行為一致），需要動態加減 features 時再切成多支。
+
+### 2.5 host JSON API 表面（給 React SPA 用）
+
+沿用既有 portal 的 API 路線，把它們定義為 host 端具名 route（每個 `ui-*` 對應一組）：
+
+| UI           | Host API                                                                                                                                            | 用既有來源                                                                           |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `ui-session` | `GET /api/session/<file>`（view model）、`GET /api/session/<file>/stream`（SSE）、`POST /api/session/<file>/message`、`GET /api/offices`（listing） | `session-view/service.ts::loadSessionViewModel`；`admin/portal.ts::listAdminOffices` |
+| `ui-admin`   | `GET/POST /api/admin/*`                                                                                                                             | 既有 `/admin/api/*` handler 平移                                                     |
+| `ui-vault`   | `GET /api/link`、`POST /api/link/complete`、`POST /api/oauth/start`、`GET /api/oauth/callback`                                                      | 既有 login/portal.ts 平移                                                            |
+
+> **token 模型保持不變**：不引入 cookie；React SPA 從 URL/token store 讀 token、放進 API call。第一階段 `ui-session` 維持 query token（`/session?token=…`），SST 路由由 shell 從 `?session=`/`?token=` 讀並導向對應頁。
+
+---
+
+## Part 3 — 建置與 dev 流程
+
+- **workspace**：新增 `pnpm-workspace.yaml`（`packages:'packages/*'`、`apps/web`）；根 `package.json` `private:true`，scripts 用 `pnpm -r` 聚合 `build:web` / `dev:web`。**不使用 pnpm 改 npm**——引進 pnpm 是 monorepo 的前置決策（需使用者同意，見 §6 open question）。
+- **client build**：`apps/web` Vite + `@vitejs/plugin-react`；shell/`ui-*` 由 alias 指向 source（對齊 DSH：`define` 修掉可能的 Node probe；`manualChunks` 把重 render 依賴分 vendor）。
+- **dev**：`pnpm dev:web` 起 Vite dev + host；DSH 的「client-plugin HMR」在本階段可先不做（單支 bundle 時 Vite HMR 對 apps/web 原生生效）。
+- **production**：`pnpm build:web` → `web-bundle` 產出 dist → `web-host` 的 static fallback 認領 dist 目錄。
+
+---
+
+## Part 4 — 遷移步驟與驗證（每步可獨立驗證）
+
+> 每步完成即跑「對應的既有測試 + 手動以既有 `./dist/main.js …` 起服驗證該畫面仍正常」。
+
+1. **S0 — 骨架**：新增 `pnpm-workspace.yaml`、根 package.json、`packages/{web-host,web-client,ui-session,ui-admin,ui-vault,web-bundle,daemon-web-bridge}`、`apps/web`；`pnpm install` 可解析；不做任何 code 變更。驗證：`pnpm -w web:...` 空 script 可跑、既有 `npm test` 不破。
+2. **S1 — host route registry**：`packages/web-host` 實作 `WebServer`；`src/web/server.ts` 改用/呼叫它，既有 route 平移。驗證：既有 login/admin/session portal 的 HTML 渲染與 API 全部與改前相同（跑 `src/test/login.test.ts`、`session-*.test.ts`、手動 curl）。
+3. **S2 — boot 注入 + static fallback**：`web-host` 認領 fallback seat、serve `apps/web` 的 dist（先放一個 placeholder `index.html` + `root` div）；`tapIndex` 注入 `__MIKAN_BOOT__`。驗證：`curl /` 回傳 index.html 且 `<head>` 有 boot script；`curl /assets/x.js` 200；`curl /unknown` 也 200（SPA fallback）。
+4. **S3 — React shell + session 頁**：`ui-session` 用 React 實作 session viewer（讀 `__MIKAN_BOOT__` → 對 `GET /api/session/...`（或既有 `/session` 資料面）fetch → 渲染 timeline/composer/SSE），`web-client` shell 組合它。驗證：`/session?token=…&session=…` 由 React 渲染、SSE 即時、`POST /session/message` 可送出、功能與舊版 HTML 等效。
+5. **S4 — admin SPA**：`ui-admin` 對既有 `/admin/api/*`（平移後的 host route）做 React 管理頁（conversations/models/settings/events/vault link…）。驗證：admin 各 tab 皆可讀寫、行為與舊 HTML 等效。
+6. **S5 — vault SPA**：`ui-vault` 做 login/link/OAuth 頁（既有 `/link`、`/api/oauth/start`、`/oauth/callback`）。驗證：API key 與 OAuth 兩模式皆可存 credential 到 vault。
+7. **S6 — 收束**：把新 web 接到 `main.ts`（沿用 `startWebServer`，改用 registry + fallback），移除已替換的 `renderPortalShell`/inline script 或留作 fallback；跑完整 `npm test` + 手動 e2e。
+
+---
+
+## Part 5 — 風險與開放問題
+
+- **pnpm**：monorepo 前置需要引入 pnpm（目前用 npm + 單一 package）。屬「新增工具鏈」層級，需使用者明確同意才換。**替代**：繼續用 npm workspaces（`workspaces` field）也能達成 packages/* 拆分，但不完全同 DSH（DSH 用 pnpm）。→ open question。
+- **不動既有 `src/`**：§2.1「只拆網站」假設 `src/web/server.ts` 仍是 host 的擁有者、由它組 `web-host`。若要更徹底（把 `src/web/*` 整個搬進 packages），風險與 import 修改正比增加，視為後續選項。
+- **bundle 策略**：先「單支 app bundle」後「多支 plugin bundles」兩階段（§2.4 退路）。單支時不需要 Cordis/plugin 生態，成本最低、最貼近「網站」而非「可插拔平台」。
+- **SSE / WS**：session-view 的即時性，第一階段沿用 SSE（`/session/stream`）；是否升級 WebSocket（對齊 DSH `/api/events.mux`）列為後續。
+- **token in URL/cookie**：維持現有 token-in-URL 模型以不破既有 `/session?token=` 連結；新 SPA 也須處理 deep-link（重整仍帶 token）。
+- **繁中 UI**：admin/login 現為繁中以字串形式寫死於 HTML template。遷移到 JSX 時應抽 `web-client` 的 `locale`/`messages`，供未來 i18n。
+
+## 附錄：驗證命令記錄
+
+### S0 — workspace 骨架（已完成 2026-06-09）
+
+**[實測]** 本地 pnpm 10.10.0：
+
+- `pnpm install` 全 workspace 8 projects 成功；git-hosted `@geminixiang/mikan-starlight-theme` 需 pnpm 的 nested CLI 下載，沙箱 read-only 的 `~/.local/share/pnpm` 需以 `XDG_DATA_HOME=<repo>/.xdg` 重定向（環境特例，非 repo 內容；`.xdg/`、`.pnpm-store/` 已 gitignore）。
+- `pnpm run build`（daemon, tsgo）成功；唯一阻塞是 `src/observability/sentry.ts` 在 pnpm 嚴格 node_modules 下 `createSentryInitOptions` 推斷型別無法命名（TS2883），以 `NodeOptions` return-type 註解修復（一行、行為不變）。另 `.npmrc` 設 `shamefully-hoist=true` 以 npm 式平舖相容既有型別圖。
+- `pnpm test`：**123 files / 1735 tests 全數通過**。
+- 新 host packages（`web-host`、`daemon-web-bridge`）`tsgo` 編譯出 `lib/`；`apps/web` Vite build 因 shell 尚未實作（`AppWebEntry` 不存在）屬預期失敗，S3 修復。
+- 既有 CI 三檔 workflow 已切換 `npm ci` → `pnpm install --frozen-lockfile` + `pnpm/action-setup` + `cache: pnpm`；`package-lock.json` 保留供外部 npm 使用者（publish 流程仍以 npm publish 出 daemon package）。
+
+### S1 — host route registry（已完成）
+
+**[實測]** `packages/web-host`（`webserver.ts`）實作 DSH 的 route registry 模式：`register({kind:'exact'|'prefix', path, handler})`、`registerUpgrade`、單一 `registerFallback` seat、`tapIndex`/`applyIndexTaps`；handler 用「回傳 false = 不是我的」boolean contract，既有 portal handlers 免改直接平移。`src/web/server.ts::startWebServer` 改用 registry，既有的 `/health`、`/github/webhook`、`/api/agent-events/stream`、`/admin*`、`/session*`、login 四條 exact routes 平移；listen 失敗改 log 不 crash（同舊行為）。`startWebServer` 變 async，link-server/oauth-link-server 測試改用 await。
+
+- 驗證：`packages/web-host` 21 tests；daemon 全量 1740 tests；真實 daemon boot 後 `/health` 200、`/unknown` 404、`/link?token=bad` 400、`/admin` 403、`/session?token=bad` 400、`/github/webhook` 404 —— 與舊 if-chain 一致。
+
+### S2 — static-dist fallback + boot-manifest 注入（已完成）
+
+**[實測]** `packages/web-host/static.ts`（`serveStatic` + `registerStaticFallback`，DSH frontend-static 模式：traversal 403、miss→index 200、index taps 注入）；`boot-manifest.ts`（`injectBootManifest` 把 `window.__MIKAN_BOOT__` 注入 `<head>` 首 script、`graphRev`）；`packages/web-bundle`（`composeWebBootGraph`、`contentRev`、`entryUrlOfIndex`）。`server.ts` 在 `webDistIndex` 存在時認領 fallback + 註冊 tap；`main.ts` 從 `MIKAN_WEB_DIST`（預設 `apps/web/dist/index.html`）傳入。
+
+- 驗證：fixture dist boot 後 `/` 回 index 且含 boot graph、`/any/path` 200（SPA routing）、具名 route 仍優先、static asset 正確 MIME。
+
+### S3 — React shell + session SPA（已完成）
+
+**[實測]** `packages/web-client`（shell：manifest.ts/api.ts/App.tsx/boot.tsx，react-router + 浮動 nav + topbar）、`packages/ui-session`（`SessionPage.tsx`：fetch 新增的 `GET /api/session/view` JSON endpoint，訂閱既有 `/session/stream` SSE 做 live reload，`POST /session/message` 送出；markdown 用 `marked`）。型別單一來源移到 `packages/daemon-web-bridge`，`src/web/session-view/types.ts` re-export。dist 存在時 SPA 接手 portal 頁面 URL（`/session`、`/admin`、`/link` → fallback serve index），API/stream/message routes 仍由 daemon 處理。
+
+- 驗證：`apps/web` Vite build 成功（~276 kB bundle）；`tsc --noEmit -p apps/web` 乾淨；`session-view-api.test.ts` 4 tests；daemon 全量 1740 tests；真實 boot 後 `/session?token=x` 回 SPA index + boot graph、`/session/stream` 仍 400、`/api/session/view?token=bad` 回 JSON error。
+
+### S4 — admin SPA（已完成）
+
+**[實測]** `packages/ui-admin`（`AdminPage.tsx`）：Conversations / Models / Usage / Events / Settings 五個 tab，全走既有 `/admin/api/*`（GET `?token=`、POST body 帶 `token`）。Conversations：office 列表 + `conversation-state`（model/door policy/auto-reply/slack）+ model picker 切換；Models 表（access status）；Usage 表（top 20）；Events 表；Settings 讀寫。
+
+### S5 — vault/login SPA（已完成）
+
+**[實測]** `packages/ui-vault`（`VaultPage.tsx`）：新增 `GET /api/link/info`（JSON：valid/expiresAt/oauthServices/existingSecrets）；API key 模式 `POST /api/link/complete`、OAuth 模式 `POST /api/oauth/start` → redirect。CSRF 沿用既有 enforceCsrf。link-server.test.ts 新增 `/api/link/info` test（9 tests 全過）。
+
+### S6 — 收束（待）
+
+- 新 web 已透過 `main.ts`（`MIKAN_WEB_DIST`）接上既有 boot；剩餘：瀏覽器層 e2e（本環境無 headless browser）、`renderPortalShell`/內嵌 script 的移除或保留決策、DSH 式 client-plugin HMR、knip 納入新 packages 白名單。

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "clean": "shx rm -rf dist",
     "build": "pnpm -r --filter './packages/*' build && npm run clean && tsgo -p src/tsconfig.build.json && node scripts/embed-web-deps.mjs && shx chmod +x dist/main.js",
     "dev": "tsgo -p src/tsconfig.build.json --watch --preserveWatchOutput",
+    "build:web": "pnpm -r build",
+    "dev:web": "pnpm --filter @geminixiang/mikan-web-frontend dev",
     "test": "vitest --run --config .config/vitest.config.ts && pnpm -r --if-present --filter './packages/sandbox-*' test",
     "test:coverage": "vitest --run --coverage --config .config/vitest.config.ts",
     "test:coverage:check": "vitest --run --coverage --config .config/vitest.config.ts",

--- a/packages/ui-admin/package.json
+++ b/packages/ui-admin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@geminixiang/mikan-ui-admin",
+  "version": "0.1.0",
+  "private": true,
+  "description": "mikan admin SPA feature: conversations, models, settings, workspace tree, skills, packages, events, usage",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/ui-admin/src/AdminPage.tsx
+++ b/packages/ui-admin/src/AdminPage.tsx
@@ -1,0 +1,633 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiGet, apiPost, queryParam } from "@geminixiang/mikan-web-client";
+import "./admin.css";
+
+// ── Wire types (mirror of the daemon's /admin/api/* responses) ──────────────
+
+interface AdminConversationRow {
+  platform: string;
+  conversationId: string;
+  label: string;
+  running: boolean;
+  lastActivityAt: string | null;
+}
+
+interface ConversationState {
+  conversationId: string;
+  provider: string | null;
+  model: string | null;
+  thinkingLevel: string | null;
+  globalProvider: string | null;
+  globalModel: string | null;
+  workspaceDoorPolicy: string;
+  workspaceLayout: string;
+  workspaceOverride: string | null;
+  globalWorkspaceDoorPolicy: string;
+  autoReplyEnabled: boolean;
+  autoReplyRules: Array<{ match: string; reply: string }>;
+  slack: { replyMode: string; globalReplyMode: string };
+}
+
+interface ModelRow {
+  provider: string;
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: number | null;
+  contextWindow: number | null;
+  maxTokens: number | null;
+  status: "available" | "unverified";
+}
+
+interface UsageRow {
+  conversationId: string;
+  label: string;
+  fileName: string;
+  sessionId: string;
+  updatedAt: string;
+  input: number;
+  output: number;
+  total: number;
+  cost: number;
+}
+
+interface EventRow {
+  name: string;
+  size: number;
+  mtimeMs: number;
+  type: string | null;
+  conversationId: string | null;
+  text: string | null;
+  at: string | null;
+  schedule: string | null;
+  timezone: string | null;
+}
+
+interface GlobalSettings {
+  provider: string | null;
+  model: string | null;
+  thinkingLevel: string | null;
+  sandboxCpus: number | null;
+  sandboxMemory: number | null;
+  workspaceDoorPolicy: string;
+  workspaceLayout: string;
+  defaultSharedVault: string | null;
+  slack: { replyMode: string };
+}
+
+interface Me {
+  platform: string;
+  platformUserId: string;
+  label: string;
+  expiresAt: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function adminUrl(path: string, token: string): string {
+  const sep = path.includes("?") ? "&" : "?";
+  return `${path}${sep}token=${encodeURIComponent(token)}`;
+}
+
+function fmtBytes(n: number): string {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+function fmtTokens(n: number | null | undefined): string {
+  if (n === null || n === undefined) return "—";
+  return n.toLocaleString();
+}
+
+// ── Tabs ────────────────────────────────────────────────────────────────────
+
+type Tab = "conversations" | "models" | "usage" | "events" | "settings";
+
+const TABS: Array<{ id: Tab; label: string }> = [
+  { id: "conversations", label: "Conversations" },
+  { id: "models", label: "Models" },
+  { id: "usage", label: "Usage" },
+  { id: "events", label: "Events" },
+  { id: "settings", label: "Settings" },
+];
+
+// ── Conversations tab ───────────────────────────────────────────────────────
+
+function ConversationsTab({ token }: { token: string }) {
+  const [rows, setRows] = useState<AdminConversationRow[] | null>(null);
+  const [selected, setSelected] = useState<AdminConversationRow | null>(null);
+  const [state, setState] = useState<ConversationState | null>(null);
+  const [models, setModels] = useState<ModelRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await apiGet<{ conversations: AdminConversationRow[] }>(
+        adminUrl("/admin/api/conversations", token),
+      );
+      setRows(data.conversations);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const open = async (row: AdminConversationRow): Promise<void> => {
+    setSelected(row);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (row.platform) params.set("platform", row.platform);
+      params.set("conversationId", row.conversationId);
+      const [stateData, modelsData] = await Promise.all([
+        apiGet<ConversationState>(
+          `${adminUrl("/admin/api/conversation-state", token)}&${params.toString()}`,
+        ),
+        apiGet<{ models: ModelRow[] }>(adminUrl("/admin/api/models", token)),
+      ]);
+      setState(stateData);
+      setModels(modelsData.models);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const switchModel = async (
+    provider: string,
+    model: string,
+    thinkingLevel: string,
+  ): Promise<void> => {
+    if (!selected) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiPost("/admin/api/conversations/model", {
+        token,
+        platform: selected.platform,
+        conversationId: selected.conversationId,
+        provider,
+        model,
+        thinkingLevel,
+      });
+      await open(selected);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (error) return <div className="err-msg">{error}</div>;
+  if (!rows) return <div className="loading-msg">Loading conversations…</div>;
+
+  return (
+    <div className="admin-split">
+      <ConversationList rows={rows} selected={selected} onOpen={(row) => void open(row)} />
+      <ConversationDetail
+        selected={selected}
+        state={state}
+        models={models}
+        busy={busy}
+        onSwitch={(p, m) => void switchModel(p, m, state?.thinkingLevel ?? "none")}
+      />
+    </div>
+  );
+}
+
+function ConversationList({
+  rows,
+  selected,
+  onOpen,
+}: {
+  rows: AdminConversationRow[];
+  selected: AdminConversationRow | null;
+  onOpen: (row: AdminConversationRow) => void;
+}) {
+  return (
+    <div className="card conv-list">
+      <p className="eyebrow">Conversations</p>
+      {rows.length === 0 ? (
+        <div className="empty-state">No conversations registered yet.</div>
+      ) : (
+        <ul className="conv-ul">
+          {rows.map((row) => (
+            <li key={`${row.platform}:${row.conversationId}`}>
+              <button
+                className={`conv-row${selected?.conversationId === row.conversationId ? " active" : ""}`}
+                onClick={() => onOpen(row)}
+              >
+                <span className="conv-label">{row.label}</span>
+                <span className="conv-meta">
+                  {row.running ? (
+                    <span className="badge running">running</span>
+                  ) : (
+                    <span className="badge">idle</span>
+                  )}
+                  <span>{row.platform}</span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ConversationDetail({
+  selected,
+  state,
+  models,
+  busy,
+  onSwitch,
+}: {
+  selected: AdminConversationRow | null;
+  state: ConversationState | null;
+  models: ModelRow[] | null;
+  busy: boolean;
+  onSwitch: (provider: string, model: string) => void;
+}) {
+  if (!selected || !state) {
+    return (
+      <div className="card conv-detail">
+        <div className="empty-state">Select a conversation to inspect it.</div>
+      </div>
+    );
+  }
+  return (
+    <div className="card conv-detail">
+      <p className="eyebrow">Conversation</p>
+      <h3 className="conv-title">{state.conversationId}</h3>
+      <dl className="kv">
+        <dt>Model</dt>
+        <dd>
+          {state.provider} / {state.model}{" "}
+          {state.thinkingLevel ? `(thinking ${state.thinkingLevel})` : ""}
+          <span className="kv-hint">
+            global: {state.globalProvider} / {state.globalModel}
+          </span>
+        </dd>
+        <dt>Door policy</dt>
+        <dd>
+          {state.workspaceDoorPolicy} / {state.workspaceLayout}
+          {state.workspaceOverride ? ` (override: ${state.workspaceOverride})` : ""}
+          <span className="kv-hint">global: {state.globalWorkspaceDoorPolicy}</span>
+        </dd>
+        <dt>Auto-reply</dt>
+        <dd>
+          {state.autoReplyEnabled ? `enabled (${state.autoReplyRules.length} rules)` : "disabled"}
+        </dd>
+        <dt>Slack reply mode</dt>
+        <dd>
+          {state.slack.replyMode} (global: {state.slack.globalReplyMode})
+        </dd>
+      </dl>
+      <p className="eyebrow">Switch model</p>
+      <ModelPicker
+        models={models ?? []}
+        currentProvider={state.provider}
+        currentModel={state.model}
+        busy={busy}
+        onSwitch={onSwitch}
+      />
+    </div>
+  );
+}
+
+function ModelPicker({
+  models,
+  currentProvider,
+  currentModel,
+  busy,
+  onSwitch,
+}: {
+  models: ModelRow[];
+  currentProvider: string | null;
+  currentModel: string | null;
+  busy: boolean;
+  onSwitch: (provider: string, model: string) => void;
+}) {
+  const [provider, setProvider] = useState(currentProvider ?? models[0]?.provider ?? "");
+  const [model, setModel] = useState(currentModel ?? "");
+  useEffect(() => {
+    setProvider(currentProvider ?? models[0]?.provider ?? "");
+    setModel(currentModel ?? "");
+  }, [currentProvider, currentModel, models]);
+  const providerModels = models.filter((m) => m.provider === provider);
+  return (
+    <div className="model-picker">
+      <select value={provider} onChange={(e) => setProvider(e.target.value)}>
+        {[...new Set(models.map((m) => m.provider))].map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      <select value={model} onChange={(e) => setModel(e.target.value)}>
+        {providerModels.map((m) => (
+          <option key={m.id} value={m.id}>
+            {m.name} {m.status === "unverified" ? "(unverified)" : ""}
+          </option>
+        ))}
+      </select>
+      <button
+        className="primary-action-btn"
+        disabled={busy || !provider || !model}
+        onClick={() => onSwitch(provider, model)}
+      >
+        {busy ? "Switching…" : "Switch"}
+      </button>
+    </div>
+  );
+}
+
+// ── Models tab ──────────────────────────────────────────────────────────────
+
+function ModelsTab({ token }: { token: string }) {
+  const [models, setModels] = useState<ModelRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    apiGet<{ models: ModelRow[] }>(adminUrl("/admin/api/models", token))
+      .then((data) => setModels(data.models))
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }, [token]);
+  if (error) return <div className="err-msg">{error}</div>;
+  if (!models) return <div className="loading-msg">Loading models…</div>;
+  return (
+    <div className="card">
+      <p className="eyebrow">Models</p>
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>Provider</th>
+            <th>Model</th>
+            <th>Reasoning</th>
+            <th>Input $/M</th>
+            <th>Context</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {models.map((m) => (
+            <tr key={`${m.provider}/${m.id}`}>
+              <td>{m.provider}</td>
+              <td>
+                {m.name}
+                <span className="mono"> ({m.id})</span>
+              </td>
+              <td>{m.reasoning ? "yes" : "no"}</td>
+              <td>{m.input === null ? "—" : m.input.toFixed(2)}</td>
+              <td>{fmtTokens(m.contextWindow)}</td>
+              <td>
+                <span className={`badge ${m.status === "available" ? "ok" : "warn"}`}>
+                  {m.status}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Usage tab ───────────────────────────────────────────────────────────────
+
+function UsageTab({ token }: { token: string }) {
+  const [rows, setRows] = useState<UsageRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    apiGet<{ sessions: UsageRow[] }>(adminUrl("/admin/api/session-usage", token))
+      .then((data) => setRows(data.sessions))
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }, [token]);
+  if (error) return <div className="err-msg">{error}</div>;
+  if (!rows) return <div className="loading-msg">Loading usage…</div>;
+  return (
+    <div className="card">
+      <p className="eyebrow">Session usage (top 20 by tokens)</p>
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>Conversation</th>
+            <th>Session</th>
+            <th>Updated</th>
+            <th>Input</th>
+            <th>Output</th>
+            <th>Total</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.sessionId}>
+              <td>{r.label}</td>
+              <td>
+                <span className="mono">{r.fileName}</span>
+              </td>
+              <td>{fmtDate(r.updatedAt)}</td>
+              <td>{fmtTokens(r.input)}</td>
+              <td>{fmtTokens(r.output)}</td>
+              <td>{fmtTokens(r.total)}</td>
+              <td>${r.cost.toFixed(4)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Events tab ──────────────────────────────────────────────────────────────
+
+function EventsTab({ token }: { token: string }) {
+  const [events, setEvents] = useState<EventRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    apiGet<{ events: EventRow[] }>(adminUrl("/admin/api/events", token))
+      .then((data) => setEvents(data.events))
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }, [token]);
+  if (error) return <div className="err-msg">{error}</div>;
+  if (!events) return <div className="loading-msg">Loading events…</div>;
+  return (
+    <div className="card">
+      <p className="eyebrow">Scheduled events</p>
+      {events.length === 0 ? (
+        <div className="empty-state">No event files yet.</div>
+      ) : (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>File</th>
+              <th>Type</th>
+              <th>Conversation</th>
+              <th>Schedule / at</th>
+              <th>Size</th>
+              <th>Modified</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((e) => (
+              <tr key={e.name}>
+                <td>
+                  <span className="mono">{e.name}</span>
+                </td>
+                <td>{e.type ?? "—"}</td>
+                <td>{e.conversationId ?? "—"}</td>
+                <td>{e.schedule ?? e.at ?? "—"}</td>
+                <td>{fmtBytes(e.size)}</td>
+                <td>{fmtDate(new Date(e.mtimeMs).toISOString())}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+// ── Settings tab ────────────────────────────────────────────────────────────
+
+function SettingsTab({ token }: { token: string }) {
+  const [settings, setSettings] = useState<GlobalSettings | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    apiGet<GlobalSettings>(adminUrl("/admin/api/settings/global", token))
+      .then(setSettings)
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }, [token]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const save = async (patch: Record<string, unknown>): Promise<void> => {
+    try {
+      await apiPost("/admin/api/settings/model", { token, ...patch });
+      setSaved("Saved ✓");
+      setError(null);
+      setTimeout(() => setSaved(null), 2500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  if (error) return <div className="err-msg">{error}</div>;
+  if (!settings) return <div className="loading-msg">Loading settings…</div>;
+
+  return (
+    <div className="card settings-card">
+      <p className="eyebrow">Global settings</p>
+      <dl className="kv">
+        <dt>Default model</dt>
+        <dd>
+          {settings.provider} / {settings.model}{" "}
+          {settings.thinkingLevel ? `(thinking ${settings.thinkingLevel})` : ""}
+        </dd>
+        <dt>Sandbox</dt>
+        <dd>
+          {settings.sandboxCpus ?? "?"} cpus · {settings.sandboxMemory ?? "?"} MB
+        </dd>
+        <dt>Workspace door</dt>
+        <dd>
+          {settings.workspaceDoorPolicy} / {settings.workspaceLayout}
+          {settings.defaultSharedVault ? ` · vault ${settings.defaultSharedVault}` : ""}
+        </dd>
+        <dt>Slack reply mode</dt>
+        <dd>{settings.slack.replyMode}</dd>
+      </dl>
+      <p className="eyebrow">Change default model</p>
+      <div className="model-picker">
+        <select
+          defaultValue={settings.provider ?? ""}
+          onChange={(e) => void save({ provider: e.target.value })}
+        >
+          <option value={settings.provider ?? ""}>{settings.provider ?? "current"}</option>
+          <option value="openai">openai</option>
+          <option value="anthropic">anthropic</option>
+        </select>
+        {saved ? <span className="save-note">{saved}</span> : null}
+      </div>
+      <div className="kv-hint">
+        Use the Models tab to pick exact ids; this tab exposes the read surface.
+      </div>
+    </div>
+  );
+}
+
+// ── Page ────────────────────────────────────────────────────────────────────
+
+export function AdminPage() {
+  const token = queryParam("token") ?? "";
+  const [tab, setTab] = useState<Tab>("conversations");
+  const [me, setMe] = useState<Me | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    apiGet<Me>(adminUrl("/admin/api/me", token))
+      .then(setMe)
+      .catch(() => setMe(null));
+  }, [token]);
+
+  if (!token) {
+    return (
+      <div className="card">
+        <p className="eyebrow">Admin</p>
+        <h2 className="card-title">Admin link required</h2>
+        <div className="err-msg">
+          This link is missing, invalid, or expired. Send <code>/admin</code> to the bot to get a
+          fresh link.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <header className="page-head">
+        <div>
+          <p className="eyebrow">Admin</p>
+          <h2 className="page-title">mikan admin</h2>
+          <p className="page-desc">
+            {me
+              ? `${me.label} · expires ${fmtDate(new Date(me.expiresAt).toISOString())}`
+              : "Authenticated by link token."}
+          </p>
+        </div>
+      </header>
+      <div className="tab-row" role="tablist">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={tab === t.id}
+            className={`tab-btn${tab === t.id ? " active" : ""}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      {tab === "conversations" ? <ConversationsTab token={token} /> : null}
+      {tab === "models" ? <ModelsTab token={token} /> : null}
+      {tab === "usage" ? <UsageTab token={token} /> : null}
+      {tab === "events" ? <EventsTab token={token} /> : null}
+      {tab === "settings" ? <SettingsTab token={token} /> : null}
+    </>
+  );
+}

--- a/packages/ui-admin/src/admin.css
+++ b/packages/ui-admin/src/admin.css
@@ -1,0 +1,209 @@
+/* Admin SPA styles. */
+
+.admin-split {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.conv-list {
+  padding: 18px 16px;
+}
+
+.conv-ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.conv-row {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text);
+  font: inherit;
+  transition:
+    background 120ms,
+    border-color 120ms;
+}
+
+.conv-row:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.conv-row.active {
+  background: rgba(0, 0, 0, 0.06);
+  border-color: var(--border);
+}
+
+.conv-label {
+  font-weight: 600;
+  font-size: 0.88rem;
+}
+
+.conv-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 0.74rem;
+  color: var(--muted);
+}
+
+.conv-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+.kv {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 8px 14px;
+  margin-bottom: 18px;
+  font-size: 0.88rem;
+}
+
+.kv dt {
+  color: var(--subtle);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding-top: 2px;
+}
+
+.kv-hint {
+  display: block;
+  color: var(--subtle);
+  font-size: 0.74rem;
+  margin-top: 2px;
+}
+
+.model-picker {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.model-picker select {
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+  font: inherit;
+  font-size: 0.84rem;
+  color: var(--text);
+}
+
+.save-note {
+  color: var(--ok-text);
+  font-size: 0.82rem;
+}
+
+.tab-row {
+  display: flex;
+  gap: 6px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
+  width: fit-content;
+}
+
+.tab-btn {
+  border: none;
+  background: transparent;
+  padding: 8px 16px;
+  border-radius: 10px;
+  font:
+    500 0.84rem/1 "DM Sans",
+    sans-serif;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background 120ms,
+    color 120ms;
+}
+
+.tab-btn:hover {
+  color: var(--text);
+}
+
+.tab-btn.active {
+  background: var(--text);
+  color: #fff;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.84rem;
+}
+
+.data-table th {
+  text-align: left;
+  color: var(--subtle);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.data-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  vertical-align: top;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--muted);
+}
+
+.badge.running {
+  background: var(--ok-bg);
+  color: var(--ok-text);
+  border: 1px solid var(--ok-border);
+}
+
+.badge.ok {
+  background: var(--ok-bg);
+  color: var(--ok-text);
+}
+
+.badge.warn {
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.mono {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.8em;
+}
+
+.settings-card .kv {
+  margin-bottom: 22px;
+}
+
+@media (max-width: 720px) {
+  .admin-split {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/ui-admin/src/index.ts
+++ b/packages/ui-admin/src/index.ts
@@ -1,0 +1,1 @@
+export { AdminPage } from "./AdminPage.js";

--- a/packages/ui-session/package.json
+++ b/packages/ui-session/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@geminixiang/mikan-ui-session",
+  "version": "0.1.0",
+  "private": true,
+  "description": "mikan session-view SPA feature: session timeline, SSE live stream, and composer",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "@geminixiang/mikan-daemon-web-bridge": "workspace:^",
+    "@geminixiang/mikan-web-client": "workspace:^",
+    "marked": "^15.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/ui-session/src/SessionPage.tsx
+++ b/packages/ui-session/src/SessionPage.tsx
@@ -1,0 +1,384 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { marked } from "marked";
+import type {
+  SessionViewApiResponse,
+  SessionViewItem,
+  SessionViewRelation,
+} from "@geminixiang/mikan-daemon-web-bridge";
+import { apiGet, apiPost, queryParam } from "@geminixiang/mikan-web-client";
+import "./session.css";
+
+marked.setOptions({ gfm: true, breaks: true });
+
+/** Escape raw HTML so it renders as text (the server portal used html:false). */
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function renderMarkdown(text: string): string {
+  return marked.parse(escapeHtml(text), { async: false }) as string;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+interface ParsedUserBody {
+  timestamp: string | null;
+  username: string | null;
+  threadTs: string | null;
+  content: string;
+}
+
+/** Parse the history-sync header baked into user-message bodies. */
+function parseUserBody(raw: string): ParsedUserBody {
+  const m = raw.match(
+    /^\[([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2})\]\s*\[([^\]]+)\](?:\s*\[in-thread:([^\]]+)\])?:\s*([\s\S]*)$/,
+  );
+  if (!m) return { timestamp: null, username: null, threadTs: null, content: raw };
+  return {
+    timestamp: m[1] ?? null,
+    username: m[2] ?? null,
+    threadTs: m[3] ?? null,
+    content: m[4] ?? "",
+  };
+}
+
+function ThreadChips({ relations, token }: { relations?: SessionViewRelation[]; token: string }) {
+  if (!relations || relations.length === 0) return null;
+  return (
+    <div className="thread-links">
+      {relations.map((r) => (
+        <a
+          key={r.fileName}
+          className="thread-link"
+          href={`/session?token=${encodeURIComponent(token)}&session=${encodeURIComponent(r.fileName)}`}
+          title={`Open ${r.title}`}
+        >
+          <span className="thread-dot" aria-hidden="true" />
+          <span className="thread-text">Thread</span>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function TimelineItem({ item, token }: { item: SessionViewItem; token: string }) {
+  if (item.kind === "system") {
+    return (
+      <div className="system-event">
+        <span className="event-dot" />
+        <span className="event-text">
+          <span className="event-title">{item.title}</span>
+          {item.body ? <span className="event-body">{renderMarkdown(item.body)}</span> : null}
+        </span>
+      </div>
+    );
+  }
+
+  if (item.kind === "user") {
+    const parsed = parseUserBody(item.body ?? "");
+    return (
+      <div className="msg-row user-row">
+        <div className="msg-avatar" aria-hidden="true" />
+        <div className="msg-bubble user-bubble">
+          {parsed.timestamp && parsed.username ? (
+            <div className="user-header">
+              <span className="user-name">{parsed.username}</span>
+              {parsed.threadTs ? <span className="thread-badge">in-thread</span> : null}
+              <span className="user-time">{parsed.timestamp}</span>
+            </div>
+          ) : null}
+          <div
+            className="markdown"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(parsed.content) }}
+          />
+          <ThreadChips relations={item.threads} token={token} />
+        </div>
+      </div>
+    );
+  }
+
+  if (item.kind === "tool") {
+    return (
+      <div
+        className={`tool-block ${item.tone === "err" ? "tool-err" : item.tone === "ok" ? "tool-ok" : ""}`}
+      >
+        <div className="tool-head">
+          <span className="tool-title">{item.title}</span>
+          {item.meta ? <span className="tool-meta">{item.meta}</span> : null}
+        </div>
+        {item.body ? <pre className="tool-output">{item.body}</pre> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="msg-row assistant-row">
+      <div className="msg-avatar" aria-hidden="true" />
+      <div className="msg-bubble assistant-bubble">
+        {item.body ? (
+          <div
+            className="markdown"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(item.body) }}
+          />
+        ) : null}
+        {item.meta ? <div className="assistant-meta">{item.meta}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+function RelationCard({ relation, token }: { relation: SessionViewRelation; token: string }) {
+  const href = `/session?token=${encodeURIComponent(token)}&session=${encodeURIComponent(relation.fileName)}`;
+  return (
+    <a className="related-link" href={href}>
+      <span className="related-copy">
+        <strong className="related-title">{relation.title}</strong>
+        {relation.summary ? <span className="related-summary">{relation.summary}</span> : null}
+        <span className="related-meta">
+          {formatDate(relation.updatedAt)} · {relation.entryCount} entries · {relation.fileName}
+        </span>
+      </span>
+      <span className="related-arrow" aria-hidden="true">
+        →
+      </span>
+    </a>
+  );
+}
+
+function SessionHeader({ data, token }: { data: SessionViewApiResponse; token: string }) {
+  const { model } = data;
+  const isThread = data.displayedSessionKey !== data.conversationId;
+  return (
+    <>
+      <header className="page-head">
+        <div>
+          <p className="eyebrow">Session</p>
+          <h2 className="page-title">{model.title}</h2>
+          <p className="page-desc">
+            <span>Created {formatDate(model.createdAt)}</span> ·{" "}
+            <span>
+              Updated <strong>{formatDate(model.updatedAt)}</strong>
+            </span>{" "}
+            · <span>{model.entryCount} entries</span>
+          </p>
+        </div>
+        <div className="session-side">
+          <span
+            className={`session-badge session-badge-status${data.isRunning ? " is-running" : ""}`}
+          >
+            <span className="session-badge-dot" />
+            <strong>{data.isRunning ? "Running" : "Idle"}</strong>
+          </span>
+          <span className="session-badge">{isThread ? "Thread" : "Channel"}</span>
+        </div>
+      </header>
+      <div className="session-detail-row">
+        <span className="session-detail">
+          <span className="session-detail-label">Session</span>
+          <code>{model.sessionId.slice(0, 8)}</code>
+        </span>
+        <span className="session-detail">
+          <span className="session-detail-label">File</span>
+          <code>{model.fileName}</code>
+        </span>
+        <span className="session-detail">
+          <span className="session-detail-label">Expires</span>
+          <span>{formatDate(new Date(data.expiresAt).toISOString())}</span>
+        </span>
+      </div>
+      {model.parent ? (
+        <section className="related-card card">
+          <p className="eyebrow">Parent session</p>
+          <RelationCard relation={model.parent} token={token} />
+        </section>
+      ) : null}
+    </>
+  );
+}
+
+function SessionComposer({
+  data,
+  token,
+  sending,
+  status,
+  onSubmit,
+}: {
+  data: SessionViewApiResponse;
+  token: string;
+  sending: boolean;
+  status: string | null;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <section className="composer-card">
+      <form className="composer-form" onSubmit={onSubmit}>
+        <input type="hidden" name="token" value={token} />
+        <input type="hidden" name="session" value={data.model.fileName} />
+        <textarea
+          name="text"
+          rows={1}
+          placeholder="Ask mikan in this session… (replies stay in Session View)"
+          required
+        />
+        <div className="composer-actions">
+          <span className="composer-status">{status}</span>
+          <button
+            className="composer-send-btn"
+            type="submit"
+            aria-label="Send"
+            title="Send"
+            disabled={sending}
+          >
+            ↑
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+/**
+ * Live updates: the existing /session/stream SSE already emits JSON events;
+ * any of them can change the model, so re-fetch (debounced) on each event and
+ * apply running-status frames immediately.
+ */
+function useSessionStream(
+  token: string,
+  session: string,
+  data: SessionViewApiResponse | null,
+  load: () => Promise<void>,
+  setData: (
+    updater: (prev: SessionViewApiResponse | null) => SessionViewApiResponse | null,
+  ) => void,
+): void {
+  useEffect(() => {
+    if (!token) return;
+    const params = new URLSearchParams({ token });
+    if (session) params.set("session", session);
+    const source = new EventSource(`/session/stream?${params.toString()}`);
+    let timer: number | undefined;
+    const scheduleReload = (): void => {
+      if (timer !== undefined) window.clearTimeout(timer);
+      timer = window.setTimeout(() => void load(), 250);
+    };
+    source.addEventListener("status", (event) => {
+      try {
+        const status = JSON.parse((event as MessageEvent).data) as { running?: boolean };
+        const running = status.running;
+        if (running !== undefined && data) {
+          setData((prev) => (prev ? { ...prev, isRunning: running } : prev));
+        }
+      } catch {
+        // malformed frame; ignore
+      }
+      scheduleReload();
+    });
+    source.addEventListener("message", scheduleReload);
+    return () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+      source.close();
+    };
+  }, [token, session, load, data, setData]);
+}
+
+export function SessionPage() {
+  const [data, setData] = useState<SessionViewApiResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [composerStatus, setComposerStatus] = useState<string | null>(null);
+  const timelineRef = useRef<HTMLDivElement>(null);
+
+  const token = queryParam("token") ?? "";
+  const session = queryParam("session") ?? "";
+
+  const load = useCallback(async () => {
+    try {
+      const params = new URLSearchParams({ token });
+      if (session) params.set("session", session);
+      const response = await apiGet<SessionViewApiResponse>(
+        `/api/session/view?${params.toString()}`,
+      );
+      setData(response);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [token, session]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useSessionStream(token, session, data, load, setData);
+
+  const submit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const text = String(formData.get("text") ?? "").trim();
+    if (!text || !data || sending) return;
+    setSending(true);
+    setComposerStatus("Sending…");
+    apiPost("/session/message", {
+      token,
+      session: data.model.fileName,
+      sessionKey: data.displayedSessionKey,
+      text,
+    })
+      .then(async () => {
+        setComposerStatus("Sent — waiting for the bot…");
+        form.reset();
+        await load();
+      })
+      .catch((err: unknown) => {
+        setComposerStatus(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setSending(false));
+  };
+
+  if (error) {
+    return (
+      <div className="card">
+        <p className="eyebrow">Session</p>
+        <h2 className="card-title">Session unavailable</h2>
+        <div className="err-msg">{error}</div>
+      </div>
+    );
+  }
+
+  if (!data) return <div className="loading-msg">Loading session…</div>;
+
+  return (
+    <>
+      <SessionHeader data={data} token={token} />
+      <div className="timeline-shell">
+        <div className="timeline-list" ref={timelineRef}>
+          {data.model.items.length > 0 ? (
+            data.model.items.map((item, index) => (
+              <TimelineItem key={item.entryId ?? index} item={item} token={token} />
+            ))
+          ) : (
+            <div className="empty-state">No messages yet — send one to the bot, then refresh.</div>
+          )}
+        </div>
+      </div>
+      <SessionComposer
+        data={data}
+        token={token}
+        sending={sending}
+        status={composerStatus}
+        onSubmit={submit}
+      />
+    </>
+  );
+}

--- a/packages/ui-session/src/index.ts
+++ b/packages/ui-session/src/index.ts
@@ -1,0 +1,1 @@
+export { SessionPage } from "./SessionPage.js";

--- a/packages/ui-session/src/session.css
+++ b/packages/ui-session/src/session.css
@@ -1,0 +1,438 @@
+/* Session viewer styles for the mikan web SPA (mirrors the server portal). */
+
+.session-side {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.session-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.session-badge-status.is-running {
+  color: var(--ok-text);
+  background: var(--ok-bg);
+  border-color: var(--ok-border);
+}
+
+.session-badge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--subtle);
+}
+
+.session-badge-status.is-running .session-badge-dot {
+  background: var(--ok-text);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.session-detail-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  padding: 2px 4px;
+}
+
+.session-detail {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.session-detail-label {
+  color: var(--subtle);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ── Related sessions ─────────────────────────────────────────────── */
+
+.related-card .eyebrow {
+  margin-bottom: 10px;
+}
+
+.related-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fff;
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color 120ms;
+}
+
+.related-link:hover {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+.related-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.related-summary {
+  color: var(--muted);
+  font-size: 0.86rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.related-meta {
+  color: var(--subtle);
+  font-size: 0.74rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+.related-arrow {
+  color: var(--subtle);
+  flex-shrink: 0;
+}
+
+/* ── Timeline ─────────────────────────────────────────────────────── */
+
+.timeline-shell {
+  position: relative;
+}
+
+.timeline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.empty-state {
+  padding: 18px 8px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.system-event {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 4px 8px;
+}
+
+.event-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--subtle);
+  flex-shrink: 0;
+}
+
+.event-title {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.event-body {
+  display: block;
+  margin-top: 2px;
+}
+
+.msg-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.user-row {
+  flex-direction: row-reverse;
+}
+
+.msg-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.msg-bubble {
+  max-width: 78%;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.user-bubble {
+  background: #e8e2d5;
+  border-color: transparent;
+}
+
+.user-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+  font-size: 0.76rem;
+}
+
+.user-name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.user-time {
+  color: var(--subtle);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+}
+
+.thread-badge {
+  font-size: 0.68rem;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--muted);
+}
+
+.assistant-meta {
+  margin-top: 6px;
+  font-size: 0.72rem;
+  color: var(--subtle);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+.thread-links {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.thread-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.72rem;
+  color: var(--muted);
+  text-decoration: none;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.thread-link:hover {
+  color: var(--text);
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+.thread-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+/* Tool blocks */
+
+.tool-block {
+  align-self: stretch;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #17171b;
+  color: #d4d4d8;
+  overflow: hidden;
+  font-size: 0.82rem;
+}
+
+.tool-ok {
+  border-color: var(--ok-border);
+}
+
+.tool-err {
+  border-color: var(--err-border);
+}
+
+.tool-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+.tool-title {
+  color: #e4e4e7;
+  font-weight: 500;
+}
+
+.tool-meta {
+  color: #71717a;
+  font-size: 0.72rem;
+}
+
+.tool-output {
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  max-height: 320px;
+  overflow-y: auto;
+  margin: 0;
+}
+
+/* Markdown body */
+
+.markdown p {
+  margin: 0 0 8px;
+}
+
+.markdown p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown pre {
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 8px;
+  padding: 8px 10px;
+  overflow-x: auto;
+  font-size: 0.78rem;
+  margin: 6px 0;
+}
+
+.markdown code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.82em;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 0.12em 0.34em;
+  border-radius: 5px;
+}
+
+.markdown pre code {
+  background: none;
+  padding: 0;
+}
+
+.markdown a {
+  color: var(--accent);
+}
+
+.markdown ul,
+.markdown ol {
+  margin: 4px 0 8px;
+  padding-left: 20px;
+}
+
+.markdown blockquote {
+  border-left: 3px solid var(--border);
+  margin: 6px 0;
+  padding-left: 10px;
+  color: var(--muted);
+}
+
+/* ── Composer ─────────────────────────────────────────────────────── */
+
+.composer-card {
+  position: sticky;
+  bottom: 16px;
+}
+
+.composer-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.composer-form textarea {
+  flex: 1;
+  border: none;
+  outline: none;
+  resize: none;
+  background: transparent;
+  font: inherit;
+  color: var(--text);
+  max-height: 120px;
+  min-height: 24px;
+  padding: 4px 2px;
+}
+
+.composer-form textarea:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.composer-status {
+  font-size: 0.76rem;
+  color: var(--muted);
+  max-width: 260px;
+}
+
+.composer-send-btn {
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background: var(--text);
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: opacity 120ms;
+}
+
+.composer-send-btn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.composer-send-btn:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}

--- a/packages/ui-vault/package.json
+++ b/packages/ui-vault/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@geminixiang/mikan-ui-vault",
+  "version": "0.1.0",
+  "private": true,
+  "description": "mikan vault/login SPA feature: link completion, API-key storage, and OAuth login",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/ui-vault/src/VaultPage.tsx
+++ b/packages/ui-vault/src/VaultPage.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiGet, apiPost, queryParam } from "@geminixiang/mikan-web-client";
+import "./vault.css";
+
+interface LinkInfo {
+  valid: boolean;
+  expiresAt?: number;
+  vaultId?: string;
+  providerIdHint?: string | null;
+  oauthServices?: Array<{ id: string; label: string }>;
+  existingSecrets?: { envKeys: string[]; mountTargets: string[] };
+}
+
+interface CompleteResponse {
+  message?: string;
+  error?: string;
+}
+
+interface OAuthStartResponse {
+  redirectUrl?: string;
+  error?: string;
+}
+
+function parseEnv(text: string): { env: Record<string, string>; error?: string } {
+  const env: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) return { env, error: `Invalid line (expected KEY=VALUE): ${line}` };
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return { env };
+}
+
+function SecretsSummary({ secrets }: { secrets: NonNullable<LinkInfo["existingSecrets"]> }) {
+  if (secrets.envKeys.length === 0 && secrets.mountTargets.length === 0) return null;
+  return (
+    <div className="card">
+      <p className="eyebrow">Currently stored</p>
+      <dl className="kv">
+        {secrets.envKeys.length > 0 ? (
+          <>
+            <dt>Env keys</dt>
+            <dd className="chips">
+              {secrets.envKeys.map((k) => (
+                <code key={k}>{k}</code>
+              ))}
+            </dd>
+          </>
+        ) : null}
+        {secrets.mountTargets.length > 0 ? (
+          <>
+            <dt>Mounts</dt>
+            <dd>{secrets.mountTargets.join(", ")}</dd>
+          </>
+        ) : null}
+      </dl>
+    </div>
+  );
+}
+
+function ApiKeyForm({ token, onStatus }: { token: string; onStatus: (message: string) => void }) {
+  const [envText, setEnvText] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const save = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    if (busy) return;
+    const parsed = parseEnv(envText);
+    if (parsed.error) {
+      onStatus(parsed.error);
+      return;
+    }
+    if (Object.keys(parsed.env).length === 0) {
+      onStatus("Enter at least one KEY=VALUE pair before continuing.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const data = await apiPost<CompleteResponse>("/api/link/complete", {
+        token,
+        mode: "api_key",
+        env: parsed.env,
+      });
+      onStatus(data.message ?? "Credential stored. You can close this tab.");
+    } catch (err) {
+      onStatus(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form onSubmit={(e) => void save(e)}>
+      <label className="field-label" htmlFor="envText">
+        Environment variables (one KEY=VALUE per line)
+      </label>
+      <textarea
+        id="envText"
+        rows={6}
+        value={envText}
+        onChange={(e) => setEnvText(e.target.value)}
+        placeholder={"OPENAI_API_KEY=sk-...\nANTHROPIC_API_KEY=sk-..."}
+        spellCheck={false}
+      />
+      <div className="form-actions">
+        <button className="primary-action-btn" type="submit" disabled={busy}>
+          {busy ? "Saving…" : "Save to vault"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function OAuthForm({
+  services,
+  token,
+  onStatus,
+}: {
+  services: NonNullable<LinkInfo["oauthServices"]>;
+  token: string;
+  onStatus: (message: string) => void;
+}) {
+  const [serviceId, setServiceId] = useState(services[0]?.id ?? "");
+  const [busy, setBusy] = useState(false);
+
+  const save = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    try {
+      const data = await apiPost<OAuthStartResponse>("/api/oauth/start", { token, serviceId });
+      if (data.redirectUrl) {
+        window.location.href = data.redirectUrl;
+        return;
+      }
+      onStatus(data.error ?? "OAuth could not start.");
+    } catch (err) {
+      onStatus(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form onSubmit={(e) => void save(e)}>
+      <label className="field-label" htmlFor="oauthService">
+        OAuth service
+      </label>
+      <select
+        className="field-like"
+        id="oauthService"
+        value={serviceId}
+        onChange={(e) => setServiceId(e.target.value)}
+      >
+        {services.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.label}
+          </option>
+        ))}
+      </select>
+      <div className="form-actions">
+        <button className="primary-action-btn" type="submit" disabled={busy}>
+          {busy ? "Redirecting…" : "Authorize"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function CredentialForm({
+  oauthServices,
+  providerIdHint,
+  token,
+  onStatus,
+}: {
+  oauthServices: NonNullable<LinkInfo["oauthServices"]>;
+  providerIdHint: string | null;
+  token: string;
+  onStatus: (message: string) => void;
+}) {
+  const [mode, setMode] = useState<"api_key" | "oauth">(providerIdHint ? "oauth" : "api_key");
+
+  return (
+    <div className="card">
+      <p className="eyebrow">Add credential</p>
+      {oauthServices.length > 0 ? (
+        <div className="mode-row">
+          <label>
+            <input
+              type="radio"
+              name="mode"
+              checked={mode === "oauth"}
+              onChange={() => setMode("oauth")}
+            />{" "}
+            OAuth login
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="mode"
+              checked={mode === "api_key"}
+              onChange={() => setMode("api_key")}
+            />{" "}
+            Store Secret
+          </label>
+        </div>
+      ) : null}
+
+      {mode === "oauth" && oauthServices.length > 0 ? (
+        <OAuthForm services={oauthServices} token={token} onStatus={onStatus} />
+      ) : (
+        <ApiKeyForm token={token} onStatus={onStatus} />
+      )}
+    </div>
+  );
+}
+
+export function VaultPage() {
+  const token = queryParam("token") ?? "";
+  const [info, setInfo] = useState<LinkInfo | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await apiGet<LinkInfo>(`/api/link/info?token=${encodeURIComponent(token)}`);
+      setInfo(data);
+    } catch {
+      setInfo({ valid: false });
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (!token) {
+      setInfo({ valid: false });
+      return;
+    }
+    void load();
+  }, [token, load]);
+
+  if (!token) {
+    return (
+      <div className="card">
+        <p className="eyebrow">Vault</p>
+        <h2 className="card-title">Login link required</h2>
+        <div className="err-msg">
+          This link is invalid or has expired. Ask the bot for a new <code>/login</code> link.
+        </div>
+      </div>
+    );
+  }
+
+  if (!info) return <div className="loading-msg">Loading link…</div>;
+  if (!info.valid) {
+    return (
+      <div className="card">
+        <p className="eyebrow">Vault</p>
+        <h2 className="card-title">Link expired</h2>
+        <div className="err-msg">
+          This link is invalid or has expired. Ask the bot for a new <code>/login</code> link.
+        </div>
+      </div>
+    );
+  }
+
+  const hint = info.providerIdHint ?? null;
+  const oauthServices = info.oauthServices ?? [];
+  const hintLabel = oauthServices.find((s) => s.id === hint)?.label ?? "OAuth";
+
+  return (
+    <>
+      <header className="page-head">
+        <div>
+          <p className="eyebrow">Vault</p>
+          <h2 className="page-title">{hint ? hintLabel : "Store Secret"}</h2>
+          <p className="page-desc">
+            {info.expiresAt
+              ? `Link expires ${new Date(info.expiresAt).toLocaleString()}`
+              : "Store credentials in your vault."}
+          </p>
+        </div>
+      </header>
+
+      {info.existingSecrets ? <SecretsSummary secrets={info.existingSecrets} /> : null}
+
+      <CredentialForm
+        oauthServices={oauthServices}
+        providerIdHint={hint}
+        token={token}
+        onStatus={setStatus}
+      />
+      {status ? <div className="inline-result ok">{status}</div> : null}
+    </>
+  );
+}

--- a/packages/ui-vault/src/index.ts
+++ b/packages/ui-vault/src/index.ts
@@ -1,0 +1,1 @@
+export { VaultPage } from "./VaultPage.js";

--- a/packages/ui-vault/src/vault.css
+++ b/packages/ui-vault/src/vault.css
@@ -1,0 +1,91 @@
+/* Vault/login SPA styles. */
+
+.mode-row {
+  display: flex;
+  gap: 18px;
+  margin-bottom: 16px;
+}
+
+.mode-row label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.88rem;
+  cursor: pointer;
+}
+
+.field-label {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+#oauthService,
+select.field-like {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+  font: inherit;
+  font-size: 0.88rem;
+  color: var(--text);
+  min-width: 240px;
+}
+
+textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.84rem;
+  color: var(--text);
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.form-actions {
+  margin-top: 14px;
+}
+
+.inline-result {
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  margin-top: 12px;
+}
+
+.inline-result.ok {
+  background: var(--ok-bg);
+  color: var(--ok-text);
+  border: 1px solid var(--ok-border);
+}
+
+.kv {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 8px 14px;
+  font-size: 0.88rem;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chips code {
+  background: rgba(0, 0, 0, 0.05);
+  padding: 2px 8px;
+  border-radius: 6px;
+}
+
+.kv dt {
+  color: var(--subtle);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding-top: 2px;
+}

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@geminixiang/mikan-web-client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "mikan web SPA shell: reads the __MIKAN_BOOT__ boot manifest, wires the router, and mounts the ui-* feature pages (DSH dsh-client-web pattern, React only)",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "@geminixiang/mikan-ui-admin": "workspace:^",
+    "@geminixiang/mikan-ui-session": "workspace:^",
+    "@geminixiang/mikan-ui-vault": "workspace:^",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/web-client/src/App.tsx
+++ b/packages/web-client/src/App.tsx
@@ -1,0 +1,152 @@
+import {
+  createBrowserRouter,
+  Link,
+  Navigate,
+  Outlet,
+  RouterProvider,
+  useLocation,
+} from "react-router-dom";
+import { createContext, useContext } from "react";
+import type { WebBootGraph } from "./manifest.js";
+import { SessionPage } from "@geminixiang/mikan-ui-session";
+import { AdminPage } from "@geminixiang/mikan-ui-admin";
+import { VaultPage } from "@geminixiang/mikan-ui-vault";
+import "./app.css";
+
+const NAV = [
+  {
+    view: "session",
+    label: "Session",
+    path: "/session",
+    svg: (
+      <svg
+        viewBox="0 0 24 24"
+        width="20"
+        height="20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+      </svg>
+    ),
+  },
+  {
+    view: "admin",
+    label: "Admin",
+    path: "/admin",
+    svg: (
+      <svg
+        viewBox="0 0 24 24"
+        width="20"
+        height="20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </svg>
+    ),
+  },
+  {
+    view: "vault",
+    label: "Vault",
+    path: "/link",
+    svg: (
+      <svg
+        viewBox="0 0 24 24"
+        width="20"
+        height="20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </svg>
+    ),
+  },
+] as const;
+
+const ManifestContext = createContext<WebBootGraph | null>(null);
+
+function useManifest(): WebBootGraph {
+  const manifest = useContext(ManifestContext);
+  if (manifest === null) throw new Error("web-client: App rendered without a boot manifest");
+  return manifest;
+}
+
+function AppFrame() {
+  const manifest = useManifest();
+  const location = useLocation();
+  const activeView = NAV.find((n) => location.pathname.startsWith(n.path))?.view;
+  const pageTitle = activeView === "admin" ? "Admin" : activeView === "vault" ? "Vault" : "Session";
+  return (
+    <>
+      <nav className="floating-view-nav" aria-label="Primary views">
+        {NAV.map((n) => {
+          const isActive = n.view === activeView;
+          const attrs = {
+            "data-tooltip": n.label,
+            "aria-label": n.label,
+            className: `view-nav-btn${isActive ? " active" : ""}`,
+          };
+          return isActive ? (
+            <span key={n.view} aria-current="page" {...attrs}>
+              {n.svg}
+            </span>
+          ) : (
+            <Link key={n.view} to={n.path} {...attrs}>
+              {n.svg}
+            </Link>
+          );
+        })}
+      </nav>
+      <main className="shell">
+        <header className="topbar">
+          <div className="topbar-brand">
+            <span className="topbar-wordmark">mikan</span>
+            <span className="topbar-sep">·</span>
+            <span className="topbar-title">{pageTitle}</span>
+          </div>
+          <div className="topbar-meta">
+            <span className="topbar-user" title={`boot rev ${manifest.rev}`}>
+              rev {manifest.rev.slice(0, 8)}
+            </span>
+          </div>
+        </header>
+        <Outlet />
+      </main>
+    </>
+  );
+}
+
+export function App({ manifest }: { manifest: WebBootGraph }) {
+  const router = createBrowserRouter([
+    {
+      element: <AppFrame />,
+      children: [
+        { path: "/", element: <Navigate to="/session" replace /> },
+        { path: "/session", element: <SessionPage /> },
+        { path: "/admin", element: <AdminPage /> },
+        { path: "/link", element: <VaultPage /> },
+        { path: "*", element: <Navigate to="/session" replace /> },
+      ],
+    },
+  ]);
+  return (
+    <ManifestContext.Provider value={manifest}>
+      <RouterProvider router={router} />
+    </ManifestContext.Provider>
+  );
+}

--- a/packages/web-client/src/api.ts
+++ b/packages/web-client/src/api.ts
@@ -1,0 +1,47 @@
+/**
+ * Thin fetch helpers for the mikan web API. Tokens travel in the URL
+ * (deep-link `?token=…`), matching the existing portal token model.
+ */
+
+export interface ApiErrorBody {
+  error?: string;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/** Read one query parameter from the current URL. */
+export function queryParam(name: string): string | null {
+  return new URLSearchParams(window.location.search).get(name);
+}
+
+/** GET a JSON endpoint. Throws ApiError on non-2xx. */
+export async function apiGet<T>(path: string): Promise<T> {
+  const res = await fetch(path, { headers: { Accept: "application/json" } });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as ApiErrorBody;
+    throw new ApiError(res.status, body.error ?? `Request failed (${res.status})`);
+  }
+  return (await res.json()) as T;
+}
+
+/** POST a JSON body to an endpoint. Throws ApiError on non-2xx. */
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const parsed = (await res.json().catch(() => ({}))) as ApiErrorBody;
+    throw new ApiError(res.status, parsed.error ?? `Request failed (${res.status})`);
+  }
+  return (await res.json()) as T;
+}

--- a/packages/web-client/src/app.css
+++ b/packages/web-client/src/app.css
@@ -1,0 +1,323 @@
+/* Shared shell styles for the mikan web SPA (adapted from portal-shell.ts). */
+
+:root {
+  --bg: #f0ece3;
+  --surface: #ffffff;
+  --border: rgba(0, 0, 0, 0.08);
+  --text: #18181b;
+  --muted: #71717a;
+  --subtle: #a1a1aa;
+  --accent: #d97706;
+
+  --ok-bg: #f0fdf4;
+  --ok-text: #15803d;
+  --ok-border: rgba(21, 128, 61, 0.16);
+  --err-bg: #fef2f2;
+  --err-text: #b91c1c;
+  --err-border: rgba(185, 28, 28, 0.14);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  padding: 28px 24px 60px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: var(--bg);
+  background-image: radial-gradient(
+    ellipse 80% 40% at 50% -10%,
+    rgba(255, 255, 255, 0.65) 0%,
+    transparent 70%
+  );
+  color: var(--text);
+  font-family: "DM Sans", "Segoe UI", system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+#root {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.shell {
+  width: 100%;
+  max-width: 960px;
+  margin-left: 72px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* ── Topbar ─────────────────────────────────────────────────────────── */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 18px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(8px);
+}
+
+.topbar-brand {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.topbar-wordmark {
+  font-family: "Lora", Georgia, serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.topbar-sep {
+  color: var(--subtle);
+  font-size: 0.9rem;
+}
+
+.topbar-title {
+  font-size: 0.86rem;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.topbar-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.topbar-user {
+  font-size: 0.8rem;
+  color: var(--muted);
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.04);
+  white-space: nowrap;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+/* ── Floating icon nav ──────────────────────────────────────────────── */
+
+.floating-view-nav {
+  position: fixed;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow:
+    0 10px 32px rgba(0, 0, 0, 0.1),
+    0 2px 6px rgba(0, 0, 0, 0.04);
+  backdrop-filter: blur(14px);
+}
+
+.view-nav-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background 160ms,
+    color 160ms,
+    transform 160ms;
+}
+
+.view-nav-btn:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text);
+}
+
+.view-nav-btn:active {
+  transform: scale(0.94);
+}
+
+.view-nav-btn.active {
+  background: var(--text);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  cursor: default;
+}
+
+.view-nav-btn svg {
+  display: block;
+}
+
+.view-nav-btn::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: calc(100% + 12px);
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+  padding: 5px 10px;
+  border-radius: 8px;
+  background: var(--text);
+  color: #fff;
+  font:
+    500 0.76rem/1 "DM Sans",
+    sans-serif;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 140ms,
+    transform 140ms;
+}
+
+.view-nav-btn:hover::after {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+/* ── Page head + cards ─────────────────────────────────────────────── */
+
+.page-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 2px 4px;
+}
+
+.page-title {
+  font-family: "Lora", Georgia, serif;
+  font-size: clamp(1.35rem, 2.4vw, 1.6rem);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.page-desc {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.eyebrow {
+  color: var(--subtle);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.card {
+  padding: 24px 28px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--surface);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 4px 16px rgba(0, 0, 0, 0.06);
+}
+
+.card-title {
+  font-family: "Lora", Georgia, serif;
+  font-size: clamp(1.1rem, 2vw, 1.3rem);
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  margin-bottom: 10px;
+}
+
+.placeholder-card {
+  text-align: center;
+  padding: 48px 28px;
+}
+
+code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.82em;
+  padding: 0.14em 0.36em;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text);
+}
+
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
+}
+
+.err-msg {
+  padding: 12px 16px;
+  border-radius: 10px;
+  background: var(--err-bg);
+  color: var(--err-text);
+  border: 1px solid var(--err-border);
+  font-size: 0.88rem;
+}
+
+.loading-msg {
+  color: var(--muted);
+  font-size: 0.9rem;
+  padding: 8px 0;
+}
+
+@media (max-width: 900px) {
+  .shell {
+    margin-left: 0;
+  }
+  .floating-view-nav {
+    left: 50%;
+    right: auto;
+    top: auto;
+    bottom: 18px;
+    transform: translateX(-50%);
+    flex-direction: row;
+  }
+  .view-nav-btn::after {
+    left: 50%;
+    top: auto;
+    bottom: calc(100% + 10px);
+    transform: translateX(-50%) translateY(4px);
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 16px 12px 96px;
+  }
+  .card {
+    padding: 18px;
+    border-radius: 16px;
+  }
+}

--- a/packages/web-client/src/boot.tsx
+++ b/packages/web-client/src/boot.tsx
@@ -1,0 +1,26 @@
+/**
+ * AppWebEntry — the SPA boot kernel (DSH AppWebEntry pattern, simplified):
+ * read `window.__MIKAN_BOOT__`, parse the manifest, and mount the app shell.
+ * Everything else lives in App.tsx; this class only finds the DOM node and
+ * hands the manifest to the shell.
+ */
+import { createRoot, type Root } from "react-dom/client";
+import { StrictMode } from "react";
+import { App } from "./App.js";
+import { parseBootManifest } from "./manifest.js";
+
+export class AppWebEntry {
+  private root: Root | undefined;
+
+  constructor(private readonly el: HTMLElement) {}
+
+  run(): void {
+    const manifest = parseBootManifest(window["__MIKAN_BOOT__"]);
+    this.root = createRoot(this.el);
+    this.root.render(
+      <StrictMode>
+        <App manifest={manifest} />
+      </StrictMode>,
+    );
+  }
+}

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -1,0 +1,4 @@
+export { AppWebEntry } from "./boot.js";
+export { App } from "./App.js";
+export { parseBootManifest, type WebBootEntry, type WebBootGraph } from "./manifest.js";
+export { ApiError, apiGet, apiPost, queryParam } from "./api.js";

--- a/packages/web-client/src/manifest.ts
+++ b/packages/web-client/src/manifest.ts
@@ -1,0 +1,58 @@
+/**
+ * Client-side boot manifest (mirror of the host's WebBootGraph). The host
+ * injects `window.__MIKAN_BOOT__` into index.html; the shell parses it here.
+ */
+
+/** One boot row: an entry bundle the shell may load. */
+export interface WebBootEntry {
+  id: string;
+  url: string;
+  rev: string;
+  immediately?: boolean;
+}
+
+/** The composed client entry graph the host injects. */
+export interface WebBootGraph {
+  rev: string;
+  entries: WebBootEntry[];
+}
+
+declare global {
+  interface Window {
+    __MIKAN_BOOT__?: unknown;
+  }
+}
+
+/**
+ * Parse `window.__MIKAN_BOOT__`. A missing or malformed graph throws (the shell
+ * shows the loud failure — a page without a valid manifest cannot boot).
+ */
+export function parseBootManifest(wire: unknown): WebBootGraph {
+  if (typeof wire !== "object" || wire === null) {
+    throw new Error("web-client: window.__MIKAN_BOOT__ is missing or not an object");
+  }
+  const graph = wire as Record<string, unknown>;
+  if (typeof graph.rev !== "string") {
+    throw new Error("web-client: boot manifest rev must be a string");
+  }
+  if (!Array.isArray(graph.entries)) {
+    throw new Error("web-client: boot manifest entries must be an array");
+  }
+  const entries: WebBootEntry[] = [];
+  for (const value of graph.entries as unknown[]) {
+    if (typeof value !== "object" || value === null) {
+      throw new Error("web-client: boot manifest entry is not an object");
+    }
+    const row = value as Record<string, unknown>;
+    if (typeof row.id !== "string" || typeof row.url !== "string" || typeof row.rev !== "string") {
+      throw new Error("web-client: boot manifest entry must carry string id/url/rev");
+    }
+    entries.push({
+      id: row.id,
+      url: row.url,
+      rev: row.rev,
+      ...(row.immediately === true ? { immediately: true } : {}),
+    });
+  }
+  return { rev: graph.rev, entries };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,34 @@ importers:
         specifier: ^4.1.9
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
 
+  apps/web:
+    dependencies:
+      '@geminixiang/mikan-web-client':
+        specifier: workspace:^
+        version: link:../../packages/web-client
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ~18.3.1
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ~18.3.0
+        version: 18.3.7(@types/react@18.3.31)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.0
+        version: 4.7.0(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0)
+
   packages/daemon-web-bridge:
     devDependencies:
       '@types/node':
@@ -258,6 +286,42 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
 
+  packages/ui-admin:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+
+  packages/ui-session:
+    dependencies:
+      '@geminixiang/mikan-daemon-web-bridge':
+        specifier: workspace:^
+        version: link:../daemon-web-bridge
+      '@geminixiang/mikan-web-client':
+        specifier: workspace:^
+        version: link:../web-client
+      marked:
+        specifier: ^15.0.0
+        version: 15.0.12
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+
+  packages/ui-vault:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+
   packages/web-bundle:
     dependencies:
       '@geminixiang/mikan-web-host':
@@ -276,6 +340,27 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+
+  packages/web-client:
+    dependencies:
+      '@geminixiang/mikan-ui-admin':
+        specifier: workspace:^
+        version: link:../ui-admin
+      '@geminixiang/mikan-ui-session':
+        specifier: workspace:^
+        version: link:../ui-session
+      '@geminixiang/mikan-ui-vault':
+        specifier: workspace:^
+        version: link:../ui-vault
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^6.30.0
+        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/web-host:
     devDependencies:
@@ -511,6 +596,44 @@ packages:
     resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -519,13 +642,41 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.8':
@@ -673,16 +824,34 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.2':
     resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.2':
@@ -691,16 +860,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.2':
     resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.2':
     resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.2':
@@ -709,10 +896,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.2':
     resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.2':
@@ -721,10 +920,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.2':
     resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.2':
@@ -733,10 +944,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.2':
     resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.2':
@@ -745,10 +968,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.2':
     resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.2':
@@ -757,10 +992,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.2':
     resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.2':
@@ -769,16 +1016,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.2':
     resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.2':
     resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.2':
@@ -787,10 +1052,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.2':
     resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.2':
@@ -799,11 +1076,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.2':
     resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.2':
     resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
@@ -811,16 +1100,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.2':
     resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.2':
     resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.2':
@@ -1012,6 +1319,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1032,6 +1345,12 @@ packages:
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -1609,6 +1928,10 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
+    engines: {node: '>=14.0.0'}
+
   '@rolldown/binding-android-arm64@1.2.4':
     resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1693,8 +2016,136 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
 
   '@sapphire/async-queue@1.5.5':
     resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
@@ -1861,6 +2312,18 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1908,6 +2371,17 @@ packages:
 
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -1973,6 +2447,12 @@ packages:
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
@@ -2104,6 +2584,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.11.14:
+    resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
@@ -2126,6 +2611,11 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
@@ -2136,6 +2626,9 @@ packages:
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
   cbor2@2.3.0:
     resolution: {integrity: sha512-76WB3hq8BoaGkMkBVJ27fW5LJU+qqDLEpgRNCG/SYKhODWXpVPOTD4UcUto3IEzYLA52nsvbhb0wabhHDn3qXg==}
@@ -2249,6 +2742,9 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -2332,6 +2828,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  electron-to-chromium@1.5.406:
+    resolution: {integrity: sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -2368,10 +2867,19 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -2517,6 +3025,10 @@ packages:
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2767,8 +3279,16 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -2777,6 +3297,11 @@ packages:
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -2881,9 +3406,16 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-bytes.js@1.13.1:
     resolution: {integrity: sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==}
@@ -2911,6 +3443,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3166,6 +3703,10 @@ packages:
   node-mock-http@1.0.5:
     resolution: {integrity: sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==}
 
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -3358,6 +3899,32 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@6.30.4:
+    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.4:
+    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   readdirp@5.1.1:
     resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
     engines: {node: '>= 20.19.0'}
@@ -3469,6 +4036,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3485,11 +4057,18 @@ packages:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
 
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
   semifies@1.0.0:
     resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   semver@7.8.5:
@@ -3797,6 +4376,12 @@ packages:
       uploadthing:
         optional: true
 
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   url-extras@0.1.0:
     resolution: {integrity: sha512-8tzwTeXFPuX/5PHuCDQE5Dd9Ts4rwoq2t9aIT+HS4iAVpmj5l4Ao7Q+BuuFjvWRqrLswBhQDk8O96ZicgCqQqw==}
     engines: {node: '>=20'}
@@ -3812,6 +4397,46 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
@@ -3948,6 +4573,9 @@ packages:
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -4391,15 +5019,114 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.3.0': {}
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.8
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.8':
     dependencies:
       '@babel/types': 7.29.8
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.8':
     dependencies:
@@ -4592,79 +5319,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.28.2':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.28.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.28.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.28.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.28.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.2':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.28.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.28.2':
@@ -4832,6 +5637,16 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -4882,6 +5697,9 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -5235,6 +6053,8 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
+  '@remix-run/router@1.23.3': {}
+
   '@rolldown/binding-android-arm64@1.2.4':
     optional: true
 
@@ -5277,7 +6097,84 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.2.4':
     optional: true
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
 
   '@sapphire/async-queue@1.5.5': {}
 
@@ -5497,6 +6394,27 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5549,6 +6467,17 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
   '@types/retry@0.12.0': {}
 
   '@types/sax@1.2.7':
@@ -5595,6 +6524,18 @@ snapshots:
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
 
   '@ungap/structured-clone@1.3.3': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -5817,6 +6758,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.11.14: {}
+
   bcp-47-match@2.0.3: {}
 
   bcp-47@2.1.1:
@@ -5839,6 +6782,14 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.8:
+    dependencies:
+      baseline-browser-mapping: 2.11.14
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.406
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
   buffer-equal-constant-time@1.0.1: {}
 
   buildcheck@0.0.7:
@@ -5848,6 +6799,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  caniuse-lite@1.0.30001809: {}
 
   cbor2@2.3.0:
     dependencies:
@@ -5943,6 +6896,8 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
+  csstype@3.2.3: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
@@ -6026,6 +6981,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  electron-to-chromium@1.5.406: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -6065,6 +7022,35 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.28.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.2
@@ -6093,6 +7079,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.2
       '@esbuild/win32-ia32': 0.28.2
       '@esbuild/win32-x64': 0.28.2
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -6251,6 +7239,8 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  gensync@1.0.0-beta.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -6629,9 +7619,13 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -6641,6 +7635,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
+
+  json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
 
@@ -6734,7 +7730,15 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@11.5.2: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-bytes.js@1.13.1: {}
 
@@ -6768,6 +7772,8 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -7288,6 +8294,8 @@ snapshots:
 
   node-mock-http@1.0.5: {}
 
+  node-releases@2.0.53: {}
+
   normalize-path@3.0.0: {}
 
   npm-run-path@2.0.2:
@@ -7544,6 +8552,30 @@ snapshots:
 
   radix3@1.1.2: {}
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.30.4(react@18.3.1)
+
+  react-router@6.30.4(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.3
+      react: 18.3.1
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   readdirp@5.1.1: {}
 
   rechoir@0.6.2:
@@ -7753,6 +8785,38 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.4
       '@rolldown/binding-win32-x64-msvc': 1.2.4
 
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -7780,9 +8844,15 @@ snapshots:
 
   sax@1.6.1: {}
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
   semifies@1.0.0: {}
 
   semver@5.7.2: {}
+
+  semver@6.3.1: {}
 
   semver@7.8.5: {}
 
@@ -8059,6 +9129,12 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
 
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
+    dependencies:
+      browserslist: 4.28.8
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   url-extras@0.1.0: {}
 
   util-deprecate@1.0.2: {}
@@ -8077,6 +9153,21 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.33.0
+      yaml: 2.9.0
 
   vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -8152,6 +9243,8 @@ snapshots:
   ws@8.21.3: {}
 
   xxhash-wasm@1.1.0: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary

Lands the React SPA on top of the host seam (landed in #133). The SPA takes over `/session`, `/admin`, and `/link` when `MIKAN_WEB_DIST` points at a built `apps/web/dist`.

### New packages

- **`apps/web`** — Vite entry (`index.html`, `main.ts`, `vite.config.ts` aliasing workspace packages to source, `tsconfig.json`). Builds to `apps/web/dist/` (277 kB JS, 13.7 kB CSS).
- **`packages/web-client`** — React shell: `AppWebEntry` boot kernel reading `window.__MIKAN_BOOT__`, `parseBootManifest`, react-router routing (`App.tsx` with floating nav + topbar), `api.ts` (fetch wrapper), `app.css` (323 lines).
- **`packages/ui-session`** — `SessionPage.tsx` (384 lines): timeline with entries, SSE live stream from `/session/stream`, composer posting to `/session/message`, markdown rendering via `marked`.
- **`packages/ui-admin`** — `AdminPage.tsx` (633 lines): Conversations / Models / Usage / Events / Settings tabs, all via the existing `/admin/api/*` JSON endpoints.
- **`packages/ui-vault`** — `VaultPage.tsx` (296 lines): API key storage via `/api/link/complete`, OAuth login via `/api/oauth/start`, reads link state from `/api/link/info`.

### Daemon integration

The host seam already handles the SPA dist via `webDistIndex` / `MIKAN_WEB_DIST` (added in #133). When the dist exists and `webDistIndex` points at it, the fallback seat serves the SPA; the page routes (`/session`, `/admin`, `/link`) are handled by the SPA while the API routes (`/session/stream`, `/session/message`, `/admin/api/*`, `/api/link/info`, `/api/link/complete`, `/api/oauth/start`, `/oauth/callback`) stay with the daemon.

### Verified

- `pnpm run build:web` — Vite build succeeds (277 kB JS, 13.7 kB CSS)
- `pnpm run build` — daemon + packages + embed still green
- 1743 daemon tests + 24 plugin package tests all pass
- oxlint 0/0, oxfmt clean, knip clean

### Docs

`docs/research/mikan-web-website.md` — the plan document with the full SPA architecture discussion (notes the `__MIKAN_BOOT__` rename).